### PR TITLE
rename: perform user mode dir loop check when not done in kernel

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,8 @@
+libfuse 3.2.4
+=============
+
+* Fixed `rename` deadlock on FreeBSD.
+
 libfuse 3.2.3 (2018-05-11)
 ==========================
 


### PR DESCRIPTION
This PR resolves the issue discussed in #245; the PR is not needed in Linux but is needed on BSD which libfuse purports to [support](https://github.com/libfuse/libfuse#supported-platforms).

Linux performs the directory loop check (`rename("a", "a/b/c")` or `rename("a/b/c", "a")`, etc.) at the VFS layer [[link](https://github.com/torvalds/linux/blob/v4.16/fs/namei.c#L4579-L4587)]. Unfortunately other libfuse supported systems do not perform this check, which results in a hang in `get_path2` as explained [here](https://github.com/libfuse/libfuse/issues/245#issuecomment-387845131).

The PR resolves the issue by adding a directory loop check in user mode for those system that do not perform it in kernel mode. The PR also adds a directory loop test in `test_syscalls.c`.

The PR has been tested on the following systems:

- On Linux where the PR is **NOT** needed using `python3 -m pytest test/` and the small test program included at the end of this post.

- On OSXFUSE where the same patch applies against [osxfuse/fuse](https://github.com/osxfuse/fuse) and resolves the same issue (osxfuse/osxfuse#495).

- **NOTE**: this PR has not been tested against FreeBSD or other BSD's. @bnaylor I am requesting your help here.

For completeness here is the small test program I used for my cross-platform testing:

```C
#include <errno.h>
#include <fcntl.h>
#include <stdio.h>
#include <sys/stat.h>
#include <unistd.h>

void prename(const char *oldpath, const char *newpath, int expect_err)
{
    int err;

    err = -1 == rename(oldpath, newpath) ? errno : 0;
    if (err != expect_err)
        printf("rename(\"%s\", \"%s\") = %d (expect %d)\n", oldpath, newpath, err, expect_err);
    else
        printf("rename(\"%s\", \"%s\") = %d\n", oldpath, newpath, err);
}

int main()
{
    mkdir("a", 0700);
    prename("a", "a", 0);
    prename("a", "a/b", EINVAL);

    mkdir("a/b", 0700);
    mkdir("a/b/c", 0700);
    prename("a", "a/b/c", EINVAL);
    prename("a", "a/b/c/a", EINVAL);
    prename("a/b/c", "a", ENOTEMPTY);

    close(open("a/foo", O_CREAT));
    prename("a/foo", "a/bar", 0);
    prename("a/bar", "a/foo", 0);
    prename("a/foo", "a/b/bar", 0);
    prename("a/b/bar", "a/foo", 0);
    prename("a/foo", "a/b/c/bar", 0);
    prename("a/b/c/bar", "a/foo", 0);

    close(open("a/bar", O_CREAT));
    prename("a/foo", "a/bar", 0);
    unlink("a/bar");

    prename("a/b", "a/d", 0);
    prename("a/d", "a/b", 0);

    mkdir("a/d", 0700);
    prename("a/b", "a/d", 0);
    prename("a/d", "a/b", 0);

    mkdir("a/d", 0700);
    mkdir("a/d/e", 0700);
    prename("a/b", "a/d", ENOTEMPTY);
    rmdir("a/d/e");
    rmdir("a/d");

    rmdir("a/b/c");
    rmdir("a/b");
    rmdir("a");

    return 0;
}
```