### PR TITLE
fuse.h doc fix: The f_frsize field is not ignored by the statfs operation

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -222,7 +222,7 @@ struct fuse_operations {
 
 	/** Get file system statistics
 	 *
-	 * The 'f_frsize', 'f_favail', 'f_fsid' and 'f_flag' fields are ignored
+	 * The 'f_favail', 'f_fsid' and 'f_flag' fields are ignored
 	 *
 	 * Replaced 'struct statfs' parameter with 'struct statvfs' in
 	 * version 2.5


### PR DESCRIPTION
Apparently the `f_frsize` field has been passed on transparently by `statfs` since
2b4781100812d42e704c39c51303cd28ad3f9aa6 (Nov 28, 2005).

There is no point in discouraging users from revealing their fs fragment size…
