### PR TITLE
fix documentation for opendir in fuse_operations

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -274,7 +274,7 @@ struct fuse_operations {
 	 * this method should check if opendir is permitted for this
 	 * directory. Optionally opendir may also return an arbitrary
 	 * filehandle in the fuse_file_info structure, which will be
-	 * passed to readdir, closedir and fsyncdir.
+	 * passed to readdir, releasedir and fsyncdir.
 	 *
 	 * Introduced in version 2.3
 	 */


### PR DESCRIPTION
the filehandle from opendir is passed to releasedir - there is no
closedir function in fuse_operations