### PR TITLE
Skip install parts that require root when not running as root

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,7 +5,11 @@ option('udevrulesdir', type : 'string', value : '',
        description: 'Where to install udev rules (if empty, query pkg-config(1))')
 
 option('utils', type : 'boolean', value : true,
-       description: 'Wheter or not to build and install helper programs')
+       description: 'Whether or not to build and install helper programs')
 
 option('examples', type : 'boolean', value : true,
-       description: 'Wheter or not to build example programs')
+       description: 'Whether or not to build example programs')
+
+option('no-root', type : 'boolean', value : false,
+       description: 'Install files without root permissions')
+

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,6 +10,6 @@ option('utils', type : 'boolean', value : true,
 option('examples', type : 'boolean', value : true,
        description: 'Whether or not to build example programs')
 
-option('no-root', type : 'boolean', value : false,
-       description: 'Install files without root permissions')
+option('useroot', type : 'boolean', value : true,
+       description: 'Set owner and setuid bits on installed file')
 

--- a/util/install_helper.sh
+++ b/util/install_helper.sh
@@ -22,16 +22,17 @@ else
     DESTDIR="${DESTDIR%/}"
 fi
 
-chown root:root "${DESTDIR}${bindir}/fusermount3"
-chmod u+s "${DESTDIR}${bindir}/fusermount3"
-
 install -D -m 644 "${MESON_SOURCE_ROOT}/util/fuse.conf" \
 	"${DESTDIR}${sysconfdir}/fuse.conf"
 
+if [ `id -u` = 0 ]; then
+    chown root:root "${DESTDIR}${bindir}/fusermount3"
+    chmod u+s "${DESTDIR}${bindir}/fusermount3"
 
-if test ! -e "${DESTDIR}/dev/fuse"; then
-    mkdir -p "${DESTDIR}/dev"
-    mknod "${DESTDIR}/dev/fuse" -m 0666 c 10 229
+    if test ! -e "${DESTDIR}/dev/fuse"; then
+        mkdir -p "${DESTDIR}/dev"
+        mknod "${DESTDIR}/dev/fuse" -m 0666 c 10 229
+    fi
 fi
 
 install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \

--- a/util/install_helper.sh
+++ b/util/install_helper.sh
@@ -9,6 +9,7 @@ set -e
 sysconfdir="$1"
 bindir="$2"
 udevrulesdir="$3"
+useroot="$4"
 
 # Both sysconfdir and bindir are absolute paths (since they are joined
 # with --prefix in meson.build), but need to be interpreted relative
@@ -25,7 +26,7 @@ fi
 install -D -m 644 "${MESON_SOURCE_ROOT}/util/fuse.conf" \
 	"${DESTDIR}${sysconfdir}/fuse.conf"
 
-if [ `id -u` = 0 ]; then
+if $useroot; then
     chown root:root "${DESTDIR}${bindir}/fusermount3"
     chmod u+s "${DESTDIR}${bindir}/fusermount3"
 

--- a/util/meson.build
+++ b/util/meson.build
@@ -20,9 +20,17 @@ if udevrulesdir == ''
   udevrulesdir = join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
 endif
 
+noroot = get_option('no-root')
+if noroot
+  useroot = 'false'
+else
+  useroot = 'true'
+endif
+
 meson.add_install_script('install_helper.sh',
                          join_paths(get_option('prefix'), get_option('sysconfdir')),
                          join_paths(get_option('prefix'), get_option('bindir')),
-                         udevrulesdir)
+                         udevrulesdir,
+                         useroot)
 
 

--- a/util/meson.build
+++ b/util/meson.build
@@ -20,17 +20,10 @@ if udevrulesdir == ''
   udevrulesdir = join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
 endif
 
-noroot = get_option('no-root')
-if noroot
-  useroot = 'false'
-else
-  useroot = 'true'
-endif
-
 meson.add_install_script('install_helper.sh',
                          join_paths(get_option('prefix'), get_option('sysconfdir')),
                          join_paths(get_option('prefix'), get_option('bindir')),
                          udevrulesdir,
-                         useroot)
+                         '@0@'.format(get_option('useroot')))
 
 


### PR DESCRIPTION
When running as non-root, for example when building a package, skip the parts of the install process that require root.

This takes the place of a patch that the Fedora build of fuse3 was applying.