### PR TITLE
Add support for reading from directories

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -9,3 +9,4 @@
 /fselclient
 /cusexmp
 /fuse_lo-plus
+/dirread

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -3,7 +3,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include -D_REENTRANT
 noinst_HEADERS = fioc.h
 noinst_PROGRAMS = fusexmp fusexmp_fh null hello hello_ll fioc fioclient \
-		  fsel fselclient cusexmp fuse_lo-plus
+		  fsel fselclient cusexmp fuse_lo-plus dirread
 
 LDADD = ../lib/libfuse3.la
 fusexmp_fh_LDADD = ../lib/libfuse3.la @fusexmp_fh_libs@

--- a/example/dirread.c
+++ b/example/dirread.c
@@ -1,0 +1,119 @@
+/*
+  FUSE: Filesystem in Userspace
+  Copyright (C) 2001-2007  Miklos Szeredi <miklos@szeredi.hu>
+
+  This program can be distributed under the terms of the GNU GPL.
+  See the file COPYING.
+*/
+
+/** @file
+ *
+ * dirread.c - read(2) on a directory
+ *
+ * \section section_compile compiling this example
+ *
+ * gcc -Wall dirread.c `pkg-config fuse3 --cflags --libs` -o dirread
+ *
+ * \section section_usage usage
+ \verbatim
+ % mkdir mnt
+ % ./hello mnt        # program will vanish into the background
+ % ls -la mnt
+   total 4
+   drwxr-xr-x 2 root root      0 Jan  1  1970 ./
+   drwxrwx--- 1 root vboxsf 4096 Jun 16 23:12 ../
+   -r--r--r-- 1 root root     13 Jan  1  1970 readable-dir
+ % cat mnt/readable-dir
+   Hello World!
+ % fusermount -u mnt
+ \endverbatim
+ *
+ * \section section_source the complete source
+ * \include dirread.c
+ */
+
+
+#define FUSE_USE_VERSION 30
+
+#include <config.h>
+
+#include <fuse.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+
+static const char *dirread_str = "Hello World!\n";
+static const char *dirread_path = "/readable-dir";
+
+static int dirread_getattr(const char *path, struct stat *stbuf)
+{
+	int res = 0;
+
+	memset(stbuf, 0, sizeof(struct stat));
+	if (strcmp(path, "/") == 0) {
+		stbuf->st_mode = S_IFDIR | 0755;
+		stbuf->st_nlink = 2;
+	} else if (strcmp(path, dirread_path) == 0) {
+		stbuf->st_mode = S_IFDIR | 0555;
+		stbuf->st_nlink = 1;
+		stbuf->st_size = strlen(dirread_str);
+	} else
+		res = -ENOENT;
+
+	return res;
+}
+
+static int dirread_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
+			   off_t offset, struct fuse_file_info *fi,
+			   enum fuse_readdir_flags flags)
+{
+	(void) offset;
+	(void) fi;
+	(void) flags;
+
+	if (strcmp(path, "/") == 0) {
+		filler(buf, ".", NULL, 0, 0);
+		filler(buf, "..", NULL, 0, 0);
+		filler(buf, dirread_path + 1, NULL, 0, 0);
+		return 0;
+	}
+
+	if (strcmp(path, dirread_path) == 0) {
+		filler(buf, ".", NULL, 0, 0);
+		filler(buf, "..", NULL, 0, 0);
+		return 0;
+	}
+
+	return -ENOENT;
+}
+
+static int dirread_dir_read(const char *path, char *buf, size_t size, off_t off,
+                            struct fuse_file_info *fi)
+{
+	size_t len;
+	(void) fi;
+	if (strcmp(path, dirread_path) != 0)
+		return -ENOENT;
+
+	len = strlen(dirread_str);
+	if (off < len) {
+		if (off + size > len)
+			size = len - off;
+		memcpy(buf, dirread_str + off, size);
+	} else
+		size = 0;
+
+	return size;
+}
+
+static struct fuse_operations dirread_oper = {
+	.getattr	= dirread_getattr,
+	.readdir	= dirread_readdir,
+	.dir_read	= dirread_dir_read,
+};
+
+int main(int argc, char *argv[])
+{
+	return fuse_main(argc, argv, &dirread_oper, NULL);
+}

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -574,6 +574,19 @@ struct fuse_operations {
 	 */
 	int (*fallocate) (const char *, int, off_t, off_t,
 			  struct fuse_file_info *);
+
+	/**
+	 * Reads from a directory
+	 *
+	 * This function is called when read(2) is called on a directory. Most
+	 * filesystems prohibit this and return EISDIR; FUSE will give this
+	 * behavior if you don't provide an implementation. Will be called after
+	 * opendir.
+	 *
+	 * Implemented in version 3.0
+	 */
+	int (*dir_read) (const char *, char *, size_t, off_t,
+			 struct fuse_file_info *);
 };
 
 /** Extra context that may be needed by some filesystems
@@ -881,6 +894,8 @@ int fuse_fs_poll(struct fuse_fs *fs, const char *path,
 		 unsigned *reventsp);
 int fuse_fs_fallocate(struct fuse_fs *fs, const char *path, int mode,
 		 off_t offset, off_t length, struct fuse_file_info *fi);
+int fuse_fs_dir_read(struct fuse_fs *fs, const char *path, char* buf,
+		size_t size, off_t off, struct fuse_file_info *fi);
 void fuse_fs_init(struct fuse_fs *fs, struct fuse_conn_info *conn);
 void fuse_fs_destroy(struct fuse_fs *fs);
 

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -102,6 +102,12 @@
  *  - add ctime and ctimensec to fuse_setattr_in
  *  - add FUSE_RENAME2 request
  *  - add FUSE_NO_OPEN_SUPPORT flag
+ *
+ *  7.24
+ *  - add FUSE_LSEEK for SEEK_HOLE and SEEK_DATA support
+ *
+ *  7.25
+ *  - add FUSE_DIR_READ
  */
 
 #ifndef _LINUX_FUSE_H
@@ -137,7 +143,7 @@
 #define FUSE_KERNEL_VERSION 7
 
 /** Minor version number of this interface */
-#define FUSE_KERNEL_MINOR_VERSION 23
+#define FUSE_KERNEL_MINOR_VERSION 25
 
 /** The node ID of the root inode */
 #define FUSE_ROOT_ID 1
@@ -358,6 +364,8 @@ enum fuse_opcode {
 	FUSE_FALLOCATE     = 43,
 	FUSE_READDIRPLUS   = 44,
 	FUSE_RENAME2       = 45,
+	FUSE_LSEEK         = 46,
+	FUSE_DIR_READ      = 47,
 
 	/* CUSE specific operations */
 	CUSE_INIT          = 4096,
@@ -757,5 +765,28 @@ struct fuse_notify_retrieve_in {
 
 /* Device ioctls: */
 #define FUSE_DEV_IOC_CLONE	_IOR(229, 0, uint32_t)
+
+struct fuse_lseek_in {
+	uint64_t	fh;
+	uint64_t	offset;
+	uint32_t	whence;
+	uint32_t	padding;
+};
+
+struct fuse_lseek_out {
+	uint64_t	offset;
+};
+
+struct fuse_dir_read_in {
+	uint32_t	size;
+	uint32_t	padding;
+	int64_t		off;
+	uint64_t	fh;
+};
+
+struct fuse_dir_read_out {
+	uint32_t	size;
+	uint32_t	padding;
+};
 
 #endif /* _LINUX_FUSE_H */

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1056,6 +1056,27 @@ struct fuse_lowlevel_ops {
 	 */
 	void (*readdirplus) (fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 			 struct fuse_file_info *fi);
+
+	/**
+	 * Read from a directory
+	 *
+	 * Introduced in version 3.0
+	 *
+	 * Call read(2) on a directory. You probably want the readdir* family of
+	 * functions instead of this.
+	 *
+	 * Valid replies:
+	 *   fuse_reply_buf
+	 *   fuse_reply_err
+	 *
+	 * @param req request handle
+	 * @param ino the inode number
+	 * @param size the size of the request
+	 * @param off the offset of the request
+	 * @param fi file information
+	 */
+	void (*dir_read) (fuse_req_t req, fuse_ino_t ino, size_t size,
+			  off_t off, struct fuse_file_info *fi);
 };
 
 /**

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -2273,6 +2273,20 @@ int fuse_fs_fallocate(struct fuse_fs *fs, const char *path, int mode,
 		return -ENOSYS;
 }
 
+int fuse_fs_dir_read(struct fuse_fs *fs, const char *path, char* buf,
+		size_t size, off_t off, struct fuse_file_info *fi)
+{
+	fuse_get_context()->private_data = fs->user_data;
+	if (fs->op.dir_read) {
+		if (fs->debug)
+			fprintf(stderr, "dir_read %s %lu %ld\n",
+				path, (unsigned long) size, (long) off);
+		return fs->op.dir_read(path, buf, size, off, fi);
+	} else {
+		return -ENOSYS;
+	}
+}
+
 static int is_open(struct fuse *f, fuse_ino_t dir, const char *name)
 {
 	struct node *node;
@@ -4204,6 +4218,34 @@ static void fuse_lib_fallocate(fuse_req_t req, fuse_ino_t ino, int mode,
 	reply_err(req, err);
 }
 
+static void fuse_lib_dir_read(fuse_req_t req, fuse_ino_t ino, size_t size,
+		off_t off, struct fuse_file_info *llfi)
+{
+	struct fuse *f = req_fuse_prepare(req);
+	int res;
+	struct fuse_file_info fi;
+	char *buf = (char *) malloc(size);
+	if (buf == NULL) {
+		reply_err(req, -ENOMEM);
+		return;
+	}
+	get_dirhandle(llfi, &fi);
+	char *path;
+	res = get_path_nullok(f, ino, &path);
+	if (!res) {
+		struct fuse_intr_data d;
+		fuse_prepare_interrupt(f, req, &d);
+		res = fuse_fs_dir_read(f->fs, path, buf, size, off, &fi);
+		fuse_finish_interrupt(f, req, &d);
+		free_path(f, ino, path);
+	}
+	if (res > 0)
+		fuse_reply_buf(req, buf, res);
+	else
+		reply_err(req, res);
+	free(buf);
+}
+
 static int clean_delay(struct fuse *f)
 {
 	/*
@@ -4300,6 +4342,7 @@ static struct fuse_lowlevel_ops fuse_path_ops = {
 	.ioctl = fuse_lib_ioctl,
 	.poll = fuse_lib_poll,
 	.fallocate = fuse_lib_fallocate,
+	.dir_read = fuse_lib_dir_read,
 };
 
 int fuse_notify_poll(struct fuse_pollhandle *ph)

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1803,6 +1803,20 @@ static void do_fallocate(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		fuse_reply_err(req, ENOSYS);
 }
 
+static void do_dir_read(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
+{
+	struct fuse_dir_read_in *arg = (struct fuse_dir_read_in *) inarg;
+	struct fuse_file_info fi;
+
+	memset(&fi, 0, sizeof(fi));
+	fi.fh = arg->fh;
+
+	if (req->f->op.dir_read)
+		req->f->op.dir_read(req, nodeid, arg->size, arg->off, &fi);
+	else
+		fuse_reply_err(req, ENOSYS);
+}
+
 static void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 {
 	struct fuse_init_in *arg = (struct fuse_init_in *) inarg;
@@ -2397,6 +2411,7 @@ static struct {
 	[FUSE_BATCH_FORGET] = { do_batch_forget, "BATCH_FORGET" },
 	[FUSE_READDIRPLUS] = { do_readdirplus,	"READDIRPLUS"},
 	[FUSE_RENAME2]     = { do_rename2,      "RENAME2"    },
+	[FUSE_DIR_READ]    = { do_dir_read,    "DIR_READ"    },
 	[CUSE_INIT]	   = { cuse_lowlevel_init, "CUSE_INIT"   },
 };
 


### PR DESCRIPTION
read(2) on a directory is an odd syscall, but the VFS permits it and existing filesystems use it, so this is the userspace side of letting FUSE filesystems implement it. I also removed fuse_kernel.h since it duplicates an outdated version of the kernel FUSE header.
