### PR TITLE
Adding pointer dereferencing after calling dlsym()

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -263,7 +263,7 @@ static int fuse_load_so_module(const char *module)
 	}
 
 	sprintf(tmp, "fuse_module_%s_factory", module);
-	factory = dlsym(so->handle, tmp);
+	factory = *((fuse_module_factory_t *) dlsym(so->handle, tmp));
 	if (factory == NULL) {
 		fprintf(stderr, "fuse: symbol <%s> not found in module: %s\n",
 			tmp, dlerror());


### PR DESCRIPTION
dlsym() resolves the location of the loaded symbol,
therefore dlsym() returns the type (fuse_module_factory_t *), not (fuse_module_factory_t).
Added pointer dereferencing to correctly refer the factory function.