### PR TITLE
fuse.h: fix typo (currenlty -> currently)

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -305,7 +305,7 @@ struct fuse_operations {
 	 * but libfuse and the kernel will still assign a different
 	 * inode for internal use (called the "nodeid").
 	 *
-	 * `fi` will always be NULL if the file is not currenlty open, but
+	 * `fi` will always be NULL if the file is not currently open, but
 	 * may also be NULL if the file is open.
 	 */
 	int (*getattr) (const char *, struct stat *, struct fuse_file_info *fi);


### PR DESCRIPTION
This just fixes a minor typo in the `fuse.h` documentation that I noticed when browsing the Doxygen pages.