### PR TITLE
Bugfix: unmount FUSE filesystems reliably on NFS

### DIFF
--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -428,7 +428,9 @@ static int unmount_fuse_locked(const char *mnt, int quiet, int lazy)
 		return -1;
 	}
 
+	drop_privs();
 	res = chdir_to_parent(copy, &last);
+	restore_privs();
 	if (res == -1)
 		goto out;
 


### PR DESCRIPTION
When an NFS directory is reachable by the user, but not by root (e.g. squash_root is set and the intermediate directories are not world readable) it is possible to mount, but not unmount a FUSE filesystem.

The problem is that fusermount -u attempts to enter the parent directory as root when unmounting the filesystem. By changing the parent directory as the user, and only then switching to root, we can traverse the root-unreadable intermediate directories. This makes the FUSE unmount behavior symmetric with mount.

Fixes #376