### PR TITLE
Two symbols (fuse_main and fuse_new) now point to a recent version of the function

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4886,7 +4886,6 @@ FUSE_SYMVER(".symver fuse_exited,__fuse_exited@");
 FUSE_SYMVER(".symver fuse_process_cmd,__fuse_process_cmd@");
 FUSE_SYMVER(".symver fuse_read_cmd,__fuse_read_cmd@");
 FUSE_SYMVER(".symver fuse_set_getcontext_func,__fuse_set_getcontext_func@");
-FUSE_SYMVER(".symver fuse_new_compat2,fuse_new@");
 FUSE_SYMVER(".symver fuse_new_compat22,fuse_new@FUSE_2.2");
 
 #endif /* __FreeBSD__ || __NetBSD__  */

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -439,7 +439,6 @@ int fuse_mount_compat1(const char *mountpoint, const char *args[])
 FUSE_SYMVER(".symver fuse_setup_compat2,__fuse_setup@");
 FUSE_SYMVER(".symver fuse_setup_compat22,fuse_setup@FUSE_2.2");
 FUSE_SYMVER(".symver fuse_teardown,__fuse_teardown@");
-FUSE_SYMVER(".symver fuse_main_compat2,fuse_main@");
 FUSE_SYMVER(".symver fuse_main_real_compat22,fuse_main_real@FUSE_2.2");
 
 #endif /* __FreeBSD__ || __NetBSD__ */


### PR DESCRIPTION
In the libfuse.so shared object the "fuse_main" pointed to "fuse_main_compat2@@FUSE_2.2", the "fuse_new" pointed to "fuse_new_compat2@@FUSE_2.2". After this patch they will point to "fuse_main@@FUSE_2.2" and "fuse_new@@FUSE_2.6".

All the other usages of FUSE_SYMVER seemed to be valid (either they point to a correct method by a correct symbol (like "fuse_setup@FUSE_2.5" -> "fuse_setup_compat25"), or they seem to be there for legacy reasons - the ones starting with "__").

I don't think that plain function names (without prefix and postfix) should point to older versions of the API functions, that does not seem logical. If someone needs an explicit (older) version of the function, load that version explicitly.

Altough I am not sure if this patch breaks any programs depending on libfuse, so please review. :)