### PR TITLE
Add CI for FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,10 @@
+# Build libfuse on FreeBSD, but don't run the tests.
+# More work is required to make the tests work.
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+  install_script: pkg install -y meson ninja
+  script:
+    - mkdir build
+    - cd build
+    - meson ..
+    - ninja

--- a/make_release_tarball.sh
+++ b/make_release_tarball.sh
@@ -22,7 +22,8 @@ mkdir "${TAG}"
 git archive --format=tar "${TAG}" | tar -x "--directory=${TAG}"
 find "${TAG}" -name .gitignore -delete
 rm "${TAG}/make_release_tarball.sh" \
-   "${TAG}/.travis.yml"
+   "${TAG}/.travis.yml" \
+   "${TAG}/.cirrus.yml"
 cp -a doc/html "${TAG}/doc/"
 tar -cJf "${TAG}.tar.xz" "${TAG}/"
 gpg --armor --detach-sign "${TAG}.tar.xz"


### PR DESCRIPTION
This commit adds builds for FreeBSD using cirrus-ci.  Running the tests
is TODO; they don't work on FreeBSD yet.

Fixes #403