### PR TITLE
Add support for specifying FUSE_MAX_PAGES at init time.

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -96,6 +96,7 @@ struct lo_data {
 	int cache;
 	int timeout_set;
 	struct lo_inode root; /* protected by lo->mutex */
+	int max_pages;
 };
 
 static const struct fuse_opt lo_opts[] = {
@@ -123,6 +124,8 @@ static const struct fuse_opt lo_opts[] = {
 	  offsetof(struct lo_data, cache), CACHE_NORMAL },
 	{ "cache=always",
 	  offsetof(struct lo_data, cache), CACHE_ALWAYS },
+	{ "max_pages=%d",
+	  offsetof(struct lo_data, max_pages), 0 },
 
 	FUSE_OPT_END
 };
@@ -168,6 +171,15 @@ static void lo_init(void *userdata,
 		if (lo->debug)
 			fprintf(stderr, "lo_init: activating flock locks\n");
 		conn->want |= FUSE_CAP_FLOCK_LOCKS;
+	}
+	if (lo->max_pages) {
+		if (conn->capable & FUSE_CAP_MAX_PAGES) {
+			conn->want |= FUSE_CAP_MAX_PAGES;
+			conn->max_pages = lo->max_pages;
+		} else {
+			fprintf(stderr, "lo_init: max_pages specified but not "
+				"supported, ignoring.\n");
+		}
 	}
 }
 

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -336,6 +336,17 @@ struct fuse_loop_config {
 #define FUSE_CAP_HANDLE_KILLPRIV         (1 << 20)
 
 /**
+ * Indicates that filesystem can specify the maximum transfer
+ * size.
+ *
+ * If this flags is set in conn.capable, the filesystem may
+ * set the max transfer size by (a) setting this flag in
+ * conn.want, and (b) setting the desired transfer size in
+ * conn.max_pages.
+ */
+#define FUSE_CAP_MAX_PAGES	       (1 << 22)
+
+/**
  * Indicates support for zero-message opendirs. If this flag is set in
  * the `capable` field of the `fuse_conn_info` structure, then the filesystem
  * may return `ENOSYS` from the opendir() handler to indicate success. Further
@@ -346,6 +357,7 @@ struct fuse_loop_config {
  * Setting (or unsetting) this flag in the `want` field has *no effect*.
  */
 #define FUSE_CAP_NO_OPENDIR_SUPPORT    (1 << 24)
+
 
 /**
  * Ioctl flags
@@ -477,9 +489,15 @@ struct fuse_conn_info {
 	unsigned time_gran;
 
 	/**
+	 * Maximum transfer size, in pages. Meaningful only if
+	 * FUSE_CAP_MAX_PAGES is set in .capable and .wanted.
+	 */
+	unsigned max_pages;
+
+	/**
 	 * For future use.
 	 */
-	unsigned reserved[22];
+	unsigned reserved[21];
 };
 
 struct fuse_session;
@@ -502,6 +520,7 @@ struct fuse_conn_info_opts;
  *   -o max_write=N         sets conn->max_write
  *   -o max_readahead=N     sets conn->max_readahead
  *   -o max_background=N    sets conn->max_background
+ *   -o max_pages=N	    sets conn->max_pages
  *   -o congestion_threshold=N  sets conn->congestion_threshold
  *   -o async_read          sets FUSE_CAP_ASYNC_READ in conn->want
  *   -o sync_read           unsets FUSE_CAP_ASYNC_READ in conn->want

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -83,6 +83,8 @@ struct fuse_conn_info_opts {
 	int set_max_background;
 	int set_congestion_threshold;
 	int set_time_gran;
+	int max_pages;
+	int set_max_pages;
 };
 
 #define CONN_OPTION(t, p, v)					\
@@ -90,6 +92,8 @@ struct fuse_conn_info_opts {
 static const struct fuse_opt conn_info_opt_spec[] = {
 	CONN_OPTION("max_write=%u", max_write, 0),
 	CONN_OPTION("max_write=", set_max_write, 1),
+	CONN_OPTION("max_pages=%u", max_pages, 0),
+	CONN_OPTION("max_pages=", set_max_pages, 1),
 	CONN_OPTION("max_readahead=%u", max_readahead, 0),
 	CONN_OPTION("max_readahead=", set_max_readahead, 1),
 	CONN_OPTION("max_background=%u", max_background, 0),
@@ -371,6 +375,10 @@ void fuse_apply_conn_info_opts(struct fuse_conn_info_opts *opts,
 		conn->time_gran = opts->time_gran;
 	if(opts->set_max_readahead)
 		conn->max_readahead = opts->max_readahead;
+	if(opts->set_max_pages) {
+		conn->max_pages = opts->max_pages;
+		conn->want |= FUSE_CAP_MAX_PAGES;
+	}
 
 #define LL_ENABLE(cond,cap) \
 	if (cond) conn->want |= (cap)


### PR DESCRIPTION
Support for max_pages is added to fuse_lowlevel.c. Example usage is added to passthrough_ll. A new "max_pages" mount option is added to fuse_parse_conn_info_opts().