### PR TITLE
util/fusermount.c: Fix user mounting under grsec kernel.

### DIFF
--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1200,18 +1200,15 @@ int main(int argc, char *argv[])
 
 	origmnt = argv[optind];
 
-	drop_privs();
 	mnt = fuse_mnt_resolve_path(progname, origmnt);
-	if (mnt != NULL) {
-		res = chdir("/");
-		if (res == -1) {
-			fprintf(stderr, "%s: failed to chdir to '/'\n", progname);
-			goto err_out;
-		}
-	}
-	restore_privs();
 	if (mnt == NULL)
 		exit(1);
+
+	res = chdir("/");
+	if (res == -1) {
+		fprintf(stderr, "%s: failed to chdir to '/'\n", progname);
+		goto err_out;
+	}
 
 	umask(033);
 	if (unmount)


### PR DESCRIPTION
If the user was not in readproc group, realpath() would fail causing
fusermount to fail.  The privilege drop for realpath() is unnecessary
as the real access checks are done in other places.

Based on patch by Timo Teräs for fuse package in Alpine Linux's aports:
http://git.alpinelinux.org/cgit/aports/commit/?id=b5d81e456487d4dbfbdf0d07ae6ca5cf3f59d186