### PR TITLE
Remove fuse_fs_fgetattr and fuse_fs_ftruncate from linker script

### DIFF
--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -53,11 +53,9 @@ FUSE_3.0 {
 		fuse_fs_chown;
 		fuse_fs_create;
 		fuse_fs_destroy;
-		fuse_fs_fgetattr;
 		fuse_fs_flush;
 		fuse_fs_fsync;
 		fuse_fs_fsyncdir;
-		fuse_fs_ftruncate;
 		fuse_fs_getattr;
 		fuse_fs_getxattr;
 		fuse_fs_init;


### PR DESCRIPTION
They were removed from source here: https://github.com/libfuse/libfuse/commit/73b6ff4b75cf1228ea61262c293fcb2fda5dfeea