### PR TITLE
Adding possibility enforce a prefix

### DIFF
--- a/util/install_helper.sh
+++ b/util/install_helper.sh
@@ -14,16 +14,16 @@ prefix="${MESON_INSTALL_DESTDIR_PREFIX}"
 chown root:root "${prefix}/${bindir}/fusermount3"
 chmod u+s "${prefix}/${bindir}/fusermount3"
 
-if test ! -e "${DESTDIR}/dev/fuse"; then
-    mkdir -p "${DESTDIR}/dev"
-    mknod "${DESTDIR}/dev/fuse" -m 0666 c 10 229
+if test ! -e "${DESTDIR}/${FORCE_PREFIX}/dev/fuse"; then
+    mkdir -p "${DESTDIR}/${FORCE_PREFIX}/dev"
+    mknod "${DESTDIR}/${FORCE_PREFIX}/dev/fuse" -m 0666 c 10 229
 fi
 
 install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
-        "${DESTDIR}/${udevrulesdir}/99-fuse3.rules"
+        "${DESTDIR}/${FORCE_PREFIX}/${udevrulesdir}/99-fuse3.rules"
 
 install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
-        "${DESTDIR}/etc/init.d/fuse3"
+        "${DESTDIR}/${FORCE_PREFIX}/etc/init.d/fuse3"
 
 if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
     /usr/sbin/update-rc.d fuse3 start 34 S . start 41 0 6 . || /bin/true


### PR DESCRIPTION
In most scenarios, the script is installing to the default locations, where eg. device nodes or udev rules are normally placed. However, since I want to install libfuse to a prefix, which is built with user permissions, I don't have the permissions to place files there.
Therefore I added a new variable, which forces to place the files into a custom prefix.
Of course, there is also DESTDIR, but in my case I don't want to use it, because (if prefix == destdir) I would get `/my/custom/prefix/path/my/custom/prefix/path` as the location for all the other files.

Any other solutions and thoughts are welcome!