### PR TITLE
Avoid gcc 9.1 strncpy(3) warnings

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -965,7 +965,7 @@ static char *add_name(char **buf, unsigned *bufsize, char *s, const char *name)
 		*bufsize = newbufsize;
 	}
 	s -= len;
-	strncpy(s, name, len);
+	memcpy(s, name, len);
 	s--;
 	*s = '/';
 

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -285,7 +285,7 @@ size_t fuse_add_direntry(fuse_req_t req, char *buf, size_t bufsize,
 	dirent->off = off;
 	dirent->namelen = namelen;
 	dirent->type = (stbuf->st_mode & S_IFMT) >> 12;
-	strncpy(dirent->name, name, namelen);
+	memcpy(dirent->name, name, namelen);
 	memset(dirent->name + namelen, 0, entlen_padded - entlen);
 
 	return entlen_padded;
@@ -378,7 +378,7 @@ size_t fuse_add_direntry_plus(fuse_req_t req, char *buf, size_t bufsize,
 	dirent->off = off;
 	dirent->namelen = namelen;
 	dirent->type = (e->attr.st_mode & S_IFMT) >> 12;
-	strncpy(dirent->name, name, namelen);
+	memcpy(dirent->name, name, namelen);
 	memset(dirent->name + namelen, 0, entlen_padded - entlen);
 
 	return entlen_padded;

--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -1757,7 +1757,8 @@ static int test_socket(void)
 		return -1;
 	}
 	su.sun_family = AF_UNIX;
-	strncpy(su.sun_path, testsock, sizeof(su.sun_path));
+	strncpy(su.sun_path, testsock, sizeof(su.sun_path) - 1);
+	su.sun_path[sizeof(su.sun_path) - 1] = '\0';
 	res = bind(fd, (struct sockaddr*)&su, sizeof(su));
 	if (res == -1) {
 		PERROR("bind");


### PR DESCRIPTION
Recent GCC releases have warnings related to common strncpy(3) bugs.
These warnings can be avoided by explicitly NUL-terminating the buffer
or using memcpy(3) when the intention is to copy just the characters
without the NUL terminator.

This commit fixes the following warnings:

  [1/27] Compiling C object 'test/9f86d08@@test_syscalls@exe/test_syscalls.c.o'.
  In function ‘test_socket’,
      inlined from ‘main’ at ../test/test_syscalls.c:1899:9:
  ../test/test_syscalls.c:1760:2: warning: ‘strncpy’ output may be truncated copying 108 bytes from a string of length 1023 [-Wstringop-truncation]
   1760 |  strncpy(su.sun_path, testsock, sizeof(su.sun_path));
        |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  [2/27] Compiling C object 'lib/76b5a35@@fuse3@sha/fuse.c.o'.
  ../lib/fuse.c: In function ‘add_name’:
  ../lib/fuse.c:968:2: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
    968 |  strncpy(s, name, len);
        |  ^~~~~~~~~~~~~~~~~~~~~
  ../lib/fuse.c:944:15: note: length computed here
    944 |  size_t len = strlen(name);
        |               ^~~~~~~~~~~~
  [3/27] Compiling C object 'lib/76b5a35@@fuse3@sha/fuse_lowlevel.c.o'.
  ../lib/fuse_lowlevel.c: In function ‘fuse_add_direntry’:
  ../lib/fuse_lowlevel.c:288:2: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
    288 |  strncpy(dirent->name, name, namelen);
        |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../lib/fuse_lowlevel.c:276:12: note: length computed here
    276 |  namelen = strlen(name);
        |            ^~~~~~~~~~~~
  ../lib/fuse_lowlevel.c: In function ‘fuse_add_direntry_plus’:
  ../lib/fuse_lowlevel.c:381:2: warning: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
    381 |  strncpy(dirent->name, name, namelen);
        |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../lib/fuse_lowlevel.c:366:12: note: length computed here
    366 |  namelen = strlen(name);
        |            ^~~~~~~~~~~~

Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>