### PR TITLE
fuse_lowlevel: validate path components

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -3525,12 +3525,6 @@ static int fill_dir(void *dh_, const char *name, const struct stat *statp,
 	return 0;
 }
 
-static int is_dot_or_dotdot(const char *name)
-{
-	return name[0] == '.' && (name[1] == '\0' ||
-				  (name[1] == '.' && name[2] == '\0'));
-}
-
 static int fill_dir_plus(void *dh_, const char *name, const struct stat *statp,
 			 off_t off, enum fuse_fill_dir_flags flags)
 {

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -131,3 +131,8 @@ struct fuse *fuse_new_31(struct fuse_args *args, const struct fuse_operations *o
 int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config *config);
 int fuse_session_loop_mt_32(struct fuse_session *se, struct fuse_loop_config *config);
 
+static inline int is_dot_or_dotdot(const char *name)
+{
+	return name[0] == '.' && (name[1] == '\0' ||
+				  (name[1] == '.' && name[2] == '\0'));
+}


### PR DESCRIPTION
Several FUSE requests contain single path components.  A correct FUSE
client sends well-formed path components but there is currently no input
validation in fuse_lowlevel.c in case something went wrong.

File system implementations might accidentally treat invalid inputs as
absolute/relative paths instead of rejecting them.  Save implementations
from duplicating input validation by handling it in fuse_lowlevel.c.

Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>