### PR TITLE
Remove leading _ on header guards to comply with reserved identifier requirements

### DIFF
--- a/include/cuse_lowlevel.h
+++ b/include/cuse_lowlevel.h
@@ -9,8 +9,8 @@
   Read example/cusexmp.c for usages.
 */
 
-#ifndef _CUSE_LOWLEVEL_H_
-#define _CUSE_LOWLEVEL_H_
+#ifndef CUSE_LOWLEVEL_H_
+#define CUSE_LOWLEVEL_H_
 
 #ifndef FUSE_USE_VERSION
 #define FUSE_USE_VERSION 29
@@ -84,4 +84,4 @@ int cuse_lowlevel_main(int argc, char *argv[], const struct cuse_info *ci,
 }
 #endif
 
-#endif /* _CUSE_LOWLEVEL_H_ */
+#endif /* CUSE_LOWLEVEL_H_ */

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -6,8 +6,8 @@
   See the file COPYING.LIB.
 */
 
-#ifndef _FUSE_H_
-#define _FUSE_H_
+#ifndef FUSE_H_
+#define FUSE_H_
 
 /** @file
  *
@@ -936,4 +936,4 @@ struct fuse_session *fuse_get_session(struct fuse *f);
 }
 #endif
 
-#endif /* _FUSE_H_ */
+#endif /* FUSE_H_ */

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -11,8 +11,8 @@
 #error "Never include <fuse_common.h> directly; use <fuse.h> or <fuse_lowlevel.h> instead."
 #endif
 
-#ifndef _FUSE_COMMON_H_
-#define _FUSE_COMMON_H_
+#ifndef FUSE_COMMON_H_
+#define FUSE_COMMON_H_
 
 #include "fuse_opt.h"
 #include <stdint.h>
@@ -523,4 +523,4 @@ struct _fuse_off_t_must_be_64bit_dummy_struct \
 	{ unsigned _fuse_off_t_must_be_64bit:((sizeof(off_t) == 8) ? 1 : -1); };
 #endif
 
-#endif /* _FUSE_COMMON_H_ */
+#endif /* FUSE_COMMON_H_ */

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -104,8 +104,8 @@
  *  - add FUSE_NO_OPEN_SUPPORT flag
  */
 
-#ifndef LINUX_FUSE_H
-#define LINUX_FUSE_H
+#ifndef _LINUX_FUSE_H
+#define _LINUX_FUSE_H
 
 #ifdef __KERNEL__
 #include <linux/types.h>
@@ -758,4 +758,4 @@ struct fuse_notify_retrieve_in {
 /* Device ioctls: */
 #define FUSE_DEV_IOC_CLONE	_IOR(229, 0, uint32_t)
 
-#endif /* LINUX_FUSE_H */
+#endif /* _LINUX_FUSE_H */

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -104,8 +104,8 @@
  *  - add FUSE_NO_OPEN_SUPPORT flag
  */
 
-#ifndef _LINUX_FUSE_H
-#define _LINUX_FUSE_H
+#ifndef LINUX_FUSE_H
+#define LINUX_FUSE_H
 
 #ifdef __KERNEL__
 #include <linux/types.h>
@@ -758,4 +758,4 @@ struct fuse_notify_retrieve_in {
 /* Device ioctls: */
 #define FUSE_DEV_IOC_CLONE	_IOR(229, 0, uint32_t)
 
-#endif /* _LINUX_FUSE_H */
+#endif /* LINUX_FUSE_H */

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -6,8 +6,8 @@
   See the file COPYING.LIB.
 */
 
-#ifndef _FUSE_LOWLEVEL_H_
-#define _FUSE_LOWLEVEL_H_
+#ifndef FUSE_LOWLEVEL_H_
+#define FUSE_LOWLEVEL_H_
 
 /** @file
  *
@@ -1728,4 +1728,4 @@ void fuse_chan_put(struct fuse_chan *ch);
 }
 #endif
 
-#endif /* _FUSE_LOWLEVEL_H_ */
+#endif /* FUSE_LOWLEVEL_H_ */

--- a/include/fuse_opt.h
+++ b/include/fuse_opt.h
@@ -6,8 +6,8 @@
   See the file COPYING.LIB.
 */
 
-#ifndef _FUSE_OPT_H_
-#define _FUSE_OPT_H_
+#ifndef FUSE_OPT_H_
+#define FUSE_OPT_H_
 
 /** @file
  *
@@ -268,4 +268,4 @@ int fuse_opt_match(const struct fuse_opt opts[], const char *opt);
 }
 #endif
 
-#endif /* _FUSE_OPT_H_ */
+#endif /* FUSE_OPT_H_ */


### PR DESCRIPTION
should close #28 (note that anything that manually checks header guards might be broken by this—though that should be rare since essentially nothing should be doing that).