### PR TITLE
Defined the (*ioctl)() commands as unsigned int (v2)

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,7 @@
+* Changed ioctl commands to "unsigned int" in order to support commands
+  which do not fit into a signed int. Commands issued by applications
+  are still truncated to 32 bits.
+
 libfuse 3.4.2 (2019-03-09)
 ==========================
 

--- a/example/ioctl.c
+++ b/example/ioctl.c
@@ -188,7 +188,7 @@ static int fioc_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	return 0;
 }
 
-static int fioc_ioctl(const char *path, int cmd, void *arg,
+static int fioc_ioctl(const char *path, unsigned int cmd, void *arg,
 		      struct fuse_file_info *fi, unsigned int flags, void *data)
 {
 	(void) arg;

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -670,8 +670,11 @@ struct fuse_operations {
 	 *
 	 * If flags has FUSE_IOCTL_DIR then the fuse_file_info refers to a
 	 * directory file handle.
+	 *
+	 * Note : the unsigned long request submitted by the application
+	 * is truncated to 32 bits.
 	 */
-	int (*ioctl) (const char *, int cmd, void *arg,
+	int (*ioctl) (const char *, unsigned int cmd, void *arg,
 		      struct fuse_file_info *, unsigned int flags, void *data);
 
 	/**
@@ -1175,8 +1178,9 @@ int fuse_fs_removexattr(struct fuse_fs *fs, const char *path,
 			const char *name);
 int fuse_fs_bmap(struct fuse_fs *fs, const char *path, size_t blocksize,
 		 uint64_t *idx);
-int fuse_fs_ioctl(struct fuse_fs *fs, const char *path, int cmd, void *arg,
-		  struct fuse_file_info *fi, unsigned int flags, void *data);
+int fuse_fs_ioctl(struct fuse_fs *fs, const char *path, unsigned int cmd,
+		  void *arg, struct fuse_file_info *fi, unsigned int flags,
+		  void *data);
 int fuse_fs_poll(struct fuse_fs *fs, const char *path,
 		 struct fuse_file_info *fi, struct fuse_pollhandle *ph,
 		 unsigned *reventsp);

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1006,9 +1006,12 @@ struct fuse_lowlevel_ops {
 	 * @param in_buf data fetched from the caller
 	 * @param in_bufsz number of fetched bytes
 	 * @param out_bufsz maximum size of output data
+	 *
+	 * Note : the unsigned long request submitted by the application
+	 * is truncated to 32 bits.
 	 */
-	void (*ioctl) (fuse_req_t req, fuse_ino_t ino, int cmd, void *arg,
-		       struct fuse_file_info *fi, unsigned flags,
+	void (*ioctl) (fuse_req_t req, fuse_ino_t ino, unsigned int cmd,
+		       void *arg, struct fuse_file_info *fi, unsigned flags,
 		       const void *in_buf, size_t in_bufsz, size_t out_bufsz);
 
 	/**

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -2304,8 +2304,9 @@ int fuse_fs_removexattr(struct fuse_fs *fs, const char *path, const char *name)
 	}
 }
 
-int fuse_fs_ioctl(struct fuse_fs *fs, const char *path, int cmd, void *arg,
-		  struct fuse_file_info *fi, unsigned int flags, void *data)
+int fuse_fs_ioctl(struct fuse_fs *fs, const char *path, unsigned int cmd,
+		  void *arg, struct fuse_file_info *fi, unsigned int flags,
+		  void *data)
 {
 	fuse_get_context()->private_data = fs->user_data;
 	if (fs->op.ioctl) {
@@ -4222,10 +4223,10 @@ static void fuse_lib_bmap(fuse_req_t req, fuse_ino_t ino, size_t blocksize,
 		reply_err(req, err);
 }
 
-static void fuse_lib_ioctl(fuse_req_t req, fuse_ino_t ino, int cmd, void *arg,
-			   struct fuse_file_info *llfi, unsigned int flags,
-			   const void *in_buf, size_t in_bufsz,
-			   size_t out_bufsz)
+static void fuse_lib_ioctl(fuse_req_t req, fuse_ino_t ino, unsigned int cmd,
+			   void *arg, struct fuse_file_info *llfi,
+			   unsigned int flags, const void *in_buf,
+			   size_t in_bufsz, size_t out_bufsz)
 {
 	struct fuse *f = req_fuse_prepare(req);
 	struct fuse_intr_data d;


### PR DESCRIPTION
On Linux the ioctl() commands are requested as "unsigned long", but fuse
truncates them to 32 bits. Transmitting the commands to user space 
file systems as "unsigned int" is a workaround for processing ioctl
commands which do not fit into a signed int.