### PR TITLE
Fix compile-time warnings on IGNORE_MTAB

### DIFF
--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -489,7 +489,7 @@ static int count_fuse_fs(void)
 
 
 #else /* IGNORE_MTAB */
-static int count_fuse_fs()
+static int count_fuse_fs(void)
 {
 	return 0;
 }
@@ -506,6 +506,7 @@ static int add_mount(const char *source, const char *mnt, const char *type,
 
 static int unmount_fuse(const char *mnt, int quiet, int lazy)
 {
+	(void) quiet;
 	return fuse_mnt_umount(progname, mnt, mnt, lazy);
 }
 #endif /* IGNORE_MTAB */


### PR DESCRIPTION
Silence below warnings which appear if IGNORE_MTAB is defined.

[59/64] Compiling C object 'util/fusermount3@exe/fusermount.c.o'.
../util/fusermount.c:493:12: warning: function declaration isn't a prototype [-Wstrict-prototypes]
 static int count_fuse_fs()
            ^~~~~~~~~~~~~
../util/fusermount.c: In function 'unmount_fuse':
../util/fusermount.c:508:46: warning: unused parameter 'quiet' [-Wunused-parameter]
 static int unmount_fuse(const char *mnt, int quiet, int lazy)
                                              ^~~~~