### PR TITLE
Set default options before parsing

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4610,6 +4610,11 @@ struct fuse *fuse_new(struct fuse_args *args,
 		goto out;
 	}
 
+	f->conf.entry_timeout = 1.0;
+	f->conf.attr_timeout = 1.0;
+	f->conf.negative_timeout = 0.0;
+	f->conf.intr_signal = FUSE_DEFAULT_INTR_SIGNAL;
+
 	/* Parse options */
 	if (fuse_opt_parse(args, &f->conf, fuse_lib_opts,
 			   fuse_lib_opt_proc) == -1)
@@ -4647,11 +4652,6 @@ struct fuse *fuse_new(struct fuse_args *args,
 		llop.getlk = NULL;
 		llop.setlk = NULL;
 	}
-
-	f->conf.entry_timeout = 1.0;
-	f->conf.attr_timeout = 1.0;
-	f->conf.negative_timeout = 0.0;
-	f->conf.intr_signal = FUSE_DEFAULT_INTR_SIGNAL;
 
 	f->pagesize = getpagesize();
 	init_list_head(&f->partial_slabs);


### PR DESCRIPTION
Previously `attr_timeout`, `entry_timeout`, and `negative_timeout` from the mount options were ignored because the defaults were set after parsing.