### PR TITLE
Add fallocate and use it instead of posix_fallocate if possible

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -936,12 +936,19 @@ static void lo_fallocate(fuse_req_t req, fuse_ino_t ino, int mode,
 	int err;
 	(void) ino;
 
+#ifdef HAVE_FALLOCATE
+	err = fallocate(fi->fh, mode, offset, length);
+	if (err < 0)
+		err = errno;
+
+#elif HAVE_POSIX_FALLOCATE
 	if (mode) {
 		fuse_reply_err(req, EOPNOTSUPP);
 		return;
 	}
 
 	err = posix_fallocate(fi->fh, offset, length);
+#endif
 
 	fuse_reply_err(req, err);
 }

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ cfg.set_quoted('PACKAGE_VERSION', meson.project_version())
 # Test for presence of some functions
 test_funcs = [ 'fork', 'fstatat', 'openat', 'readlinkat', 'pipe2',
                'splice', 'vmsplice', 'posix_fallocate', 'fdatasync',
-               'utimensat', 'copy_file_range' ]
+               'utimensat', 'copy_file_range', 'fallocate' ]
 foreach func : test_funcs
     cfg.set('HAVE_' + func.to_upper(),
         cc.has_function(func, prefix: include_default, args: args_default))


### PR DESCRIPTION
fuse.ko has supported FALLOC_FL_KEEP_SIZE and FALLOC_FL_PUNCH_HOLE at this
moment and more modes may be supported in the future.

fallocate(2) supports modes while posix_fallocate(2) does not, so this
makes lo_fallocate use fallocate(2) instead.

Signed-off-by: Liu Bo <bo.liu@linux.alibaba.com>