### PR TITLE
silence bogus eclipse linter warning

### DIFF
--- a/example/cuse.c
+++ b/example/cuse.c
@@ -233,6 +233,7 @@ static void cusexmp_ioctl(fuse_req_t req, int cmd, void *arg,
 
 	case FIOC_READ:
 		is_read = 1;
+		/* no break */
 	case FIOC_WRITE:
 		fioc_do_rw(req, arg, in_buf, in_bufsz, out_bufsz, is_read);
 		break;


### PR DESCRIPTION
bogus warning
"No break at the end of case	cuse.c	/example	line 235	Code Analysis Problem"