### PR TITLE
Defined the (*ioctl)() commands as unsigned int

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -670,8 +670,11 @@ struct fuse_operations {
 	 *
 	 * If flags has FUSE_IOCTL_DIR then the fuse_file_info refers to a
 	 * directory file handle.
+	 *
+	 * Note : the unsigned long request submitted by the application
+	 * is truncated to 32 bits.
 	 */
-	int (*ioctl) (const char *, int cmd, void *arg,
+	int (*ioctl) (const char *, unsigned int cmd, void *arg,
 		      struct fuse_file_info *, unsigned int flags, void *data);
 
 	/**

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1006,9 +1006,12 @@ struct fuse_lowlevel_ops {
 	 * @param in_buf data fetched from the caller
 	 * @param in_bufsz number of fetched bytes
 	 * @param out_bufsz maximum size of output data
+	 *
+	 * Note : the unsigned long request submitted by the application
+	 * is truncated to 32 bits.
 	 */
-	void (*ioctl) (fuse_req_t req, fuse_ino_t ino, int cmd, void *arg,
-		       struct fuse_file_info *fi, unsigned flags,
+	void (*ioctl) (fuse_req_t req, fuse_ino_t ino, unsigned int cmd,
+		       void *arg, struct fuse_file_info *fi, unsigned flags,
 		       const void *in_buf, size_t in_bufsz, size_t out_bufsz);
 
 	/**


### PR DESCRIPTION
On Linux the ioctl() commands are requested as "unsigned long", but fuse
truncates them to 32 bits. Transmitting the commands to user space
file systems as "unsigned int" is a workaround for processing ioctl
commands which do not fit into a signed int.