### PR TITLE
Add FAT to mountpoint file system whitelist

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,4 +1,5 @@
 * Allow fuse to be mounted into autofs folder hierarchy
+* Allow fuse to be mounted into FAT folder hierarchy
 
 libfuse 3.2.5 (2018-07-24)
 ==========================

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1030,6 +1030,7 @@ static int check_perm(const char **mntp, struct stat *stbuf, int *mountpoint_fd)
 		0x58465342 /* XFS_SB_MAGIC */,
 		0x2FC12FC1 /* ZFS_SUPER_MAGIC */,
 		0x00000187 /* AUTOFS */,
+		0x00004d44 /* FAT */,
 	};
 	for (i = 0; i < sizeof(f_type_whitelist)/sizeof(f_type_whitelist[0]); i++) {
 		if (f_type_whitelist[i] == fs_buf.f_type)


### PR DESCRIPTION
FAT needs to whitelisted as well.