### PR TITLE
passthrough_ll update

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -329,7 +329,7 @@ static void lo_lookup(fuse_req_t req, fuse_ino_t parent, const char *name)
 	if (lo_debug(req))
 		fprintf(stderr, "lo_lookup(parent=%" PRIu64 ", name=%s)\n",
 			parent, name);
-	
+
 	err = lo_do_lookup(req, parent, name, &e);
 	if (err)
 		fuse_reply_err(req, err);
@@ -730,7 +730,7 @@ static void lo_create(fuse_req_t req, fuse_ino_t parent, const char *name,
 	if (lo_debug(req))
 		fprintf(stderr, "lo_create(parent=%" PRIu64 ", name=%s)\n",
 			parent, name);
-			
+
 	fd = openat(lo_fd(req, parent), name,
 		    (fi->flags | O_CREAT) & ~O_NOFOLLOW, mode);
 	if (fd == -1)
@@ -758,8 +758,7 @@ static void lo_fsyncdir(fuse_req_t req, fuse_ino_t ino, int datasync,
 	fuse_reply_err(req, res == -1 ? errno : 0);
 }
 
-static void lo_open(fuse_req_t req, fuse_ino_t ino,
-		    struct fuse_file_info *fi)
+static void lo_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 {
 	int fd;
 	char buf[64];
@@ -853,7 +852,7 @@ static void lo_write_buf(fuse_req_t req, fuse_ino_t ino,
 	if (lo_debug(req))
 		fprintf(stderr, "lo_write(ino=%" PRIu64 ", size=%zd, off=%lu)\n",
 			ino, out_buf.buf[0].size, (unsigned long) off);
-	
+
 	res = fuse_buf_copy(&out_buf, in_buf, 0);
 	if(res < 0)
 		fuse_reply_err(req, -res);
@@ -953,7 +952,7 @@ int main(int argc, char *argv[])
 
 	if (fuse_opt_parse(&args, &lo, lo_opts, NULL)== -1)
 		return 1;
-	
+
 	lo.debug = opts.debug;
 	lo.root.refcount = 2;
 	if (lo.source) {

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -69,6 +69,7 @@ struct lo_inode {
 	struct lo_inode *next; /* protected by lo->mutex */
 	struct lo_inode *prev; /* protected by lo->mutex */
 	int fd;
+	bool is_symlink;
 	ino_t ino;
 	dev_t dev;
 	uint64_t refcount; /* protected by lo->mutex */
@@ -193,6 +194,7 @@ static int lo_do_lookup(fuse_req_t req, fuse_ino_t parent, const char *name,
 		if (!inode)
 			goto out_err;
 
+		inode->is_symlink = S_ISLNK(e->attr.st_mode);
 		inode->refcount = 1;
 		inode->fd = newfd;
 		inode->ino = e->attr.st_ino;
@@ -612,6 +614,7 @@ int main(int argc, char *argv[])
 	
 	lo.debug = opts.debug;
 	lo.root.refcount = 2;
+	lo.root.is_symlink = false;
 	lo.root.fd = open("/", O_PATH);
 	if (lo.root.fd == -1)
 		err(1, "open(\"/\", O_PATH)");

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -585,6 +585,9 @@ int main(int argc, char *argv[])
 	                      .writeback = 0 };
 	int ret = -1;
 
+	/* Don't mask creation mode, kernel already did that */
+	umask(0);
+
 	pthread_mutex_init(&lo.mutex, NULL);
 	lo.root.next = lo.root.prev = &lo.root;
 	lo.root.fd = -1;

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -702,9 +702,10 @@ static void lo_do_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
 			struct fuse_entry_param e;
 
 			if (is_dot_or_dotdot(name)) {
-				e.ino = 0;
-				e.attr.st_ino = d->entry->d_ino;
-				e.attr.st_mode = d->entry->d_type << 12;
+				e = (struct fuse_entry_param) {
+					.attr.st_ino = d->entry->d_ino,
+					.attr.st_mode = d->entry->d_type << 12,
+				};
 			} else {
 				err = lo_do_lookup(req, ino, name, &e);
 				if (err)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -65,53 +65,10 @@ def test_hello(tmpdir, name, options):
     else:
         umount(mount_process, mnt_dir)
 
-
 @pytest.mark.parametrize("writeback", (False, True))
+@pytest.mark.parametrize("name", ('passthrough', 'passthrough_fh', 'passthrough_ll'))
 @pytest.mark.parametrize("debug", (False, True))
-def test_passthrough_ll(tmpdir, writeback, debug, capfd):
-    
-    progname = pjoin(basename, 'example', 'passthrough_ll')
-    if not os.path.exists(progname):
-        pytest.skip('%s not built' % os.path.basename(progname))
-    
-    # Avoid false positives from libfuse debug messages
-    if debug:
-        capfd.register_output(r'^   unique: [0-9]+, error: -[0-9]+ .+$',
-                              count=0)
-
-    mnt_dir = str(tmpdir.mkdir('mnt'))
-    src_dir = str(tmpdir.mkdir('src'))
-
-    cmdline = base_cmdline + [ progname, '-f', mnt_dir ]
-    if debug:
-        cmdline.append('-d')
-
-    if writeback:
-        cmdline.append('-o')
-        cmdline.append('writeback')
-        
-    mount_process = subprocess.Popen(cmdline)
-    try:
-        wait_for_mount(mount_process, mnt_dir)
-        work_dir = mnt_dir + src_dir
-
-        tst_statvfs(work_dir)
-        tst_readdir(src_dir, work_dir)
-        tst_open_read(src_dir, work_dir)
-        tst_open_write(src_dir, work_dir)
-        tst_create(work_dir)
-        tst_passthrough(src_dir, work_dir)
-        tst_append(src_dir, work_dir)
-        tst_seek(src_dir, work_dir)
-    except:
-        cleanup(mnt_dir)
-        raise
-    else:
-        umount(mount_process, mnt_dir)
-
-@pytest.mark.parametrize("name", ('passthrough', 'passthrough_fh'))
-@pytest.mark.parametrize("debug", (False, True))
-def test_passthrough(tmpdir, name, debug, capfd):
+def test_passthrough(tmpdir, name, debug, capfd, writeback):
     
     # Avoid false positives from libfuse debug messages
     if debug:
@@ -130,6 +87,13 @@ def test_passthrough(tmpdir, name, debug, capfd):
                 '-f', mnt_dir ]
     if debug:
         cmdline.append('-d')
+
+    if writeback:
+        if name != 'passthrough_ll':
+            pytest.skip('example does not support writeback caching')
+        cmdline.append('-o')
+        cmdline.append('writeback')
+        
     mount_process = subprocess.Popen(cmdline)
     try:
         wait_for_mount(mount_process, mnt_dir)
@@ -157,9 +121,15 @@ def test_passthrough(tmpdir, name, debug, capfd):
         tst_truncate_path(work_dir)
         tst_truncate_fd(work_dir)
         tst_open_unlink(work_dir)
-        
-        subprocess.check_call([ os.path.join(basename, 'test', 'test_syscalls'),
-                                work_dir, ':' + src_dir ])
+
+        syscall_test_cmd = [ os.path.join(basename, 'test', 'test_syscalls'),
+                             work_dir, ':' + src_dir ]
+        if writeback:
+            # When writeback caching is enabled, kernel has to open files for
+            # reading even when userspace opens with O_WDONLY. This fails if the
+            # filesystem process doesn't have special permission.
+            syscall_test_cmd.append('-52')
+        subprocess.check_call(syscall_test_cmd)
     except:
         cleanup(mnt_dir)
         raise


### PR DESCRIPTION
This fixes a couple of bugs in the passthrough_ll example filesystem and adds support for lots of missing operations.  Options are added to configure a base path and to control caching.
