### PR TITLE
Fix libfuse3.so.3.4.1 build fail, when modules/iconv.c is built

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -9,11 +9,14 @@ else
    libfuse_sources += [ 'mount_bsd.c' ]
 endif
 
+deps = [ thread_dep ]
+
 if cfg.get('HAVE_ICONV')
    libfuse_sources += [ 'modules/iconv.c' ]
+   libiconv = cc.find_library('iconv', required: true)
+   deps += [ libiconv ]
 endif
 
-deps = [ thread_dep ]
 libdl = cc.find_library('dl', required: false)
 if libdl.found()
    deps += [ libdl ]

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -10,7 +10,7 @@ else
 endif
 
 deps = [ thread_dep ]
-libiconv = cc.find_library('iconv', required: fale)
+libiconv = cc.find_library('iconv', required: false)
 
 if cfg.get('HAVE_ICONV') and libiconv.found()
    libfuse_sources += [ 'modules/iconv.c' ]

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -10,10 +10,10 @@ else
 endif
 
 deps = [ thread_dep ]
+libiconv = cc.find_library('iconv', required: fale)
 
-if cfg.get('HAVE_ICONV')
+if cfg.get('HAVE_ICONV') and libiconv.found()
    libfuse_sources += [ 'modules/iconv.c' ]
-   libiconv = cc.find_library('iconv', required: true)
    deps += [ libiconv ]
 endif
 


### PR DESCRIPTION
when modules/iconv.c is built, libiconv is required ,otherwise Link will fail. Such as :

FAILED: lib/libfuse3.so.3.4.1 
    -o lib/libfuse3.so.3.4.1 'lib/lib@@fuse3@sha/fuse.c.o' 'lib/lib@@fuse3@sha/fuse_loop.c.o' 'lib/lib@@fuse3@sha/fuse_loop_mt.c.o' 'lib/lib@@fuse3@sha/fuse_lowlevel.c.o' 'lib/lib@@fuse3@sha/f▽se_opt.c.o' 'lib/lib@@fuse3@sha/fuse_signals.c.o' 'lib/lib@@fuse3@sha/buffer.c.o' 'lib/lib@@fuse3@sha/cuse_lowlevel.c.o' 'lib/lib@@fuse3@sha/helper.c.o' 'lib/lib@@fuse3@sha/modules_subdir.c.o' 'lib/lib@@fuse3@sha/mount_util.c.o' 'lib/lib@@fuse3@sha/mount.c.o' 'lib/lib@@fuse3@sha/modules_iconv.c.o' -Wl,--no-undefined -Wl,--as-needed -shared -fPIC -Wl,--start-group -Wl,-soname,libfuse3.so.3 -Wl,--version-script,/root/fusermaste/libfuse-master/lib/fuse_versionscript -ldl -lrt -Wl,--end-group -pthread  
lib/lib@@fuse3@sha/modules_iconv.c.o: In function `iconv_new':
/root/fusermaste/libfuse-master/build/../lib/modules/iconv.c:679: undefined reference to `libiconv_open'
/root/fusermaste/libfuse-master/build/../lib/modules/iconv.c:685: undefined reference to `libiconv_open'
/root/fusermaste/libfuse-master/build/../lib/modules/iconv.c:704: undefined reference to `libiconv_close'
/root/fusermaste/libfuse-master/build/../lib/modules/iconv.c:706: undefined reference to `libiconv_close'
lib/lib@@fuse3@sha/modules_iconv.c.o: In function `iconv_convpath':
/root/fusermaste/libfuse-master/build/../lib/modules/iconv.c:68: undefined reference to `libiconv'
/root/fusermaste/libfuse-master/build/../lib/modules/iconv.c:96: undefined reference to `libiconv'
lib/lib@@fuse3@sha/modules_iconv.c.o: In function `iconv_destroy':
/root/fusermaste/libfuse-master/build/../lib/modules/iconv.c:571: undefined reference to `libiconv_close'
/root/fusermaste/libfuse-master/build/../lib/modules/iconv.c:572: undefined reference to `libiconv_close'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.