### PR TITLE
Make meson build scripts subprojects friendly

### DIFF
--- a/example/meson.build
+++ b/example/meson.build
@@ -20,17 +20,14 @@ threaded_examples = [ 'notify_inval_inode',
 
 foreach ex : examples
     executable(ex, ex + '.c',
-               include_directories: include_dirs,
-               link_with: [ libfuse ],
+               dependencies: [ libfuse_dep ],
                install: false)
 endforeach
 
 
 foreach ex : threaded_examples
     executable(ex, ex + '.c',
-               include_directories: include_dirs,
-               link_with: [ libfuse ],
-               dependencies: thread_dep,
+               dependencies: [ thread_dep, libfuse_dep ],
                install: false)
 endforeach
 

--- a/include/meson.build
+++ b/include/meson.build
@@ -2,4 +2,3 @@ libfuse_headers = [ 'fuse.h', 'fuse_common.h', 'fuse_lowlevel.h',
 	            'fuse_opt.h', 'cuse_lowlevel.h' ]
 
 install_headers(libfuse_headers, subdir: 'fuse3')
-

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -44,4 +44,6 @@ pkg.generate(libraries: [ libfuse, '-lpthread' ],
              name: 'fuse3',
              description: 'Filesystem in Userspace',
              subdirs: 'fuse3')
-             
+
+libfuse_dep = declare_dependency(include_directories: include_dirs,
+                                 link_with: libfuse, dependencies: deps)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libfuse3', 'c', version: '3.2.5',
-        meson_version: '>= 0.38',
+        meson_version: '>= 0.40.1',
         default_options: [ 'buildtype=debugoptimized' ])
 
 
@@ -63,9 +63,9 @@ configure_file(output: 'config.h',
 #
 # Compiler configuration
 #
-add_global_arguments('-D_REENTRANT', '-DHAVE_CONFIG_H', '-Wall', '-Wextra', '-Wno-sign-compare',
-                     '-Wstrict-prototypes', '-Wmissing-declarations', '-Wwrite-strings',
-                     '-fno-strict-aliasing', language: 'c')
+add_project_arguments('-D_REENTRANT', '-DHAVE_CONFIG_H', '-Wall', '-Wextra', '-Wno-sign-compare',
+                      '-Wstrict-prototypes', '-Wmissing-declarations', '-Wwrite-strings',
+                      '-fno-strict-aliasing', language: 'c')
 
 # Some (stupid) GCC versions warn about unused return values even when they are
 # casted to void. This makes -Wunused-result pretty useless, since there is no
@@ -80,7 +80,7 @@ int main(void) {
 }'''
 if not cc.compiles(code, args: [ '-O0', '-Werror=unused-result' ])
      message('Compiler warns about unused result even when casting to void')
-     add_global_arguments('-Wno-unused-result', language: 'c')
+     add_project_arguments('-Wno-unused-result', language: 'c')
 endif
 
 # '.' will refer to current build directory, which contains config.h


### PR DESCRIPTION
Multiple meson build scripts improvements including:
 * Bump meson requirement to 0.40.1 (0.40 already required)
 * Declare a dependency object for main library
 * Stop using add_global_arguments()
 * Various minor style fixes

The main interest for this is to be able to [wrap](http://mesonbuild.com/Wrap-dependency-system-manual.html) libfuse as a [meson subproject](http://mesonbuild.com/Subprojects.html).