### PR TITLE
Whitelist smb2

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,8 @@
 * Changed ioctl commands to "unsigned int" in order to support commands
   which do not fit into a signed int. Commands issued by applications
   are still truncated to 32 bits.
+* Added SMB2 to whitelist (so users can now mount FUSE filesystems
+  on mountpoints within SMB 2.0 filesystems).
 
 libfuse 3.4.2 (2019-03-09)
 ==========================

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1012,27 +1012,28 @@ static int check_perm(const char **mntp, struct stat *stbuf, int *mountpoint_fd)
 	 * but got expanded as we found more filesystems that needed to be
 	 * overlayed. */
 	typeof(fs_buf.f_type) f_type_whitelist[] = {
-		0x5346414f /* OPENAFS_SUPER_MAGIC */,
 		0x61756673 /* AUFS_SUPER_MAGIC */,
 		0x00000187 /* AUTOFS_SUPER_MAGIC */,
 		0xCA451A4E /* BCACHEFS_STATFS_MAGIC */,
 		0x9123683E /* BTRFS_SUPER_MAGIC */,
 		0x00C36400 /* CEPH_SUPER_MAGIC */,
 		0xFF534D42 /* CIFS_MAGIC_NUMBER */,
-		0X00004D44 /* MSDOS_SUPER_MAGIC */,
 		0x0000F15F /* ECRYPTFS_SUPER_MAGIC */,
 		0x0000EF53 /* EXT[234]_SUPER_MAGIC */,
 		0xF2F52010 /* F2FS_SUPER_MAGIC */,
 		0x65735546 /* FUSE_SUPER_MAGIC */,
 		0x01161970 /* GFS2_MAGIC */,
 		0x47504653 /* GPFS_SUPER_MAGIC */,
-		0x3153464A /* JFS_SUPER_MAGIC */,
+		0x0000482b /* HFSPLUS_SUPER_MAGIC */,
 		0x000072B6 /* JFFS2_SUPER_MAGIC */,
+		0x3153464A /* JFS_SUPER_MAGIC */,
 		0x0BD00BD0 /* LL_SUPER_MAGIC */,
+		0X00004D44 /* MSDOS_SUPER_MAGIC */,
 		0x0000564C /* NCP_SUPER_MAGIC */,
 		0x00006969 /* NFS_SUPER_MAGIC */,
 		0x00003434 /* NILFS_SUPER_MAGIC */,
 		0x5346544E /* NTFS_SB_MAGIC */,
+		0x5346414f /* OPENAFS_SUPER_MAGIC */,
 		0x794C7630 /* OVERLAYFS_SUPER_MAGIC */,
 		0x52654973 /* REISERFS_SUPER_MAGIC */,
 		0xFE534D42 /* SMB2_SUPER_MAGIC */,
@@ -1041,7 +1042,6 @@ static int check_perm(const char **mntp, struct stat *stbuf, int *mountpoint_fd)
 		0x24051905 /* UBIFS_SUPER_MAGIC */,
 		0x58465342 /* XFS_SB_MAGIC */,
 		0x2FC12FC1 /* ZFS_SUPER_MAGIC */,
-		0x0000482b /* HFSPLUS_SUPER_MAGIC */,
 	};
 	for (i = 0; i < sizeof(f_type_whitelist)/sizeof(f_type_whitelist[0]); i++) {
 		if (f_type_whitelist[i] == fs_buf.f_type)

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1035,6 +1035,7 @@ static int check_perm(const char **mntp, struct stat *stbuf, int *mountpoint_fd)
 		0x5346544E /* NTFS_SB_MAGIC */,
 		0x794C7630 /* OVERLAYFS_SUPER_MAGIC */,
 		0x52654973 /* REISERFS_SUPER_MAGIC */,
+		0xFE534D42 /* SMB2_SUPER_MAGIC */,
 		0x73717368 /* SQUASHFS_MAGIC */,
 		0x01021994 /* TMPFS_MAGIC */,
 		0x24051905 /* UBIFS_SUPER_MAGIC */,


### PR DESCRIPTION
Whitelist SMB2 found on some NAS devices. We have CIFS whitelisted already, so let's allow next-gen CIFS as well.

Also I've sorted out allowed filesystems alphabetically.