### PR TITLE
RFC: max_pages support implementation

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,6 +4,12 @@ Unreleased Changes
 * Added a new example (passthrough_hp). The functionality is similar
   to passthrough_ll, but the implementation focuses on performance and
   correctness rather than simplicity.
+* Added support for fuse kernel feature `max_pages` which allows to increase
+  the maximum number of pages that can be used per request. This feature was
+  introduced in kernel 4.20. `max_pages` is set based on the value in
+  `max_write`. By default `max_write` will be 1MiB now for kernels that support
+  `max_pages`. If you want smaller buffers or writes you have to set
+  `max_write` manually.
 
 libfuse 3.5.0 (2019-04-16)
 ==========================

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -131,3 +131,9 @@ struct fuse *fuse_new_31(struct fuse_args *args, const struct fuse_operations *o
 int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config *config);
 int fuse_session_loop_mt_32(struct fuse_session *se, struct fuse_loop_config *config);
 
+#define FUSE_MAX_MAX_PAGES 256
+#define FUSE_DEFAULT_MAX_PAGES_PER_REQ 32
+
+/* room needed in buffer to accommodate header */
+#define FUSE_BUFFER_HEADER_SIZE 0x1000
+


### PR DESCRIPTION
Hi,

implementation for libfuse of the 4.20 max_pages feature. In this implementation I am coupling it to the max_write parameter. By default the max_pages will be at the maximum on kernels >= 4.20 and at 32 for < 4.20.

Best,
Markus