### PR TITLE
Avoid using MESON_SOURCE_ROOT in install script

### DIFF
--- a/util/install_helper.sh
+++ b/util/install_helper.sh
@@ -6,9 +6,10 @@
 
 set -e
 
-sysconfdir="$1"
-bindir="$2"
-udevrulesdir="$3"
+utildir="$1"
+sysconfdir="$2"
+bindir="$3"
+udevrulesdir="$4"
 
 # Both sysconfdir and bindir are absolute paths (since they are joined
 # with --prefix in meson.build), but need to be interpreted relative
@@ -25,7 +26,7 @@ fi
 chown root:root "${DESTDIR}${bindir}/fusermount3"
 chmod u+s "${DESTDIR}${bindir}/fusermount3"
 
-install -D -m 644 "${MESON_SOURCE_ROOT}/util/fuse.conf" \
+install -D -m 644 "${utildir}/fuse.conf" \
 	"${DESTDIR}${sysconfdir}/fuse.conf"
 
 
@@ -34,10 +35,10 @@ if test ! -e "${DESTDIR}/dev/fuse"; then
     mknod "${DESTDIR}/dev/fuse" -m 0666 c 10 229
 fi
 
-install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
+install -D -m 644 "${utildir}/udev.rules" \
         "${DESTDIR}${udevrulesdir}/99-fuse3.rules"
 
-install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
+install -D -m 755 "${utildir}/init_script" \
         "${DESTDIR}${sysconfdir}/init.d/fuse3"
 
 
@@ -47,5 +48,4 @@ else
     echo "== FURTHER ACTION REQUIRED =="
     echo "Make sure that your init system will start the ${sysconfdir}/init.d/fuse3 init script"
 fi
-
 

--- a/util/meson.build
+++ b/util/meson.build
@@ -21,6 +21,7 @@ if udevrulesdir == ''
 endif
 
 meson.add_install_script('install_helper.sh',
+                         meson.current_source_dir(),
                          join_paths(get_option('prefix'), get_option('sysconfdir')),
                          join_paths(get_option('prefix'), get_option('bindir')),
                          udevrulesdir)


### PR DESCRIPTION
When libfuse is used as a meson subproject, `MESON_SOURCE_ROOT` is set to
the parent package source directory in install script environment, thus
breaking source file references. There doesn't seem to be a preferred
way of accessing the current project's source directory from such a script
at the moment [1]. This patch works around this by passing the current
project source directory as an argument of the script.

[1] https://github.com/mesonbuild/meson/issues/4399