### PR TITLE
Add fuse_file_info flags: no_read_buf, not_write_buf

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -77,6 +77,10 @@ struct fuse_file_info {
 	/** Requested poll events.  Available in ->poll.  Only set on kernels
 	    which support it.  If unsupported, this field is set to zero. */
 	uint32_t poll_events;
+
+	/** Can be filled in by open to indicate not to use read/write_buf */
+	unsigned int no_read_buf : 1;
+	unsigned int no_write_buf : 1;
 };
 
 

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -1690,7 +1690,7 @@ int fuse_fs_read_buf(struct fuse_fs *fs, const char *path,
 				(unsigned long long) fi->fh,
 				size, (unsigned long long) off, fi->flags);
 
-		if (fs->op.read_buf) {
+		if (fs->op.read_buf && !fi->no_read_buf) {
 			res = fs->op.read_buf(path, bufp, size, off, fi);
 		} else {
 			struct fuse_bufvec *buf;
@@ -1744,7 +1744,7 @@ int fuse_fs_read(struct fuse_fs *fs, const char *path, char *mem, size_t size,
 				(unsigned long long) fi->fh,
 				size, (unsigned long long) off, fi->flags);
 
-		if (fs->op.read_buf) {
+		if (fs->op.read_buf && !fi->no_read_buf) {
 			struct fuse_bufvec *buf = NULL;
 
 			res = fs->op.read_buf(path, &buf, size, off, fi);
@@ -1792,7 +1792,7 @@ int fuse_fs_write_buf(struct fuse_fs *fs, const char *path,
 				(unsigned long long) off,
 				fi->flags);
 
-		if (fs->op.write_buf) {
+		if (fs->op.write_buf && !fi->no_write_buf) {
 			res = fs->op.write_buf(path, buf, off, fi);
 		} else {
 			void *mem = NULL;


### PR DESCRIPTION
Currently the decision whether to use _read_ (_write_) or _read_buf_ (_write_buf_) is done in compilation time. We at Ctera Networks are developing a cloud-cache file system which upon a cache hit opens a spliacable disk file and upon a cache miss opens an a no-fd network stream. 
We would like to have the option to decide whether to use the _\_buf_ functions at run time (on _open_).
This can be done by adding "no_read_buf" and "no_write_buf" flags to _struct fuse_file_info_