### PR TITLE
Fix uninitialised read in fuse_new_30() (#231)

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4842,6 +4842,9 @@ struct fuse *fuse_new_30(struct fuse_args *args,
 			 size_t op_size, void *user_data)
 {
 	struct fuse_config conf;
+
+	memset(&conf, 0, sizeof(conf));
+
 	const struct fuse_opt opts[] = {
 		FUSE_LIB_OPT("-h", show_help, 1),
 		FUSE_LIB_OPT("--help", show_help, 1),


### PR DESCRIPTION
Ensure that conf is always zero before it's read from to prevent
sporadic failure at startup if higher layers were build against
version 3.0