### PR TITLE
Fix build error on DragonFlyBSD (sync with other *BSD)

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,4 +1,4 @@
-if not platform.endswith('bsd')
+if not platform.endswith('bsd') and platform != 'dragonfly'
   install_man('fusermount3.1', 'mount.fuse.8')
 endif
 

--- a/example/meson.build
+++ b/example/meson.build
@@ -3,7 +3,7 @@ examples = [ 'passthrough', 'passthrough_fh',
              'ioctl_client', 'poll_client', 'ioctl',
              'cuse', 'cuse_client' ]
 
-if not platform.endswith('bsd')
+if not platform.endswith('bsd') and platform != 'dragonfly'
     examples += 'passthrough_ll'
 
     # According to Conrad Meyer <cem@freebsd.org>, FreeBSD doesn't

--- a/meson.build
+++ b/meson.build
@@ -93,7 +93,7 @@ thread_dep = dependency('threads')
 # Read build files from sub-directories
 #
 subdirs = [ 'lib', 'include', 'example', 'doc', 'test' ]
-if not platform.endswith('bsd')
+if not platform.endswith('bsd') and platform != 'dragonfly'
   subdirs += 'util'
 endif
 foreach n : subdirs

--- a/test/util.py
+++ b/test/util.py
@@ -46,7 +46,7 @@ def wait_for_mount(mount_process, mnt_dir,
 def cleanup(mnt_dir):
     # Don't bother trying Valgrind if things already went wrong
 
-    if 'bsd' in sys.platform:
+    if 'bsd' in sys.platform or 'dragonfly' in sys.platform:
         cmd = [ 'umount', '-f', mnt_dir ]
     else:
         cmd = [pjoin(basename, 'util', 'fusermount3'),
@@ -56,7 +56,7 @@ def cleanup(mnt_dir):
 
 def umount(mount_process, mnt_dir):
 
-    if 'bsd' in sys.platform:
+    if 'bsd' in sys.platform or 'dragonfly' in sys.platform:
         cmdline = [ 'umount', mnt_dir ]
     else:
         # fusermount3 will be setuid root, so we can only trace it with
@@ -109,7 +109,7 @@ def fuse_test_marker():
 
     skip = lambda x: pytest.mark.skip(reason=x)
 
-    if 'bsd' in sys.platform:
+    if 'bsd' in sys.platform or 'dragonfly' in sys.platform:
         return pytest.mark.uses_fuse()
 
     with subprocess.Popen(['which', 'fusermount3'], stdout=subprocess.PIPE,


### PR DESCRIPTION
> Meson encountered an error in file util/meson.build, line 24, column 2:
> Native dependency 'udev' not found

DragonFlyBSD has no "bsd" in uname, so add 'dragonfly' to conditionals.
While here do the same for test/util.py.

-- e.g. uname(1) in DragonFlyBSD
[root@ ~]# uname
DragonFly
[root@ ~]# python -c "import sys; print(sys.platform)"
dragonfly5