### PR TITLE
fix memory leak in print_module_help method

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4645,6 +4645,7 @@ static void print_module_help(const char *name,
 		return;
 	printf("\nOptions for %s module:\n", name);
 	(*fac)(&a, NULL);
+	fuse_opt_free_args(&a);
 }
 
 void fuse_lib_help(struct fuse_args *args)


### PR DESCRIPTION
The members of the fuse_args struct are never freed, so there is a small memory leak.