### PR TITLE
Fix compiler warnings of gcc-5.4.x

### DIFF
--- a/example/cuse_client.c
+++ b/example/cuse_client.c
@@ -40,7 +40,7 @@
 #include <config.h>
 
 #include <sys/types.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <stdio.h>

--- a/example/ioctl_client.c
+++ b/example/ioctl_client.c
@@ -24,7 +24,7 @@
 #include <config.h>
 
 #include <sys/types.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 #include <stdio.h>

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -21,7 +21,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/wait.h>


### PR DESCRIPTION
This PR can fix below  warnings which occur on compilation via gcc-5.4.x.

In file included from mount.c:24:0:
/home/banglang/work/op-lede/x86/staging_dir/toolchain-x86_64_gcc-5.4.0_musl/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
 #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
  ^

In file included from cuse_client.c:43:0:
/home/banglang/work/op-lede/x86/staging_dir/toolchain-x86_64_gcc-5.4.0_musl/include/sys/fcntl.h:1:2: warning: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Wcpp]
 #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
  ^

In file included from ioctl_client.c:27:0:
/home/banglang/work/op-lede/x86/staging_dir/toolchain-x86_64_gcc-5.4.0_musl/include/sys/fcntl.h:1:2: warning: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Wcpp]
 #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
  ^

Signed-off-by: Banglang <banglang.huang@foxmail.com>