### PR TITLE
fix lto build

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -9,6 +9,8 @@ Unreleased Changes
 
 * Fixed installation directory for udev rules.  
 
+* Fixed compilation with LTO.
+
 libfuse 3.1.1 (2017-08-06)
 ==========================
 

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4629,8 +4629,6 @@ void fuse_stop_cleanup_thread(struct fuse *f)
 
 /* Explicit prototype to prevent compiler warnings
    (fuse.h only defines fuse_new()) */
-struct fuse *fuse_new_31(struct fuse_args *args, const struct fuse_operations *op,
-		      size_t op_size, void *private_data);
 FUSE_SYMVER(".symver fuse_new_31,fuse_new@@FUSE_3.1");
 struct fuse *fuse_new_31(struct fuse_args *args,
 		      const struct fuse_operations *op,

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -125,3 +125,6 @@ int fuse_session_receive_buf_int(struct fuse_session *se, struct fuse_buf *buf,
 				 struct fuse_chan *ch);
 void fuse_session_process_buf_int(struct fuse_session *se,
 				  const struct fuse_buf *buf, struct fuse_chan *ch);
+
+struct fuse *fuse_new_31(struct fuse_args *args, const struct fuse_operations *op,
+		      size_t op_size, void *private_data);

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -302,7 +302,7 @@ int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
 	}
 
 
-	fuse = fuse_new(&args, op, op_size, user_data);
+	fuse = fuse_new_31(&args, op, op_size, user_data);
 	if (fuse == NULL) {
 		res = 1;
 		goto out1;


### PR DESCRIPTION
attempt at a workaround for https://github.com/libfuse/libfuse/issues/198

same as what you did [here](https://github.com/libfuse/libfuse/commit/5a5edc3353f468600933112422f080004189a665) for `fuse.c`, but you ignored the same call in `helper.c`.

builds on your gcc 4.8 travis. also, on my arch setup with gcc 7.1, this builds and runs fuse3+sshfs with -flto.