### PR TITLE
Remove incorrect comment about fuse_entry_param.generation

### DIFF
--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -75,9 +75,6 @@ struct fuse_entry_param {
 	 * it must assign a new, previously unused generation number
 	 * to the inode at the same time.
 	 *
-	 * The generation must be non-zero, otherwise FUSE will treat
-	 * it as an error.
-	 *
 	 */
 	uint64_t generation;
 


### PR DESCRIPTION
A comment said that fuse_entry_param.generation must be non-zero.
However, I can't find anything in the kernel that requires that, and
real-world file systems don't seem to follow that advice, either.