### PR TITLE
fix for the building under CentOS 6

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -51,6 +51,16 @@
 #include <err.h>
 #include <inttypes.h>
 
+#ifndef AT_EMPTY_PATH
+# define AT_EMPTY_PATH 0x1000
+#endif
+#ifndef O_PATH
+# define O_PATH 010000000
+#endif
+#ifndef O_CLOEXEC
+# define O_CLOEXEC 02000000
+#endif
+
 /* We are re-using pointers to our `struct lo_inode` and `struct
    lo_dirp` elements as inodes. This means that we must be able to
    store uintptr_t values in a fuse_ino_t variable. The following


### PR DESCRIPTION
This fixes the following errors:
```
[root@ip-172-22-2-106 build]# scl enable rh-python36 -- ninja install
[1/30] Compiling C object 'example/passthrough_ll@exe/passthrough_ll.c.o'.
FAILED: example/passthrough_ll@exe/passthrough_ll.c.o
cc  -Iexample/passthrough_ll@exe -Iexample -I../example -I. -I../ -Ilib -I../lib -Iinclude -I../include -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -D_REENTRANT -DHAVE_CONFIG_H -Wall -Wextra -Wno-sign-compare -Wstrict-prototypes -Wmissing-declarations -Wwrite-strings -fno-strict-aliasing -Wno-unused-result -MD -MQ 'example/passthrough_ll@exe/passthrough_ll.c.o' -MF 'example/passthrough_ll@exe/passthrough_ll.c.o.d' -o 'example/passthrough_ll@exe/passthrough_ll.c.o' -c ../example/passthrough_ll.c
../example/passthrough_ll.c: In function ‘lo_getattr’:
../example/passthrough_ll.c:136: error: ‘AT_EMPTY_PATH’ undeclared (first use in this function)
../example/passthrough_ll.c:136: error: (Each undeclared identifier is reported only once
../example/passthrough_ll.c:136: error: for each function it appears in.)
../example/passthrough_ll.c: In function ‘lo_do_lookup’:
../example/passthrough_ll.c:166: error: ‘O_PATH’ undeclared (first use in this function)
../example/passthrough_ll.c:170: error: ‘AT_EMPTY_PATH’ undeclared (first use in this function)
../example/passthrough_ll.c: In function ‘main’:
../example/passthrough_ll.c:572: error: ‘O_PATH’ undeclared (first use in this function)
At top level:
cc1: warning: unrecognized command line option "-Wno-unused-result"
[2/30] Compiling C object 'example/null@exe/null.c.o'.
ninja: build stopped: subcommand failed.
```