### PR TITLE
Add example configuration file

### DIFF
--- a/util/fuse.conf
+++ b/util/fuse.conf
@@ -1,0 +1,17 @@
+# The file /etc/fuse.conf allows for the following parameters:
+#
+# user_allow_other - Using the allow_other mount option works fine as root, in
+# order to have it work as user you need user_allow_other in /etc/fuse.conf as
+# well. (This option allows users to use the allow_other option.) You need
+# allow_other if you want users other than the owner to access a mounted fuse.
+# This option must appear on a line by itself. There is no value, just the
+# presence of the option.
+
+#user_allow_other
+
+
+# mount_max = n - this option sets the maximum number of mounts.
+# Currently (2014) it must be typed exactly as shown
+# (with a single space before and after the equals sign).
+
+#mount_max = 1000

--- a/util/install_helper.sh
+++ b/util/install_helper.sh
@@ -25,6 +25,9 @@ install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
 install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
         "${DESTDIR}/etc/init.d/fuse3"
 
+install -D -m 644 "${MESON_SOURCE_ROOT}/util/fuse.conf" \
+	"${DESTDIR}/etc/fuse.conf"
+
 if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
     /usr/sbin/update-rc.d fuse3 start 34 S . start 41 0 6 . || /bin/true
 else


### PR DESCRIPTION
Add a configuration file with all options disabled that includes
all valid options and their description. This file is called out
in the packaging notes to be included in the -common package