### PR TITLE
Fix readdir() bug when a non-zero offset is specified in filler

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,9 @@ libfuse 3.2.5
 ==========================
 
 * Added a test of `seekdir` to test_syscalls.
+* Fixed `readdir` bug when non-zero offsets are given to filler and the
+  filesystem client, after reading a whole directory, re-reads it from a
+  non-zero offset e. g. by calling `seekdir` followed by `readdir`.
 
 libfuse 3.2.4 (2018-07-11)
 ==========================

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,8 @@
+libfuse 3.2.5
+==========================
+
+* Added a test of `seekdir` to test_syscalls.
+
 libfuse 3.2.4 (2018-07-11)
 ==========================
 


### PR DESCRIPTION
Hello,

The first commit adds a test of seekdir(), and the second fixes the bug that is exposed by the test.
I am not sure this is the best fix, but I tried to change as little as possible.

Another thing is that 2.9.x branch is also affected by the same bug. Would a similar fix be accepted there as well?