### PR TITLE
Fix support for FUSE_POSIX_ACL

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,10 @@
+Unreleased Changes
+==================
+
+* Fixed support for `FUSE_CAP_POSIX_ACL`: setting this capability
+  flag had no effect in the previous versions of libfuse 3.x;
+  now ACLs should actually work.
+
 libfuse 3.1.1 (2017-08-06)
 ==========================
 

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1981,6 +1981,8 @@ static void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		outarg.flags |= FUSE_ASYNC_DIO;
 	if (se->conn.want & FUSE_CAP_WRITEBACK_CACHE)
 		outarg.flags |= FUSE_WRITEBACK_CACHE;
+	if (se->conn.want & FUSE_CAP_POSIX_ACL)
+		outarg.flags |= FUSE_POSIX_ACL;
 	outarg.max_readahead = se->conn.max_readahead;
 	outarg.max_write = se->conn.max_write;
 	if (se->conn.proto_minor >= 13) {


### PR DESCRIPTION
I tried to use the POSIX ACL feature which has been included in Linux kernels ≥ 4.9 but it did not work for me. After looking into the libfuse and Linux kernel sources I concluded that the kernel expects the `FUSE_POSIX_ACL` to be included when replying the initial `FUSE_INIT` request and the library never sets it. The change included in the attached commit fixes the problem for me.

However, maybe I did something wrong? I can see there are a few other flags which are never set by libfuse in `outarg.flags` in `do_init` (e.g., `FUSE_HANDLE_KILLPRIV`). Is the lack of `FUSE_POSIX_ACL` in `outarg.flags` an oversight in the library or maybe there is something else that file system implementations have to do to enable ACLs? How about the other flags?