### PR TITLE
Add support for posix ACLs

### DIFF
--- a/example/fusexmp.c
+++ b/example/fusexmp.c
@@ -33,6 +33,7 @@
 #endif
 
 #include <fuse.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -41,9 +42,19 @@
 #include <dirent.h>
 #include <errno.h>
 #include <sys/time.h>
+#include <libgen.h>
 #ifdef HAVE_SETXATTR
 #include <sys/xattr.h>
 #endif
+
+struct xmp_data {
+	int acls;
+};
+
+static int xmp_setacl(const char *path, enum posix_acl_type type,
+		      struct fuse_acl *acl);
+static int xmp_getacl(const char *path, enum posix_acl_type type,
+		      struct fuse_acl **acl);
 
 static int xmp_getattr(const char *path, struct stat *stbuf)
 {
@@ -108,9 +119,47 @@ static int xmp_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	return 0;
 }
 
+static int xmp_acl_mknod(const char *path, mode_t *pmode, bool is_dir,
+			 struct fuse_acl **default_acl,
+			 struct fuse_acl **access_acl)
+{
+	struct fuse_acl *p = NULL, *d = NULL, *a = NULL;
+	char *tmp, *parent_path;
+	int res;
+
+	tmp = strdup(path);
+	if (!tmp)
+		return -errno;
+	parent_path = dirname(tmp);
+	res = xmp_getacl(parent_path, POSIX_ACL_TYPE_DEFAULT, &p);
+	free(tmp);
+	if (res == -ENODATA)
+		goto out;
+	if (res)
+		return res;
+	res = fuse_acl_mknod(p, pmode, is_dir, &d, &a);
+	free(p);
+	if (res)
+		return res;
+
+out:
+	*access_acl = a;
+	*default_acl = d;
+	return 0;
+}
+
 static int xmp_mknod(const char *path, mode_t mode, dev_t rdev)
 {
+	struct xmp_data *xmp = fuse_get_context()->private_data;
 	int res;
+	struct fuse_acl *default_acl = NULL, *access_acl = NULL;
+
+	if (xmp->acls) {
+		res = xmp_acl_mknod(path, &mode, false, &default_acl,
+				    &access_acl);
+		if (res)
+			return res;
+	}
 
 	/* On Linux this could just be 'mknod(path, mode, rdev)' but this
 	   is more portable */
@@ -122,21 +171,62 @@ static int xmp_mknod(const char *path, mode_t mode, dev_t rdev)
 		res = mkfifo(path, mode);
 	else
 		res = mknod(path, mode, rdev);
-	if (res == -1)
-		return -errno;
+	if (res == -1) {
+		res = -errno;
+		goto out;
+	}
 
-	return 0;
+	if (default_acl) {
+		res = xmp_setacl(path, POSIX_ACL_TYPE_DEFAULT, default_acl);
+		if (res)
+			goto out;
+	}
+	if (access_acl) {
+		res = xmp_setacl(path, POSIX_ACL_TYPE_ACCESS, access_acl);
+		if (res)
+			goto out;
+	}
+
+out:
+	free(default_acl);
+	free(access_acl);
+	return res;
 }
 
 static int xmp_mkdir(const char *path, mode_t mode)
 {
+	struct xmp_data *xmp = fuse_get_context()->private_data;
+	struct fuse_acl *default_acl = NULL, *access_acl = NULL;
 	int res;
 
-	res = mkdir(path, mode);
-	if (res == -1)
-		return -errno;
+	if (xmp->acls) {
+		res = xmp_acl_mknod(path, &mode, true, &default_acl,
+				    &access_acl);
+		if (res)
+			return res;
+	}
 
-	return 0;
+	res = mkdir(path, mode);
+	if (res == -1) {
+		res = -errno;
+		goto out;
+	}
+
+	if (default_acl) {
+		res = xmp_setacl(path, POSIX_ACL_TYPE_DEFAULT, default_acl);
+		if (res)
+			goto out;
+	}
+	if (access_acl) {
+		res = xmp_setacl(path, POSIX_ACL_TYPE_ACCESS, access_acl);
+		if (res)
+			goto out;
+	}
+
+out:
+	free(default_acl);
+	free(access_acl);
+	return res;
 }
 
 static int xmp_unlink(const char *path)
@@ -199,7 +289,23 @@ static int xmp_link(const char *from, const char *to)
 
 static int xmp_chmod(const char *path, mode_t mode)
 {
+	struct xmp_data *xmp = fuse_get_context()->private_data;
 	int res;
+
+	if (xmp->acls) {
+		struct fuse_acl *acl;
+		res = xmp_getacl(path, POSIX_ACL_TYPE_ACCESS, &acl);
+		if (!res) {
+			res = fuse_acl_chmod(acl, mode);
+			if (!res)
+				res = xmp_setacl(path, POSIX_ACL_TYPE_ACCESS, acl);
+			free(acl);
+			if (res)
+				return res;
+		} else if (res != -ENODATA) {
+			return res;
+		}
+	}
 
 	res = chmod(path, mode);
 	if (res == -1)
@@ -385,9 +491,122 @@ static int xmp_removexattr(const char *path, const char *name)
 		return -errno;
 	return 0;
 }
+
+/*
+ * Data of ACL xattrs is the same as standard posix ACLs, but use
+ * different xattr names so that the underlying filesystem doesn't
+ * treat them as ACLs.
+ */
+#define XMP_ACCESS_ACL_XATTR	"user.fusexmp_acl_access"
+#define XMP_DEFAULT_ACL_XATTR	"user.fusexmp_acl_default"
+
+static int xmp_setacl(const char *path, enum posix_acl_type type,
+		      struct fuse_acl *acl)
+{
+	struct xmp_data *xmp = fuse_get_context()->private_data;
+	const char *name;
+	struct posix_acl_xattr *xattr;
+	ssize_t size;
+	uint32_t mode;
+	int ret = 0;
+
+	if (!xmp->acls)
+		return -ENOSYS;
+
+	switch (type) {
+	case POSIX_ACL_TYPE_ACCESS:
+		name = XMP_ACCESS_ACL_XATTR;
+		if (acl) {
+			ret = fuse_acl_equiv_mode(acl, &mode);
+			if (ret < 0)
+				return ret;
+		}
+		break;
+	case POSIX_ACL_TYPE_DEFAULT:
+		name = XMP_DEFAULT_ACL_XATTR;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (!acl)
+		return xmp_removexattr(path, name);
+
+	size = fuse_acl_to_xattr(acl, &xattr);
+	if (size < 0)
+		return (int)size;
+	ret = xmp_setxattr(path, name, (char *)xattr, size, 0);
+	if (!ret && type == POSIX_ACL_TYPE_ACCESS) {
+		/* Don't use xmp_chmod() as it will try to update the ACL */
+		if (chmod(path, mode) == -1)
+			ret = -errno;
+	}
+	free(xattr);
+	return ret;
+}
+
+static int xmp_getacl(const char *path, enum posix_acl_type type,
+		      struct fuse_acl **acl)
+{
+	struct xmp_data *xmp = fuse_get_context()->private_data;
+	const char *name;
+	ssize_t size;
+	struct posix_acl_xattr *xattr;
+	int ret;
+
+	if (!xmp->acls)
+		return -ENODATA;
+
+	switch (type) {
+	case POSIX_ACL_TYPE_ACCESS:
+		name = XMP_ACCESS_ACL_XATTR;
+		break;
+	case POSIX_ACL_TYPE_DEFAULT:
+		name = XMP_DEFAULT_ACL_XATTR;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	size = lgetxattr(path, name, NULL, 0);
+	if (size == -1)
+		return -errno;
+	xattr = malloc(size);
+	if (!xattr)
+		return -ENOMEM;
+
+	size = lgetxattr(path, name, xattr, size);
+	if (size == -1)
+		ret = -errno;
+	else
+		ret = fuse_acl_from_xattr(xattr, size, acl);
+	free(xattr);
+	return ret;
+}
+#else
+static int xmp_setacl(const char *path, enum posix_acl_type type,
+		      struct fuse_acl *acl)
+{
+	return -ENOSYS;
+}
+
+
+static int xmp_getacl(const char *path, enum posix_acl_type type,
+		      struct fuse_acl **acl)
+{
+	return -ENODATA;
+}
 #endif /* HAVE_SETXATTR */
 
+static void *xmp_init(struct fuse_conn_info *conn)
+{
+	struct xmp_data *xmp = fuse_get_context()->private_data;
+	xmp->acls = (conn->want & FUSE_CAP_POSIX_ACL) != 0;
+	return xmp;
+}
+
 static struct fuse_operations xmp_oper = {
+	.init		= xmp_init,
 	.getattr	= xmp_getattr,
 	.access		= xmp_access,
 	.readlink	= xmp_readlink,
@@ -419,11 +638,14 @@ static struct fuse_operations xmp_oper = {
 	.getxattr	= xmp_getxattr,
 	.listxattr	= xmp_listxattr,
 	.removexattr	= xmp_removexattr,
+	.setacl		= xmp_setacl,
+	.getacl		= xmp_getacl,
 #endif
 };
 
 int main(int argc, char *argv[])
 {
+	struct xmp_data xmp = {0,};
 	umask(0);
-	return fuse_main(argc, argv, &xmp_oper, NULL);
+	return fuse_main(argc, argv, &xmp_oper, &xmp);
 }

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -15,6 +15,7 @@
 #define FUSE_COMMON_H_
 
 #include "fuse_opt.h"
+#include <string.h>
 #include <stdint.h>
 #include <sys/types.h>
 
@@ -102,6 +103,7 @@ struct fuse_file_info {
  * FUSE_CAP_ASYNC_DIO: asynchronous direct I/O submission
  * FUSE_CAP_WRITEBACK_CACHE: use writeback cache for buffered writes
  * FUSE_CAP_NO_OPEN_SUPPORT: support zero-message opens
+ * FUSE_CAP_POSIX_ACL: filesystem supports posix acls
  */
 #define FUSE_CAP_ASYNC_READ		(1 << 0)
 #define FUSE_CAP_POSIX_LOCKS		(1 << 1)
@@ -120,6 +122,7 @@ struct fuse_file_info {
 #define FUSE_CAP_ASYNC_DIO		(1 << 15)
 #define FUSE_CAP_WRITEBACK_CACHE	(1 << 16)
 #define FUSE_CAP_NO_OPEN_SUPPORT	(1 << 17)
+#define FUSE_CAP_POSIX_ACL		(1 << 18)
 
 /**
  * Ioctl flags
@@ -496,6 +499,43 @@ int fuse_set_signal_handlers(struct fuse_session *se);
  * fuse_set_signal_handlers()
  */
 void fuse_remove_signal_handlers(struct fuse_session *se);
+
+/* ----------------------------------------------------------- *
+ * Posix ACLs						       *
+ * ----------------------------------------------------------- */
+
+#define POSIX_ACL_XATTR_VERSION 0x00002
+#define POSIX_ACL_XATTR_ACCESS "system.posix_acl_access"
+#define POSIX_ACL_XATTR_DEFAULT "system.posix_acl_default"
+
+enum posix_acl_type {
+	POSIX_ACL_TYPE_ACCESS,
+	POSIX_ACL_TYPE_DEFAULT,
+};
+
+#define POSIX_ACL_TAG_USER_OBJ	0x01
+#define POSIX_ACL_TAG_USER	0x02
+#define POSIX_ACL_TAG_GROUP_OBJ	0x04
+#define POSIX_ACL_TAG_GROUP	0x08
+#define POSIX_ACL_TAG_MASK	0x10
+#define POSIX_ACL_TAG_OTHER	0x20
+
+struct posix_acl_xattr_entry {
+	uint16_t	tag;
+	uint16_t	perm;
+	uint32_t	id;
+};
+
+struct posix_acl_xattr {
+	uint32_t			version;
+	struct posix_acl_xattr_entry	entries[0];
+};
+
+static inline int is_posix_acl(const char *name)
+{
+	return !strcmp(name, POSIX_ACL_XATTR_ACCESS) ||
+	       !strcmp(name, POSIX_ACL_XATTR_DEFAULT);
+}
 
 /* ----------------------------------------------------------- *
  * Compatibility stuff					       *

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -102,6 +102,13 @@
  *  - add ctime and ctimensec to fuse_setattr_in
  *  - add FUSE_RENAME2 request
  *  - add FUSE_NO_OPEN_SUPPORT flag
+ *
+ *  7.24
+ *  - add FUSE_LSEEK for SEEK_HOLE and SEEK_DATA support
+ *
+ *  7.25
+ *  - add FUSE_PARALLEL_DIROPS
+ *  - add FUSE_POSIX_ACL
  */
 
 #ifndef _LINUX_FUSE_H
@@ -137,7 +144,7 @@
 #define FUSE_KERNEL_VERSION 7
 
 /** Minor version number of this interface */
-#define FUSE_KERNEL_MINOR_VERSION 23
+#define FUSE_KERNEL_MINOR_VERSION 25
 
 /** The node ID of the root inode */
 #define FUSE_ROOT_ID 1
@@ -231,6 +238,8 @@ struct fuse_file_lock {
  * FUSE_ASYNC_DIO: asynchronous direct I/O submission
  * FUSE_WRITEBACK_CACHE: use writeback cache for buffered writes
  * FUSE_NO_OPEN_SUPPORT: kernel supports zero-message opens
+ * FUSE_PARALLEL_DIROPS: allow parallel lookups and readdir
+ * FUSE_POSIX_ACL: filesystem supports posix acls
  */
 #define FUSE_ASYNC_READ		(1 << 0)
 #define FUSE_POSIX_LOCKS	(1 << 1)
@@ -250,6 +259,8 @@ struct fuse_file_lock {
 #define FUSE_ASYNC_DIO		(1 << 15)
 #define FUSE_WRITEBACK_CACHE	(1 << 16)
 #define FUSE_NO_OPEN_SUPPORT	(1 << 17)
+#define FUSE_PARALLEL_DIROPS    (1 << 18)
+#define FUSE_POSIX_ACL		(1 << 19)
 
 /**
  * CUSE INIT request/reply flags
@@ -358,6 +369,7 @@ enum fuse_opcode {
 	FUSE_FALLOCATE     = 43,
 	FUSE_READDIRPLUS   = 44,
 	FUSE_RENAME2       = 45,
+	FUSE_LSEEK         = 46,
 
 	/* CUSE specific operations */
 	CUSE_INIT          = 4096,
@@ -757,5 +769,16 @@ struct fuse_notify_retrieve_in {
 
 /* Device ioctls: */
 #define FUSE_DEV_IOC_CLONE	_IOR(229, 0, uint32_t)
+
+struct fuse_lseek_in {
+	uint64_t	fh;
+	uint64_t	offset;
+	uint32_t	whence;
+	uint32_t	padding;
+};
+
+struct fuse_lseek_out {
+	uint64_t	offset;
+};
 
 #endif /* _LINUX_FUSE_H */

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1056,6 +1056,47 @@ struct fuse_lowlevel_ops {
 	 */
 	void (*readdirplus) (fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 			 struct fuse_file_info *fi);
+
+	/**
+	 * Set an ACL in the filesystem based on the supplied posix ACL xattr
+	 *
+	 * Valid replies:
+	 *   fuse_reply_err
+	 *
+	 * @param req request handle
+	 * @param ino the inode number
+	 * @param name name of the posix ACL xattr
+	 * @param value buffer containing the posix ACL xattr
+	 * @param size size of the posix ACL xattr
+	 */
+	void (*setacl) (fuse_req_t req, fuse_ino_t ino, const char *name,
+			const struct posix_acl_xattr *value, size_t size);
+
+	/**
+	 * Read an ACL from the filesystem into a posix ACL xattr
+	 *
+	 * If size is zero, the size of the value should be sent with
+	 * fuse_reply_xattr.
+	 *
+	 * If the size is non-zero, and the value fits in the buffer, the
+	 * value should be sent with fuse_reply_buf.
+	 *
+	 * If the size is too small for the value, the ERANGE error should
+	 * be sent.
+	 *
+	 * Valid replies:
+	 *   fuse_reply_buf
+	 *   fuse_reply_data
+	 *   fuse_reply_xattr
+	 *   fuse_reply_err
+	 *
+	 * @param req request handle
+	 * @param ino the inode number
+	 * @param name of the posix ACL xattr
+	 * @param size maximum size of the value to send
+	 */
+	void (*getacl) (fuse_req_t req, fuse_ino_t ino, const char *name,
+			size_t size);
 };
 
 /**

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -125,6 +125,13 @@ FUSE_3.0 {
 		fuse_lowlevel_notify_delete;
 		fuse_fs_flock;
 		fuse_fs_fallocate;
+		fuse_fs_setacl;
+		fuse_fs_getacl;
+		fuse_acl_from_xattr;
+		fuse_acl_to_xattr;
+		fuse_acl_equiv_mode;
+		fuse_acl_chmod;
+		fuse_acl_mknod;
 
 	local:
 		*;

--- a/lib/modules/iconv.c
+++ b/lib/modules/iconv.c
@@ -577,6 +577,32 @@ static int iconv_bmap(const char *path, size_t blocksize, uint64_t *idx)
 	return err;
 }
 
+static int iconv_setacl(const char *path, enum posix_acl_type type,
+			struct fuse_acl *acl)
+{
+	struct iconv *ic = iconv_get();
+	char *newpath;
+	int err = iconv_convpath(ic, path, &newpath, 0);
+	if (!err) {
+		err = fuse_fs_setacl(ic->next, path, type, acl);
+		free(newpath);
+	}
+	return err;
+}
+
+static int iconv_getacl(const char *path, enum posix_acl_type type,
+			 struct fuse_acl **pacl)
+{
+	struct iconv *ic = iconv_get();
+	char *newpath;
+	int err = iconv_convpath(ic, path, &newpath, 0);
+	if (!err) {
+		err = fuse_fs_getacl(ic->next, path, type, pacl);
+		free(newpath);
+	}
+	return err;
+}
+
 static void *iconv_init(struct fuse_conn_info *conn)
 {
 	struct iconv *ic = iconv_get();
@@ -634,6 +660,8 @@ static const struct fuse_operations iconv_oper = {
 	.lock		= iconv_lock,
 	.flock		= iconv_flock,
 	.bmap		= iconv_bmap,
+	.setacl		= iconv_setacl,
+	.getacl		= iconv_getacl,
 
 	.flag_nopath = 1,
 };

--- a/lib/modules/subdir.c
+++ b/lib/modules/subdir.c
@@ -563,6 +563,32 @@ static int subdir_bmap(const char *path, size_t blocksize, uint64_t *idx)
 	return err;
 }
 
+static int subdir_setacl(const char *path, enum posix_acl_type type,
+			 struct fuse_acl *acl)
+{
+	struct subdir *d = subdir_get();
+	char *newpath;
+	int err = subdir_addpath(d, path, &newpath);
+	if (!err) {
+		err = fuse_fs_setacl(d->next, newpath, type, acl);
+		free(newpath);
+	}
+	return err;
+}
+
+static int subdir_getacl(const char *path, enum posix_acl_type type,
+			 struct fuse_acl **pacl)
+{
+	struct subdir *d = subdir_get();
+	char *newpath;
+	int err = subdir_addpath(d, path, &newpath);
+	if (!err) {
+		err = fuse_fs_getacl(d->next, newpath, type, pacl);
+		free(newpath);
+	}
+	return err;
+}
+
 static void *subdir_init(struct fuse_conn_info *conn)
 {
 	struct subdir *d = subdir_get();
@@ -616,6 +642,8 @@ static const struct fuse_operations subdir_oper = {
 	.lock		= subdir_lock,
 	.flock		= subdir_flock,
 	.bmap		= subdir_bmap,
+	.setacl		= subdir_setacl,
+	.getacl		= subdir_getacl,
 
 	.flag_nopath = 1,
 };


### PR DESCRIPTION
This pull request requires kernel support. Patches for Linux can be found at:

http://lkml.kernel.org/r/1472478397-131967-1-git-send-email-seth.forshee@canonical.com

With kernel support, these patches add support for posix ACLs by passing the raw posix ACL xattrs between the kernel and userspace. If supported by the filesystem, libfuse will parse the raw xattrs into an easier to use data structure and pass these to the filesystem's setacl/getacl callbacks for processing. Helpers are provided for common operations like converting between the posix and fuse ACL data structures, calculating the file mode from ACLs, updating ACLs when the file mode changes, and determining what ACLs should be inherited by children of a directory with default ACLs.