### PR TITLE
Add build options for utils and examples

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -92,10 +92,15 @@ thread_dep = dependency('threads')
 #
 # Read build files from sub-directories
 #
-subdirs = [ 'lib', 'include', 'example', 'doc', 'test' ]
-if not platform.endswith('bsd') and platform != 'dragonfly'
-  subdirs += 'util'
+subdirs = [ 'lib', 'include', 'test' ]
+if get_option('utils') and not platform.endswith('bsd') and platform != 'dragonfly'
+  subdirs += [ 'util', 'doc' ]
 endif
+
+if get_option('examples')
+  subdirs += 'example'
+endif
+
 foreach n : subdirs
     subdir(n)
 endforeach

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,3 +3,9 @@ option('disable-mtab', type : 'boolean', value : false,
 
 option('udevrulesdir', type : 'string', value : '',
        description: 'Where to install udev rules (if empty, query pkg-config(1))')
+
+option('utils', type : 'boolean', value : true,
+       description: 'Wheter or not to build and install helper programs')
+
+option('examples', type : 'boolean', value : true,
+       description: 'Wheter or not to build example programs')


### PR DESCRIPTION
Allow skipping utils build & installation (-Dutils=false) and examples
build (-Dexamples=false). By default behaviour is unchanged (both are
true: utils and examples get build).