### PR TITLE
[2.9 backport] Add support for stream-like files

### DIFF
--- a/example/fsel.c
+++ b/example/fsel.c
@@ -104,13 +104,14 @@ static int fsel_open(const char *path, struct fuse_file_info *fi)
 	fsel_open_mask |= (1 << idx);
 
 	/*
-	 * fsel files are nonseekable somewhat pipe-like files which
+	 * fsel files are nonseekable stream-like files similar to pipes which
 	 * gets filled up periodically by producer thread and consumed
 	 * on read.  Tell FUSE as such.
 	 */
 	fi->fh = idx;
 	fi->direct_io = 1;
 	fi->nonseekable = 1;
+	fi->stream = 1;
 
 	return 0;
 }

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -76,8 +76,14 @@ struct fuse_file_info {
 	   2.9 */
 	unsigned int flock_release : 1;
 
+	unsigned int : 1; /* cache_readdir on libfuse3 */
+
+	/** Can be filled in by open, to indicate that the file is
+	    stream-like (no file position at all). */
+	unsigned int stream : 1;
+
 	/** Padding.  Do not use*/
-	unsigned int padding : 27;
+	unsigned int padding : 25;
 
 	/** File handle.  May be filled in by filesystem in open().
 	    Available in all other file operations */

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -186,10 +186,12 @@ struct fuse_file_lock {
  * FOPEN_DIRECT_IO: bypass page cache for this open file
  * FOPEN_KEEP_CACHE: don't invalidate the data cache on open
  * FOPEN_NONSEEKABLE: the file is not seekable
+ * FOPEN_STREAM: the file is stream-like (no file position at all)
  */
 #define FOPEN_DIRECT_IO		(1 << 0)
 #define FOPEN_KEEP_CACHE	(1 << 1)
 #define FOPEN_NONSEEKABLE	(1 << 2)
+#define FOPEN_STREAM		(1 << 4)
 
 /**
  * INIT request/reply flags

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -352,6 +352,8 @@ static void fill_open(struct fuse_open_out *arg,
 		arg->open_flags |= FOPEN_KEEP_CACHE;
 	if (f->nonseekable)
 		arg->open_flags |= FOPEN_NONSEEKABLE;
+	if (f->stream)
+		arg->open_flags |= FOPEN_STREAM;
 }
 
 int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param *e)


### PR DESCRIPTION
This is 2.9 backport of https://github.com/libfuse/libfuse/pull/434.
Please see details in that PR and in the second patch in hereby series.

Thanks beforehand,
Kirill

/cc @Nikratio, @szmi 