### PR TITLE
Should fuse_do_release call do_forget() ?

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -3039,6 +3039,8 @@ static void fuse_do_release(struct fuse *f, fuse_ino_t ino, const char *path,
 			free_path(f, ino, unlinkpath);
 		}
 	}
+
+	do_forget(f, ino, 1);
 }
 
 static void fuse_lib_create(fuse_req_t req, fuse_ino_t parent,


### PR DESCRIPTION
I see the name and id caches continually growing, even with "-o remember=60".

My test is an infinite loop of open, write, close on random file names.

fuse_clean_cache is not reaping old nodes because forget isn't called and we never decrement nlookup. With this patch, nodes go onto the lru list and are eventually reaped. Memory no longer grows continuously.
