### PR TITLE
make udevrulesdir configurable

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,5 @@
 option('disable-mtab', type : 'boolean', value : false,
        description: 'Disable and ignore usage of /etc/mtab')
+
+option('udevrulesdir', type : 'string', value : '',
+       description: 'Path where udev rules are installed to (Defaults to udevdir specified in udev.pc)')

--- a/util/meson.build
+++ b/util/meson.build
@@ -18,8 +18,12 @@ executable('mount.fuse3', ['mount.fuse.c'],
            install: true,
            install_dir: get_option('sbindir'))
 
-udev = dependency('udev')
-udevrulesdir = join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
+
+udevrulesdir = get_option('udevrulesdir')
+if udevrulesdir == ''
+  udev = dependency('udev')
+  udevrulesdir = join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
+endif
 
 meson.add_install_script('install_helper.sh', get_option('sysconfdir'),
                          get_option('bindir'), udevrulesdir)


### PR DESCRIPTION
on nixos we install fuse in its own hierarchy independent from systemd.

cc @primeos