### PR TITLE
Allow passing `/dev/fuse` file descriptor from parent process 

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -8,6 +8,10 @@ Unreleased Changes
 * The description of the FUSE_CAP_READDIRPLUS_AUTO flag has been
   improved.
 
+* Allow open `/dev/fuse` file descriptors to be passed via mountpoints of the
+  special format `/dev/fd/%u`. This allows mounting to be handled by the parent
+  so the FUSE filesystem process can run fully unprivileged.
+
 libfuse 3.2.6 (2018-08-31)
 ==========================
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -12,6 +12,11 @@ Unreleased Changes
   special format `/dev/fd/%u`. This allows mounting to be handled by the parent
   so the FUSE filesystem process can run fully unprivileged.
 
+* Add a `drop_privileges` option to mount.fuse3 which causes it to open
+  `/dev/fuse` and mount the file system itself, then run the FUSE file
+  filesystem fully unprivileged and unable to re-acquire privilege via setuid,
+  fscaps, etc.
+
 libfuse 3.2.6 (2018-08-31)
 ==========================
 

--- a/doc/mount.fuse3.8
+++ b/doc/mount.fuse3.8
@@ -199,6 +199,16 @@ inode numbers.
 .TP
 \fBmodules=M1[:M2...]\fP
 Add modules to the filesystem stack.  Modules are pushed in the order they are specified, with the original filesystem being on the bottom of the stack.
+
+.SS "\fBmount.fuse3\fP options:"
+These options are interpreted by \fBmount.fuse3\fP and are thus only available when mounting a file system via \fBmount.fuse3\fP (such as when mounting via the generic \fBmount\fP(1) command or \fI/etc/fstab\fP). Supported options are:
+.TP
+\fBsetuid=USER\fP
+Switch to \fBUSER\fP and its primary group before launching the FUSE file system process. mount.fuse3 must be run as root or with \fBCAP_SETUID\fP and \fBCAP_SETGID\fP for this to work.
+.TP
+\fBdrop_privileges\fP
+Perform setup of the FUSE file descriptor and mounting the file system before launching the FUSE file system process. \fBmount.fuse3\fP requires privilege to do so, i.e. must be run as root or at least with \fBCAP_SYS_ADMIN\fP and \fBCAP_SETPCAP\fP. It will launch the file system process fully unprivileged, i.e. without \fBcapabilities\fP(7) and \fBprctl\fP(2) flags set up such that privileges can't be reacquired (e.g. via setuid or fscaps binaries). This reduces risk in the event of the FUSE file system process getting compromised by malicious file system data.
+
 .SH FUSE MODULES (STACKING)
 Modules are filesystem stacking support to high level API. Filesystem modules can be built into libfuse or loaded from shared object
 .SS "iconv"

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -1219,6 +1219,16 @@ typedef struct fuse_fs *(*fuse_module_factory_t)(struct fuse_args *args,
 /** Get session from fuse object */
 struct fuse_session *fuse_get_session(struct fuse *f);
 
+/**
+ * Open a FUSE file descriptor and set up the mount for the given
+ * mountpoint and flags.
+ *
+ * @param mountpoint reference to the mount in the file system
+ * @param options mount options
+ * @return the FUSE file descriptor or -1 upon error
+ */
+int fuse_open_channel(const char *mountpoint, const char *options);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -148,6 +148,11 @@ FUSE_3.2 {
 		fuse_loop_mt_31;
 } FUSE_3.1;
 
+FUSE_3.3 {
+	global:
+		fuse_open_channel;
+} FUSE_3.2;
+
 # Local Variables:
 # indent-tabs-mode: t
 # End:

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -15,6 +15,7 @@
 #include "fuse_misc.h"
 #include "fuse_opt.h"
 #include "fuse_lowlevel.h"
+#include "mount_util.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -147,7 +148,11 @@ static int fuse_helper_opt_proc(void *data, const char *arg, int key,
 	switch (key) {
 	case FUSE_OPT_KEY_NONOPT:
 		if (!opts->mountpoint) {
-			char mountpoint[PATH_MAX];
+			if (fuse_mnt_parse_fuse_fd(arg) != -1) {
+				return fuse_opt_add_opt(&opts->mountpoint, arg);
+			}
+
+			char mountpoint[PATH_MAX] = "";
 			if (realpath(arg, mountpoint) == NULL) {
 				fprintf(stderr,
 					"fuse: bad mount point `%s': %s\n",

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -420,3 +420,21 @@ struct fuse_conn_info_opts* fuse_parse_conn_info_opts(struct fuse_args *args)
 	}
 	return opts;
 }
+
+int fuse_open_channel(const char *mountpoint, const char* options)
+{
+	struct mount_opts *opts = NULL;
+	int fd = -1;
+	const char *argv[] = { "", "-o", options };
+	int argc = sizeof(argv) / sizeof(argv[0]);
+	struct fuse_args args = FUSE_ARGS_INIT(argc, (char**) argv);
+
+	opts = parse_mount_opts(&args);
+	if (opts == NULL)
+		return -1;
+
+	fd = fuse_kern_mount(mountpoint, opts);
+	destroy_mount_opts(opts);
+
+	return fd;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -32,7 +32,7 @@ libfuse = library('fuse3', libfuse_sources, version: meson.project_version(),
                   soversion: '3', include_directories: include_dirs,
                   dependencies: deps, install: true,
                   link_depends: 'fuse_versionscript',
-                  c_args: [ '-DFUSE_USE_VERSION=32',
+                  c_args: [ '-DFUSE_USE_VERSION=33',
                             '-DFUSERMOUNT_DIR="@0@"'.format(fusermount_path) ],
                   link_args: ['-Wl,--version-script,' + meson.current_source_dir()
                               + '/fuse_versionscript' ])

--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -352,3 +352,16 @@ int fuse_mnt_check_fuseblk(void)
 	fclose(f);
 	return 0;
 }
+
+int fuse_mnt_parse_fuse_fd(const char *mountpoint)
+{
+	int fd = -1;
+	int len = 0;
+
+	if (sscanf(mountpoint, "/dev/fd/%u%n", &fd, &len) == 1 &&
+	    len == strlen(mountpoint)) {
+		return fd;
+	}
+
+	return -1;
+}

--- a/lib/mount_util.h
+++ b/lib/mount_util.h
@@ -15,3 +15,4 @@ int fuse_mnt_umount(const char *progname, const char *abs_mnt,
 		    const char *rel_mnt, int lazy);
 char *fuse_mnt_resolve_path(const char *progname, const char *orig);
 int fuse_mnt_check_fuseblk(void);
+int fuse_mnt_parse_fuse_fd(const char *mountpoint);

--- a/test/util.py
+++ b/test/util.py
@@ -7,6 +7,7 @@ import time
 from os.path import join as pjoin
 import sys
 import re
+import itertools
 
 basename = pjoin(os.path.dirname(__file__), '..')
 
@@ -138,6 +139,12 @@ def fuse_test_marker():
 
     return pytest.mark.uses_fuse()
 
+def powerset(iterable):
+  s = list(iterable)
+  return itertools.chain.from_iterable(
+      itertools.combinations(s, r) for r in range(len(s)+1))
+
+
 # Use valgrind if requested
 if os.environ.get('TEST_WITH_VALGRIND', 'no').lower().strip() \
    not in ('no', 'false', '0'):
@@ -147,6 +154,8 @@ else:
 
 # Try to use local fusermount3
 os.environ['PATH'] = '%s:%s' % (pjoin(basename, 'util'), os.environ['PATH'])
+# Put example binaries on PATH
+os.environ['PATH'] = '%s:%s' % (pjoin(basename, 'example'), os.environ['PATH'])
 
 try:
     (fuse_proto, fuse_caps) = test_printcap()

--- a/util/meson.build
+++ b/util/meson.build
@@ -6,10 +6,12 @@ executable('fusermount3', ['fusermount.c', '../lib/mount_util.c'],
            install_dir: get_option('bindir'),
            c_args: '-DFUSE_CONF="@0@"'.format(fuseconf_path))
 
-executable('mount.fuse3', ['mount.fuse.c'], 
+executable('mount.fuse3', ['mount.fuse.c'],
            include_directories: include_dirs,
+           link_with: [ libfuse ],
            install: true,
-           install_dir: get_option('sbindir'))
+           install_dir: get_option('sbindir'),
+           c_args: '-DFUSE_USE_VERSION=33')
 
 
 udevrulesdir = get_option('udevrulesdir')


### PR DESCRIPTION
This adds a new "pre-mounted" mode of operation in which the FUSE file
system helper is launched after the /dev/fuse file descriptor has been
opened opened and the file system been mounted by a suitably
privileged process.

Pre-mounted mode is requested by passing an empty string as
mountpoint, which reflects the fact that the FUSE helper doesn't
actually perform or trigger any mounting itself.

The main benefit of pre-mounted mode is that no privileged operations
need to be performed by the file system implementation itself directly
or indirectly, so the FUSE process can run with zero privilege.
Moreover, mechanisms like securebits and no_new_privs can be used to
prevent subprocesses from re-acquiring privilege, which further helps
reduce risk for the case the FUSE helper gets exploited by a malicious
file system.

Below is an example that illustrates this. Note that I'm using shell
for presentation purposes, the assumption is that there's a privileged
daemon that handles mounting and spawning the FUSE helper in a
suitable sandbox.

  # Make binaries and libs executable by anyone
  $ chmod o+rx build/lib/libfuse3.so* example/hello
  $ export LD_LIBRARY_PATH=$PWD/build/lib

  # example/hello can mount successfully with privilege
  $ sudo sh -c "LD_LIBRARY_PATH=build/lib ./example/hello /mnt/tmp"
  $ sudo cat /mnt/tmp/hello
  Hello World!
  $ sudo umount /mnt/tmp

  # example/hello fails to mount without privilege
  $ sudo capsh --drop=all --secbits=0x3f -- -c 'LD_LIBRARY_PATH=build/lib ./example/hello -f /mnt/tmp'
  fusermount3: mount failed: Operation not permitted

  # Pre-mounting allows example/hello to work without privilege
  $ sudo sh -c '
    exec 0<>/dev/fuse
    mount -i -o nodev,nosuid,noexec,fd=0,rootmode=40000,user_id=0,group_id=0 -t fuse hello /mnt/tmp
    capsh --drop=all --secbits=0x3f -- -c "LD_LIBRARY_PATH=build/lib example/hello -f \"\""
  ' &
  [1] 55491
  $ sudo cat /mnt/tmp/hello
  Hello World!
  $ sudo umount /mnt/tmp
  [1]+  Done                    sudo sh -c '
    exec 0<>/dev/fuse
    mount -i -o nodev,nosuid,noexec,fd=0,rootmode=40000,user_id=0,group_id=0 -t fuse hello /mnt/tmp
    capsh --drop=all --secbits=0x3f -- -c "LD_LIBRARY_PATH=build/lib example/hello -f \"\""
  '