### PR TITLE
* Fixed ninja test / meson test when libfuse is a subproject

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -19,6 +19,12 @@ td += custom_target('test_scripts', input: test_scripts,
                                 '@INPUT@', meson.current_build_dir() ])
 
 # Provide something helpful when running 'ninja test'
-wrong_cmd = executable('wrong_command', 'wrong_command.c',
-                       install: false)
-test('wrong_cmd', wrong_cmd)
+
+if meson.is_subproject()
+	test('libfuse is a subproject, skipping tests', executable('wrong_command',
+                      'wrong_command.c', install: false,
+                       c_args: [ '-DMESON_IS_SUBPROJECT' ]))
+else
+	test('wrong_command', executable('wrong_command', 'wrong_command.c',
+                      install: false))
+endif

--- a/test/wrong_command.c
+++ b/test/wrong_command.c
@@ -1,9 +1,16 @@
 #include <stdio.h>
 
 int main(void) {
+#ifdef MESON_IS_SUBPROJECT
+	fprintf(stderr, "libfuse tests were skipped because it's a meson subproject.\n"
+			"If you wish to run them try:\n"
+			"'cd <srcdir>/subprojects/libfuse && meson . build && cd build && python3 -m pytest test/' instead");
+	return 77; /* report as a skipped test */
+#else
 	fprintf(stderr, "\x1B[31m\e[1m"
 		"This is not the command you are looking for.\n"
 		"You probably want to run 'python3 -m pytest test/' instead"
 		"\e[0m\n");
 	return 1;
+#endif
 }


### PR DESCRIPTION
Modified test/meson.build and test/wrong_command.c to report a
skip to remove clutter from parent project running meson test harness.