### PR TITLE
lib/{mount.c,mount_util.c}: Depend on IGNORE_MTAB instead of __NetBSD__.

### DIFF
--- a/lib/mount.c
+++ b/lib/mount.c
@@ -37,8 +37,11 @@
 #define MS_SYNCHRONOUS	MNT_SYNCHRONOUS
 #define MS_NOATIME	MNT_NOATIME
 
+#ifndef IGNORE_MTAB
+#define IGNORE_MTAB 1
+#endif /* IGNORE_MTAB */
 #define umount2(mnt, flags) unmount(mnt, (flags == 2) ? MNT_FORCE : 0)
-#endif
+#endif /* __NetBSD__ */
 
 #define FUSERMOUNT_PROG		"fusermount3"
 #define FUSE_COMMFD_ENV		"_FUSE_COMMFD"
@@ -481,7 +484,6 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
 		goto out_close;
 	}
 
-#ifndef __NetBSD__
 #ifndef IGNORE_MTAB
 	if (geteuid() == 0) {
 		char *newmnt = fuse_mnt_resolve_path("fuse", mnt);
@@ -496,7 +498,6 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
 			goto out_umount;
 	}
 #endif /* IGNORE_MTAB */
-#endif /* __NetBSD__ */
 	free(type);
 	free(source);
 

--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -33,10 +33,6 @@
 #define IGNORE_MTAB 1
 #endif /* IGNORE_MTAB */
 #define umount2(mnt, flags) unmount(mnt, (flags == 2) ? MNT_FORCE : 0)
-#else /* !__NetBSD__ */
-#ifdef IGNORE_MTAB
-#undef IGNORE_MTAB
-#endif /* IGNORE_MTAB */
 #endif /* __NetBSD__ */
 
 #ifdef IGNORE_MTAB

--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -29,7 +29,17 @@
 #include <sys/param.h>
 
 #ifdef __NetBSD__
+#ifndef IGNORE_MTAB
+#define IGNORE_MTAB 1
+#endif /* IGNORE_MTAB */
 #define umount2(mnt, flags) unmount(mnt, (flags == 2) ? MNT_FORCE : 0)
+#else /* !__NetBSD__ */
+#ifdef IGNORE_MTAB
+#undef IGNORE_MTAB
+#endif /* IGNORE_MTAB */
+#endif /* __NetBSD__ */
+
+#ifdef IGNORE_MTAB
 #define mtab_needs_update(mnt) 0
 #else
 static int mtab_needs_update(const char *mnt)
@@ -75,7 +85,7 @@ static int mtab_needs_update(const char *mnt)
 
 	return 1;
 }
-#endif /* __NetBSD__ */
+#endif /* IGNORE_MTAB */
 
 static int add_mount(const char *progname, const char *fsname,
 		       const char *mnt, const char *type, const char *opts)


### PR DESCRIPTION
Define `IGNORE_MTAB` in these files if `__NetBSD__` is defined.

It makes the code more consistent (same pattern) and also allows
avoiding call to `mtab_needs_update()` (making it a macro returning 0)
if libfuse was configured with `--disable-mtab`.

util/fusermount.c's preprocessor directives also check `IGNORE_MTAB`, but
`__NetBSD__` is nowhere inspected there, and because I don't have NetBSD
and I don't know NetBSD mounting behavior, I refrained from touching
this file and making `-D__NetBSD__` -> `-DIGNORE_MTAB` a global thing.