### PR TITLE
add option to disable symbol versioning

### DIFF
--- a/lib/fuse_misc.h
+++ b/lib/fuse_misc.h
@@ -13,7 +13,7 @@
     - confuse the dynamic linker in uClibc
     - not supported on MacOSX (in MachO binary format)
 */
-#if (!defined(__UCLIBC__) && !defined(__APPLE__))
+#if (!defined(__UCLIBC__) && !defined(__APPLE__)) && !defined(DISABLE_SYMVER)
 #define FUSE_SYMVER(x) __asm__(x)
 #else
 #define FUSE_SYMVER(x)

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -28,12 +28,18 @@ else
 endif
 
 fusermount_path = join_paths(get_option('prefix'), get_option('bindir'))
+c_args = [ '-DFUSE_USE_VERSION=34',
+           '-DFUSERMOUNT_DIR="@0@"'.format(fusermount_path) ]
+
+if get_option('disable-symver')
+  c_args += [ '-DDISABLE_SYMVER' ]
+endif
+
 libfuse = library('fuse3', libfuse_sources, version: meson.project_version(),
                   soversion: '3', include_directories: include_dirs,
                   dependencies: deps, install: true,
                   link_depends: 'fuse_versionscript',
-                  c_args: [ '-DFUSE_USE_VERSION=34',
-                            '-DFUSERMOUNT_DIR="@0@"'.format(fusermount_path) ],
+                  c_args: c_args,
                   link_args: ['-Wl,--version-script,' + meson.current_source_dir()
                               + '/fuse_versionscript' ])
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,9 @@
 option('disable-mtab', type : 'boolean', value : false,
        description: 'Disable and ignore usage of /etc/mtab')
 
+option('disable-symver', type : 'boolean', value : false,
+       description: 'Disable symvers')
+
 option('udevrulesdir', type : 'string', value : '',
        description: 'Where to install udev rules (if empty, query pkg-config(1))')
 


### PR DESCRIPTION
I found that when building libfuse as a static library (`meson configure --default-library static`), I invariably hit errors like this when trying to use it:

```
libtool: link:  gcc -shared  -fPIC -DPIC  .libs/projfs.o .libs/projfs_vfsapi.o   -lfuse3 -ldl -lpthread  -g -O2   -Wl,-soname -Wl,libprojfs.so.0 -Wl,-version-script -Wl,.libs/libprojfs.ver -o .libs/libprojfs.so.0.0.0
/usr/bin/ld: .libs/libprojfs.so.0.0.0: version node not found for symbol fuse_loop_mt@@FUSE_3.2
/usr/bin/ld: failed to set dynamic section sizes: Bad value
collect2: error: ld returned 1 exit status
```

This is without adjusting the calling code at all. Indeed, even if I drop all calls to `fuse_loop_mt` in the calling code, this still happens, so I guess some versioning weirdness left inside `libfuse.a` is producing this when linking.

Disabling symbol versioning with the option in this PR gets things moving, though I have to a) not build examples, as `invalidate_path` won't build like this (undefined reference to `fuse_new`), and b) use names like `fuse_new_31` and `fuse_loop_mt_32` in the calling code.

I'm probably missing something big re: symbol versioning and static linkage, but it's all pretty new to me. I'm submitting this PR _in case_ it might be something useful to have anyway. Feel free to close quickly if you don't care for it.