### PR TITLE
Allow inode cache invalidation in high-level API

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -794,6 +794,19 @@ void fuse_stop_cleanup_thread(struct fuse *fuse);
  */
 int fuse_clean_cache(struct fuse *fuse);
 
+/**
+ * Notify the kernel to invalidate cache for the specified FS inode.
+ *
+ * This can be used to notify the kernel about external changes
+ * to files and directories, for example in network file systems.
+ *
+ * This uses a one-to-many mapping from the inode numbers reported
+ * by the file system (in the `st_ino` field in `getattr` output)
+ * and FUSE nodes. This calls `fuse_lowlevel_notify_inval_inode`
+ * internally.
+ */
+int fuse_notify_inval_fs_inode(struct fuse *fuse, ino_t fs_inode);
+
 /*
  * Stacking API
  */


### PR DESCRIPTION
> We introduce a new routine to the high-level FUSE API,
> fuse_notify_inval_fs_inode, which is responsible for invalidating the
> cached data for an inode.
> 
> The routine uses a new mapping of the "FS inodes" (inode numbers
> returned in the 'st_ino' field from 'getattr') into the nodes in the
> high-level FUSE API. Naturally, because multiple paths may refer to
> the same inode on the file system due to hard links, the mapping is
> one-to-many, and is implemented by means of a hash table. Internally,
> the high-level API routine calls the low-level routine
> fuse_notify_inval_inode.
> 
> This is useful for network-based file systems which use the high-level
> FUSE API. Up to now, there was no way for those file systems to notify
> the kernel about external changes.

I know this PR is not in perfect shape now (it could be using dynamically-sized hash tables, and it's based on fuse_2_9_bugfix), but before fixing and rebasing it, I'd like to ask for feedback from the maintainers on whether this would be an acceptable solution for providing external change notifications from file systems which use the high-level FUSE API.