### PR TITLE
man: Document suid requirement

### DIFF
--- a/doc/fusermount.1
+++ b/doc/fusermount.1
@@ -10,6 +10,7 @@
 Filesystem in Userspace (FUSE) is a simple interface for userspace programs to export a virtual filesystem to the Linux kernel. It also aims to provide a secure method for non privileged users to create and mount their own filesystem implementations.
 .PP
 \fBfusermount\fR is a program to mount and unmount FUSE filesystems.
+To work, it must be set-uid root.
 
 .SH OPTIONS
 .IP "\-h" 4


### PR DESCRIPTION
/usr/bin/fusermount could not be set-uid-root if package manager blacklists suid executables.
Currently, a mount() fails, printing `"fusermount: mount failed:%s", "Operation not permitted"`,
which looks like there is a mis-configuration of fstab.