### PR TITLE
Revert "Dropped example/null.c"

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,5 +1,6 @@
 /passthrough
 /passthrough_fh
+/null
 /hello
 /hello_ll
 /ioctl

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -2,7 +2,7 @@
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -D_REENTRANT
 noinst_HEADERS = ioctl.h
-noinst_PROGRAMS = passthrough passthrough_fh hello hello_ll \
+noinst_PROGRAMS = passthrough passthrough_fh null hello hello_ll \
 		  ioctl ioctl_client poll poll_client \
 		  passthrough_ll notify_inval_inode \
 		  notify_store_retrieve notify_inval_entry \

--- a/example/null.c
+++ b/example/null.c
@@ -1,0 +1,137 @@
+/*
+  FUSE: Filesystem in Userspace
+  Copyright (C) 2001-2007  Miklos Szeredi <miklos@szeredi.hu>
+
+  This program can be distributed under the terms of the GNU GPL.
+  See the file COPYING.
+*/
+
+/** @file
+ *
+ * null.c - FUSE: Filesystem in Userspace
+ *
+ * \section section_compile compiling this example
+ *
+ * gcc -Wall null.c `pkg-config fuse3 --cflags --libs` -o null
+ *
+ * \section section_source the complete source
+ * \include null.c
+ */
+
+
+#define FUSE_USE_VERSION 30
+
+#include <config.h>
+
+#include <fuse.h>
+#include <fuse_lowlevel.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <time.h>
+#include <errno.h>
+
+static int null_getattr(const char *path, struct stat *stbuf,
+			struct fuse_file_info *fi)
+{
+	(void) fi;
+
+	if(strcmp(path, "/") != 0)
+		return -ENOENT;
+
+	stbuf->st_mode = S_IFREG | 0644;
+	stbuf->st_nlink = 1;
+	stbuf->st_uid = getuid();
+	stbuf->st_gid = getgid();
+	stbuf->st_size = (1ULL << 32); /* 4G */
+	stbuf->st_blocks = 0;
+	stbuf->st_atime = stbuf->st_mtime = stbuf->st_ctime = time(NULL);
+
+	return 0;
+}
+
+static int null_truncate(const char *path, off_t size,
+			 struct fuse_file_info *fi)
+{
+	(void) size;
+	(void) fi;
+
+	if(strcmp(path, "/") != 0)
+		return -ENOENT;
+
+	return 0;
+}
+
+static int null_open(const char *path, struct fuse_file_info *fi)
+{
+	(void) fi;
+
+	if(strcmp(path, "/") != 0)
+		return -ENOENT;
+
+	return 0;
+}
+
+static int null_read(const char *path, char *buf, size_t size,
+		     off_t offset, struct fuse_file_info *fi)
+{
+	(void) buf;
+	(void) offset;
+	(void) fi;
+
+	if(strcmp(path, "/") != 0)
+		return -ENOENT;
+
+	if (offset >= (1ULL << 32))
+		return 0;
+
+	return size;
+}
+
+static int null_write(const char *path, const char *buf, size_t size,
+		      off_t offset, struct fuse_file_info *fi)
+{
+	(void) buf;
+	(void) offset;
+	(void) fi;
+
+	if(strcmp(path, "/") != 0)
+		return -ENOENT;
+
+	return size;
+}
+
+static struct fuse_operations null_oper = {
+	.getattr	= null_getattr,
+	.truncate	= null_truncate,
+	.open		= null_open,
+	.read		= null_read,
+	.write		= null_write,
+};
+
+int main(int argc, char *argv[])
+{
+	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
+	struct fuse_cmdline_opts opts;
+	struct stat stbuf;
+
+	if (fuse_parse_cmdline(&args, &opts) != 0)
+		return 1;
+
+	if (!opts.mountpoint) {
+		fprintf(stderr, "missing mountpoint parameter\n");
+		return 1;
+	}
+
+	if (stat(opts.mountpoint, &stbuf) == -1) {
+		fprintf(stderr ,"failed to access mountpoint %s: %s\n",
+			opts.mountpoint, strerror(errno));
+		return 1;
+	}
+	if (!S_ISREG(stbuf.st_mode)) {
+		fprintf(stderr, "mountpoint is not a regular file\n");
+		return 1;
+	}
+
+	return fuse_main(argc, argv, &null_oper, NULL);
+}


### PR DESCRIPTION
This reverts commit d5cdbb94a0650b0a462682cf0a84463ff1513900.

null works completely fine, just the mountpoint should
be a regular file -- so there is no need to dismiss it.

Also fixing up compiler warnings.