### PR TITLE
Fix build with IGNORE_MTAB

### DIFF
--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -208,6 +208,7 @@ static int may_unmount(const char *mnt, int quiet)
 
 	return 0;
 }
+#endif
 
 /*
  * Check whether the file specified in "fusermount3 -u" is really a
@@ -395,6 +396,7 @@ static int chdir_to_parent(char *copy, const char **lastp)
 	return 0;
 }
 
+#ifndef IGNORE_MTAB
 /* Check whether the kernel supports UMOUNT_NOFOLLOW flag */
 static int umount_nofollow_support(void)
 {


### PR DESCRIPTION
`IGNORE_MTAB` doesn't seem to be a documented option, but it is referenced in `lib/mount.c`, `lib/mount_util.c`, and `util/fusermount.c`, though only defined in `lib/mount_util.c`.

However, I've been building with `-DIGNORE_MTAB` since my system has `/etc/mtab` as a symlink to `/proc/self/mounts`, and I don't want fuse to try to modify it.