### PR TITLE
Spelling

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -470,7 +470,7 @@ FUSE 2.9.4 (2015-05-22)
   in EINVAL when mounting the filesystem.  This also needs a fix in
   the kernel.
 
-* Initilaize stat buffer passed to ->getattr() and ->fgetattr() to
+* Initialize stat buffer passed to ->getattr() and ->fgetattr() to
   zero in all cases.  Reported by Daniel Iwan
 
 * libfuse: Add missing includes.  This allows compiling fuse with

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -854,7 +854,7 @@ ENUM_VALUES_PER_LINE   = 4
 # Netscape 6.0+, Internet explorer 5.0+, or Konqueror). Windows users are
 # probably better off using the HTML help feature. Other possible values
 # for this tag are: HIERARCHIES, which will generate the Groups, Directories,
-# and Class Hiererachy pages using a tree view instead of an ordered list;
+# and Class Hierarchy pages using a tree view instead of an ordered list;
 # ALL, which combines the behavior of FRAME and HIERARCHIES; and NONE, which
 # disables this behavior completely. For backwards compatibility with previous
 # releases of Doxygen, the values YES and NO are equivalent to FRAME and NONE

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -672,7 +672,7 @@ REFERENCES_RELATION    = NO
 # If the REFERENCES_LINK_SOURCE tag is set to YES (the default)
 # and SOURCE_BROWSER tag is set to YES, then the hyperlinks from
 # functions in REFERENCES_RELATION and REFERENCED_BY_RELATION lists will
-# link to the source code.  Otherwise they will link to the documentstion.
+# link to the source code.  Otherwise they will link to the documentation.
 
 REFERENCES_LINK_SOURCE = YES
 

--- a/example/notify_store_retrieve.c
+++ b/example/notify_store_retrieve.c
@@ -312,7 +312,7 @@ static void* update_fs_loop(void *data) {
             bufv.buf[0].mem = file_contents;
             bufv.buf[0].flags = 0;
 
-            /* This shouldn't fail, but apparenly it sometimes
+            /* This shouldn't fail, but apparently it sometimes
                does - see https://github.com/libfuse/libfuse/issues/105 */
             ret = fuse_lowlevel_notify_store(se, FILE_INO, 0, &bufv, 0);
             if (-ret == ENODEV) {

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -816,7 +816,7 @@ struct fuse_context {
  * @param argv the argument vector passed to the main() function
  * @param op the file system operation
  * @param private_data Initial value for the `private_data`
- *            field of `struct fuse_context`. May be overriden by the
+ *            field of `struct fuse_context`. May be overridden by the
  *            `struct fuse_operations.init` handler.
  * @return 0 on success, nonzero on failure
  *
@@ -869,7 +869,7 @@ void fuse_lib_help(struct fuse_args *args);
  * @param op the filesystem operations
  * @param op_size the size of the fuse_operations structure
  * @param private_data Initial value for the `private_data`
- *            field of `struct fuse_context`. May be overriden by the
+ *            field of `struct fuse_context`. May be overridden by the
  *            `struct fuse_operations.init` handler.
  * @return the created FUSE handle
  */
@@ -1171,7 +1171,7 @@ int fuse_notify_poll(struct fuse_pollhandle *ph);
  * @param op the filesystem operations
  * @param op_size the size of the fuse_operations structure
  * @param private_data Initial value for the `private_data`
- *            field of `struct fuse_context`. May be overriden by the
+ *            field of `struct fuse_context`. May be overridden by the
  *            `struct fuse_operations.init` handler.
  * @return a new filesystem object
  */

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -305,7 +305,7 @@ struct fuse_operations {
 	 * but libfuse and the kernel will still assign a different
 	 * inode for internal use (called the "nodeid").
 	 *
-	 * `fi` will always be NULL if the file is not currenly open, but
+	 * `fi` will always be NULL if the file is not currenlty open, but
 	 * may also be NULL if the file is open.
 	 */
 	int (*getattr) (const char *, struct stat *, struct fuse_file_info *fi);
@@ -361,14 +361,14 @@ struct fuse_operations {
 
 	/** Change the permission bits of a file
 	 *
-	 * `fi` will always be NULL if the file is not currenly open, but
+	 * `fi` will always be NULL if the file is not currenlty open, but
 	 * may also be NULL if the file is open.
 	 */
 	int (*chmod) (const char *, mode_t, struct fuse_file_info *fi);
 
 	/** Change the owner and group of a file
 	 *
-	 * `fi` will always be NULL if the file is not currenly open, but
+	 * `fi` will always be NULL if the file is not currenlty open, but
 	 * may also be NULL if the file is open.
 	 *
 	 * Unless FUSE_CAP_HANDLE_KILLPRIV is disabled, this method is
@@ -378,7 +378,7 @@ struct fuse_operations {
 
 	/** Change the size of a file
 	 *
-	 * `fi` will always be NULL if the file is not currenly open, but
+	 * `fi` will always be NULL if the file is not currenlty open, but
 	 * may also be NULL if the file is open.
 	 *
 	 * Unless FUSE_CAP_HANDLE_KILLPRIV is disabled, this method is
@@ -642,7 +642,7 @@ struct fuse_operations {
 	 * This supersedes the old utime() interface.  New applications
 	 * should use this.
 	 *
-	 * `fi` will always be NULL if the file is not currenly open, but
+	 * `fi` will always be NULL if the file is not currenlty open, but
 	 * may also be NULL if the file is open.
 	 *
 	 * See the utimensat(2) man page for details.

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -212,7 +212,7 @@ struct fuse_loop_config {
  *
  * This flag should always be set when available. If all file changes
  * go through the kernel, *attr_timeout* should be set to a very large
- * number to avoid unneccessary getattr() calls.
+ * number to avoid unnecessary getattr() calls.
  *
  * This feature is enabled by default when supported by the kernel.
  */

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -384,7 +384,7 @@ struct fuse_conn_info {
 	 * 4.8, only two types of requests fall into this category:
 	 *
 	 *   1. Read-ahead requests
-	 *   2. Asychronous direct I/O requests
+	 *   2. Asynchronous direct I/O requests
 	 *
 	 * Read-ahead requests are generated (if max_readahead is
 	 * non-zero) by the kernel to preemptively fill its caches

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1800,7 +1800,7 @@ int fuse_parse_cmdline(struct fuse_args *args,
  * and the function returns NULL.
  *
  * Option parsing skips argv[0], which is assumed to contain the
- * program name. To prevent accidentially passing an option in
+ * program name. To prevent accidentally passing an option in
  * argv[0], this element must always be present (even if no options
  * are specified). It may be set to the empty string ('\0') if no
  * reasonable value can be provided.

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1443,7 +1443,7 @@ size_t fuse_add_direntry(fuse_req_t req, char *buf, size_t bufsize,
 /**
  * Add a directory entry to the buffer with the attributes
  *
- * See documentation of `fuse_add_direntryt()` for more details.
+ * See documentation of `fuse_add_direntry()` for more details.
  *
  * @param req request handle
  * @param buf the point where the new entry will be added to the buffer

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1936,7 +1936,7 @@ static void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		se->op.init(se->userdata, &se->conn);
 
 	if (se->conn.want & (~se->conn.capable)) {
-		fprintf(stderr, "fuse: error: filesystem requested capabilites "
+		fprintf(stderr, "fuse: error: filesystem requested capabilities "
 			"0x%x that are not supported by kernel, aborting.\n",
 			se->conn.want & (~se->conn.capable));
 		fuse_reply_err(req, EPROTO);

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -260,7 +260,7 @@ int fuse_daemonize(int foreground)
 				close(nullfd);
 		}
 
-		/* Propagate completion of daemon initializatation */
+		/* Propagate completion of daemon initialization */
 		completed = 1;
 		(void) write(waiter[1], &completed, sizeof(completed));
 		close(waiter[0]);


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`