### PR TITLE
fuse_types.h: rename standard types

### DIFF
--- a/example/cuse.c
+++ b/example/cuse.c
@@ -92,7 +92,7 @@ static void cusexmp_open(fuse_req_t req, struct fuse_file_info *fi)
 	fuse_reply_open(req, fi);
 }
 
-static void cusexmp_read(fuse_req_t req, size_t size, off_t off,
+static void cusexmp_read(fuse_req_t req, size_t size, fuse_off_t off,
 			 struct fuse_file_info *fi)
 {
 	(void)fi;
@@ -106,7 +106,7 @@ static void cusexmp_read(fuse_req_t req, size_t size, off_t off,
 }
 
 static void cusexmp_write(fuse_req_t req, const char *buf, size_t size,
-			  off_t off, struct fuse_file_info *fi)
+			  fuse_off_t off, struct fuse_file_info *fi)
 {
 	(void)fi;
 
@@ -123,7 +123,7 @@ static void fioc_do_rw(fuse_req_t req, void *addr, const void *in_buf,
 		       size_t in_bufsz, size_t out_bufsz, int is_read)
 {
 	const struct fioc_rw_arg *arg;
-	struct iovec in_iov[2], out_iov[3], iov[3];
+	struct fuse_iovec in_iov[2], out_iov[3], iov[3];
 	size_t cur_size;
 
 	/* read in arg */
@@ -210,7 +210,7 @@ static void cusexmp_ioctl(fuse_req_t req, int cmd, void *arg,
 	switch (cmd) {
 	case FIOC_GET_SIZE:
 		if (!out_bufsz) {
-			struct iovec iov = { arg, sizeof(size_t) };
+			struct fuse_iovec iov = { arg, sizeof(size_t) };
 
 			fuse_reply_ioctl_retry(req, NULL, 0, &iov, 1);
 		} else
@@ -220,7 +220,7 @@ static void cusexmp_ioctl(fuse_req_t req, int cmd, void *arg,
 
 	case FIOC_SET_SIZE:
 		if (!in_bufsz) {
-			struct iovec iov = { arg, sizeof(size_t) };
+			struct fuse_iovec iov = { arg, sizeof(size_t) };
 
 			fuse_reply_ioctl_retry(req, &iov, 1, NULL, 0);
 		} else {

--- a/example/hello.c
+++ b/example/hello.c
@@ -60,13 +60,13 @@ static void *hello_init(struct fuse_conn_info *conn,
 	return NULL;
 }
 
-static int hello_getattr(const char *path, struct stat *stbuf,
+static int hello_getattr(const char *path, struct fuse_stat *stbuf,
 			 struct fuse_file_info *fi)
 {
 	(void) fi;
 	int res = 0;
 
-	memset(stbuf, 0, sizeof(struct stat));
+	memset(stbuf, 0, sizeof(struct fuse_stat));
 	if (strcmp(path, "/") == 0) {
 		stbuf->st_mode = S_IFDIR | 0755;
 		stbuf->st_nlink = 2;
@@ -81,7 +81,7 @@ static int hello_getattr(const char *path, struct stat *stbuf,
 }
 
 static int hello_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-			 off_t offset, struct fuse_file_info *fi,
+			 fuse_off_t offset, struct fuse_file_info *fi,
 			 enum fuse_readdir_flags flags)
 {
 	(void) offset;
@@ -109,7 +109,7 @@ static int hello_open(const char *path, struct fuse_file_info *fi)
 	return 0;
 }
 
-static int hello_read(const char *path, char *buf, size_t size, off_t offset,
+static int hello_read(const char *path, char *buf, size_t size, fuse_off_t offset,
 		      struct fuse_file_info *fi)
 {
 	size_t len;

--- a/example/hello_ll.c
+++ b/example/hello_ll.c
@@ -32,7 +32,7 @@
 static const char *hello_str = "Hello World!\n";
 static const char *hello_name = "hello";
 
-static int hello_stat(fuse_ino_t ino, struct stat *stbuf)
+static int hello_stat(fuse_ino_t ino, struct fuse_stat *stbuf)
 {
 	stbuf->st_ino = ino;
 	switch (ino) {
@@ -56,7 +56,7 @@ static int hello_stat(fuse_ino_t ino, struct stat *stbuf)
 static void hello_ll_getattr(fuse_req_t req, fuse_ino_t ino,
 			     struct fuse_file_info *fi)
 {
-	struct stat stbuf;
+	struct fuse_stat stbuf;
 
 	(void) fi;
 
@@ -92,7 +92,7 @@ struct dirbuf {
 static void dirbuf_add(fuse_req_t req, struct dirbuf *b, const char *name,
 		       fuse_ino_t ino)
 {
-	struct stat stbuf;
+	struct fuse_stat stbuf;
 	size_t oldsize = b->size;
 	b->size += fuse_add_direntry(req, NULL, 0, name, NULL, 0);
 	b->p = (char *) realloc(b->p, b->size);
@@ -105,7 +105,7 @@ static void dirbuf_add(fuse_req_t req, struct dirbuf *b, const char *name,
 #define min(x, y) ((x) < (y) ? (x) : (y))
 
 static int reply_buf_limited(fuse_req_t req, const char *buf, size_t bufsize,
-			     off_t off, size_t maxsize)
+			     fuse_off_t off, size_t maxsize)
 {
 	if (off < bufsize)
 		return fuse_reply_buf(req, buf + off,
@@ -115,7 +115,7 @@ static int reply_buf_limited(fuse_req_t req, const char *buf, size_t bufsize,
 }
 
 static void hello_ll_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
-			     off_t off, struct fuse_file_info *fi)
+			     fuse_off_t off, struct fuse_file_info *fi)
 {
 	(void) fi;
 
@@ -145,7 +145,7 @@ static void hello_ll_open(fuse_req_t req, fuse_ino_t ino,
 }
 
 static void hello_ll_read(fuse_req_t req, fuse_ino_t ino, size_t size,
-			  off_t off, struct fuse_file_info *fi)
+			  fuse_off_t off, struct fuse_file_info *fi)
 {
 	(void) fi;
 

--- a/example/invalidate_path.c
+++ b/example/invalidate_path.c
@@ -81,7 +81,7 @@ static void *xmp_init(struct fuse_conn_info *conn, struct fuse_config *cfg)
 }
 
 static int xmp_getattr(const char *path,
-		struct stat *stbuf, struct fuse_file_info* fi) {
+		struct fuse_stat *stbuf, struct fuse_file_info* fi) {
 	(void) fi;
 	if (strcmp(path, "/") == 0) {
 		stbuf->st_ino = 1;
@@ -105,7 +105,7 @@ static int xmp_getattr(const char *path,
 }
 
 static int xmp_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-		off_t offset, struct fuse_file_info *fi,
+		fuse_off_t offset, struct fuse_file_info *fi,
 		enum fuse_readdir_flags flags) {
 	(void) fi;
 	(void) offset;
@@ -115,7 +115,7 @@ static int xmp_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	} else {
 		(void) filler;
 		(void) buf;
-		struct stat file_stat;
+		struct fuse_stat file_stat;
 		xmp_getattr("/" TIME_FILE_NAME, &file_stat, NULL);
 		filler(buf, TIME_FILE_NAME, &file_stat, 0, 0);
 		xmp_getattr("/" GROW_FILE_NAME, &file_stat, NULL);
@@ -132,7 +132,7 @@ static int xmp_open(const char *path, struct fuse_file_info *fi) {
 	return 0;
 }
 
-static int xmp_read(const char *path, char *buf, size_t size, off_t offset,
+static int xmp_read(const char *path, char *buf, size_t size, fuse_off_t offset,
 		struct fuse_file_info *fi) {
 	(void) fi;
 	(void) offset;

--- a/example/ioctl.c
+++ b/example/ioctl.c
@@ -81,7 +81,7 @@ static int fioc_file_type(const char *path)
 	return FIOC_NONE;
 }
 
-static int fioc_getattr(const char *path, struct stat *stbuf,
+static int fioc_getattr(const char *path, struct fuse_stat *stbuf,
 			struct fuse_file_info *fi)
 {
 	(void) fi;
@@ -115,7 +115,7 @@ static int fioc_open(const char *path, struct fuse_file_info *fi)
 	return -ENOENT;
 }
 
-static int fioc_do_read(char *buf, size_t size, off_t offset)
+static int fioc_do_read(char *buf, size_t size, fuse_off_t offset)
 {
 	if (offset >= fioc_size)
 		return 0;
@@ -129,7 +129,7 @@ static int fioc_do_read(char *buf, size_t size, off_t offset)
 }
 
 static int fioc_read(const char *path, char *buf, size_t size,
-		     off_t offset, struct fuse_file_info *fi)
+		     fuse_off_t offset, struct fuse_file_info *fi)
 {
 	(void) fi;
 
@@ -139,7 +139,7 @@ static int fioc_read(const char *path, char *buf, size_t size,
 	return fioc_do_read(buf, size, offset);
 }
 
-static int fioc_do_write(const char *buf, size_t size, off_t offset)
+static int fioc_do_write(const char *buf, size_t size, fuse_off_t offset)
 {
 	if (fioc_expand(offset + size))
 		return -ENOMEM;
@@ -150,7 +150,7 @@ static int fioc_do_write(const char *buf, size_t size, off_t offset)
 }
 
 static int fioc_write(const char *path, const char *buf, size_t size,
-		      off_t offset, struct fuse_file_info *fi)
+		      fuse_off_t offset, struct fuse_file_info *fi)
 {
 	(void) fi;
 
@@ -160,7 +160,7 @@ static int fioc_write(const char *path, const char *buf, size_t size,
 	return fioc_do_write(buf, size, offset);
 }
 
-static int fioc_truncate(const char *path, off_t size,
+static int fioc_truncate(const char *path, fuse_off_t size,
 			 struct fuse_file_info *fi)
 {
 	(void) fi;
@@ -171,7 +171,7 @@ static int fioc_truncate(const char *path, off_t size,
 }
 
 static int fioc_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-			off_t offset, struct fuse_file_info *fi,
+			fuse_off_t offset, struct fuse_file_info *fi,
 			enum fuse_readdir_flags flags)
 {
 	(void) fi;

--- a/example/notify_inval_entry.c
+++ b/example/notify_inval_entry.c
@@ -112,7 +112,7 @@ static const struct fuse_opt option_spec[] = {
     FUSE_OPT_END
 };
 
-static int tfs_stat(fuse_ino_t ino, struct stat *stbuf) {
+static int tfs_stat(fuse_ino_t ino, struct fuse_stat *stbuf) {
     stbuf->st_ino = ino;
     if (ino == FUSE_ROOT_ID) {
         stbuf->st_mode = S_IFDIR | 0755;
@@ -167,7 +167,7 @@ static void tfs_forget (fuse_req_t req, fuse_ino_t ino,
 
 static void tfs_getattr(fuse_req_t req, fuse_ino_t ino,
                         struct fuse_file_info *fi) {
-    struct stat stbuf;
+    struct fuse_stat stbuf;
 
     (void) fi;
 
@@ -185,7 +185,7 @@ struct dirbuf {
 
 static void dirbuf_add(fuse_req_t req, struct dirbuf *b, const char *name,
                        fuse_ino_t ino) {
-    struct stat stbuf;
+    struct fuse_stat stbuf;
     size_t oldsize = b->size;
     b->size += fuse_add_direntry(req, NULL, 0, name, NULL, 0);
     b->p = (char *) realloc(b->p, b->size);
@@ -198,7 +198,7 @@ static void dirbuf_add(fuse_req_t req, struct dirbuf *b, const char *name,
 #define min(x, y) ((x) < (y) ? (x) : (y))
 
 static int reply_buf_limited(fuse_req_t req, const char *buf, size_t bufsize,
-                             off_t off, size_t maxsize) {
+                             fuse_off_t off, size_t maxsize) {
     if (off < bufsize)
         return fuse_reply_buf(req, buf + off,
                               min(bufsize - off, maxsize));
@@ -207,7 +207,7 @@ static int reply_buf_limited(fuse_req_t req, const char *buf, size_t bufsize,
 }
 
 static void tfs_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
-                        off_t off, struct fuse_file_info *fi) {
+                        fuse_off_t off, struct fuse_file_info *fi) {
     (void) fi;
 
     if (ino != FUSE_ROOT_ID)

--- a/example/notify_inval_inode.c
+++ b/example/notify_inval_inode.c
@@ -101,7 +101,7 @@ static const struct fuse_opt option_spec[] = {
     FUSE_OPT_END
 };
 
-static int tfs_stat(fuse_ino_t ino, struct stat *stbuf) {
+static int tfs_stat(fuse_ino_t ino, struct fuse_stat *stbuf) {
     stbuf->st_ino = ino;
     if (ino == FUSE_ROOT_ID) {
         stbuf->st_mode = S_IFDIR | 0755;
@@ -156,7 +156,7 @@ static void tfs_forget (fuse_req_t req, fuse_ino_t ino,
 
 static void tfs_getattr(fuse_req_t req, fuse_ino_t ino,
                         struct fuse_file_info *fi) {
-    struct stat stbuf;
+    struct fuse_stat stbuf;
 
     (void) fi;
 
@@ -174,7 +174,7 @@ struct dirbuf {
 
 static void dirbuf_add(fuse_req_t req, struct dirbuf *b, const char *name,
                        fuse_ino_t ino) {
-    struct stat stbuf;
+    struct fuse_stat stbuf;
     size_t oldsize = b->size;
     b->size += fuse_add_direntry(req, NULL, 0, name, NULL, 0);
     b->p = (char *) realloc(b->p, b->size);
@@ -187,7 +187,7 @@ static void dirbuf_add(fuse_req_t req, struct dirbuf *b, const char *name,
 #define min(x, y) ((x) < (y) ? (x) : (y))
 
 static int reply_buf_limited(fuse_req_t req, const char *buf, size_t bufsize,
-                             off_t off, size_t maxsize) {
+                             fuse_off_t off, size_t maxsize) {
     if (off < bufsize)
         return fuse_reply_buf(req, buf + off,
                               min(bufsize - off, maxsize));
@@ -196,7 +196,7 @@ static int reply_buf_limited(fuse_req_t req, const char *buf, size_t bufsize,
 }
 
 static void tfs_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
-                        off_t off, struct fuse_file_info *fi) {
+                        fuse_off_t off, struct fuse_file_info *fi) {
     (void) fi;
 
     if (ino != FUSE_ROOT_ID)
@@ -232,7 +232,7 @@ static void tfs_open(fuse_req_t req, fuse_ino_t ino,
 }
 
 static void tfs_read(fuse_req_t req, fuse_ino_t ino, size_t size,
-                     off_t off, struct fuse_file_info *fi) {
+                     fuse_off_t off, struct fuse_file_info *fi) {
     (void) fi;
 
     assert(ino == FILE_INO);

--- a/example/notify_store_retrieve.c
+++ b/example/notify_store_retrieve.c
@@ -104,7 +104,7 @@ static const struct fuse_opt option_spec[] = {
     FUSE_OPT_END
 };
 
-static int tfs_stat(fuse_ino_t ino, struct stat *stbuf) {
+static int tfs_stat(fuse_ino_t ino, struct fuse_stat *stbuf) {
     stbuf->st_ino = ino;
     if (ino == FUSE_ROOT_ID) {
         stbuf->st_mode = S_IFDIR | 0755;
@@ -159,7 +159,7 @@ static void tfs_forget (fuse_req_t req, fuse_ino_t ino,
 
 static void tfs_getattr(fuse_req_t req, fuse_ino_t ino,
                         struct fuse_file_info *fi) {
-    struct stat stbuf;
+    struct fuse_stat stbuf;
 
     (void) fi;
 
@@ -177,7 +177,7 @@ struct dirbuf {
 
 static void dirbuf_add(fuse_req_t req, struct dirbuf *b, const char *name,
                        fuse_ino_t ino) {
-    struct stat stbuf;
+    struct fuse_stat stbuf;
     size_t oldsize = b->size;
     b->size += fuse_add_direntry(req, NULL, 0, name, NULL, 0);
     b->p = (char *) realloc(b->p, b->size);
@@ -190,7 +190,7 @@ static void dirbuf_add(fuse_req_t req, struct dirbuf *b, const char *name,
 #define min(x, y) ((x) < (y) ? (x) : (y))
 
 static int reply_buf_limited(fuse_req_t req, const char *buf, size_t bufsize,
-                             off_t off, size_t maxsize) {
+                             fuse_off_t off, size_t maxsize) {
     if (off < bufsize)
         return fuse_reply_buf(req, buf + off,
                               min(bufsize - off, maxsize));
@@ -199,7 +199,7 @@ static int reply_buf_limited(fuse_req_t req, const char *buf, size_t bufsize,
 }
 
 static void tfs_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
-                        off_t off, struct fuse_file_info *fi) {
+                        fuse_off_t off, struct fuse_file_info *fi) {
     (void) fi;
 
     if (ino != FUSE_ROOT_ID)
@@ -235,7 +235,7 @@ static void tfs_open(fuse_req_t req, fuse_ino_t ino,
 }
 
 static void tfs_read(fuse_req_t req, fuse_ino_t ino, size_t size,
-                     off_t off, struct fuse_file_info *fi) {
+                     fuse_off_t off, struct fuse_file_info *fi) {
     (void) fi;
 
     assert(ino == FILE_INO);
@@ -243,7 +243,7 @@ static void tfs_read(fuse_req_t req, fuse_ino_t ino, size_t size,
 }
 
 static void tfs_retrieve_reply(fuse_req_t req, void *cookie, fuse_ino_t ino,
-                               off_t offset, struct fuse_bufvec *data) {
+                               fuse_off_t offset, struct fuse_bufvec *data) {
     struct fuse_bufvec bufv;
     char buf[MAX_STR_LEN];
     char *expected;

--- a/example/null.c
+++ b/example/null.c
@@ -33,7 +33,7 @@
 #include <time.h>
 #include <errno.h>
 
-static int null_getattr(const char *path, struct stat *stbuf,
+static int null_getattr(const char *path, struct fuse_stat *stbuf,
 			struct fuse_file_info *fi)
 {
 	(void) fi;
@@ -52,7 +52,7 @@ static int null_getattr(const char *path, struct stat *stbuf,
 	return 0;
 }
 
-static int null_truncate(const char *path, off_t size,
+static int null_truncate(const char *path, fuse_off_t size,
 			 struct fuse_file_info *fi)
 {
 	(void) size;
@@ -75,7 +75,7 @@ static int null_open(const char *path, struct fuse_file_info *fi)
 }
 
 static int null_read(const char *path, char *buf, size_t size,
-		     off_t offset, struct fuse_file_info *fi)
+		     fuse_off_t offset, struct fuse_file_info *fi)
 {
 	(void) buf;
 	(void) offset;
@@ -92,7 +92,7 @@ static int null_read(const char *path, char *buf, size_t size,
 }
 
 static int null_write(const char *path, const char *buf, size_t size,
-		      off_t offset, struct fuse_file_info *fi)
+		      fuse_off_t offset, struct fuse_file_info *fi)
 {
 	(void) buf;
 	(void) offset;
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 {
 	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
 	struct fuse_cmdline_opts opts;
-	struct stat stbuf;
+	struct fuse_stat stbuf;
 
 	if (fuse_parse_cmdline(&args, &opts) != 0)
 		return 1;

--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -75,7 +75,7 @@ static void *xmp_init(struct fuse_conn_info *conn,
 	return NULL;
 }
 
-static int xmp_getattr(const char *path, struct stat *stbuf,
+static int xmp_getattr(const char *path, struct fuse_stat *stbuf,
 		       struct fuse_file_info *fi)
 {
 	(void) fi;
@@ -113,7 +113,7 @@ static int xmp_readlink(const char *path, char *buf, size_t size)
 
 
 static int xmp_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-		       off_t offset, struct fuse_file_info *fi,
+		       fuse_off_t offset, struct fuse_file_info *fi,
 		       enum fuse_readdir_flags flags)
 {
 	DIR *dp;
@@ -128,7 +128,7 @@ static int xmp_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 		return -errno;
 
 	while ((de = readdir(dp)) != NULL) {
-		struct stat st;
+		struct fuse_stat st;
 		memset(&st, 0, sizeof(st));
 		st.st_ino = de->d_ino;
 		st.st_mode = de->d_type << 12;
@@ -140,7 +140,7 @@ static int xmp_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	return 0;
 }
 
-static int xmp_mknod(const char *path, mode_t mode, dev_t rdev)
+static int xmp_mknod(const char *path, fuse_mode_t mode, fuse_dev_t rdev)
 {
 	int res;
 
@@ -151,7 +151,7 @@ static int xmp_mknod(const char *path, mode_t mode, dev_t rdev)
 	return 0;
 }
 
-static int xmp_mkdir(const char *path, mode_t mode)
+static int xmp_mkdir(const char *path, fuse_mode_t mode)
 {
 	int res;
 
@@ -220,7 +220,7 @@ static int xmp_link(const char *from, const char *to)
 	return 0;
 }
 
-static int xmp_chmod(const char *path, mode_t mode,
+static int xmp_chmod(const char *path, fuse_mode_t mode,
 		     struct fuse_file_info *fi)
 {
 	(void) fi;
@@ -233,7 +233,7 @@ static int xmp_chmod(const char *path, mode_t mode,
 	return 0;
 }
 
-static int xmp_chown(const char *path, uid_t uid, gid_t gid,
+static int xmp_chown(const char *path, fuse_uid_t uid, fuse_gid_t gid,
 		     struct fuse_file_info *fi)
 {
 	(void) fi;
@@ -246,7 +246,7 @@ static int xmp_chown(const char *path, uid_t uid, gid_t gid,
 	return 0;
 }
 
-static int xmp_truncate(const char *path, off_t size,
+static int xmp_truncate(const char *path, fuse_off_t size,
 			struct fuse_file_info *fi)
 {
 	int res;
@@ -262,7 +262,7 @@ static int xmp_truncate(const char *path, off_t size,
 }
 
 #ifdef HAVE_UTIMENSAT
-static int xmp_utimens(const char *path, const struct timespec ts[2],
+static int xmp_utimens(const char *path, const struct fuse_timespec ts[2],
 		       struct fuse_file_info *fi)
 {
 	(void) fi;
@@ -277,7 +277,7 @@ static int xmp_utimens(const char *path, const struct timespec ts[2],
 }
 #endif
 
-static int xmp_create(const char *path, mode_t mode,
+static int xmp_create(const char *path, fuse_mode_t mode,
 		      struct fuse_file_info *fi)
 {
 	int res;
@@ -302,7 +302,7 @@ static int xmp_open(const char *path, struct fuse_file_info *fi)
 	return 0;
 }
 
-static int xmp_read(const char *path, char *buf, size_t size, off_t offset,
+static int xmp_read(const char *path, char *buf, size_t size, fuse_off_t offset,
 		    struct fuse_file_info *fi)
 {
 	int fd;
@@ -326,7 +326,7 @@ static int xmp_read(const char *path, char *buf, size_t size, off_t offset,
 }
 
 static int xmp_write(const char *path, const char *buf, size_t size,
-		     off_t offset, struct fuse_file_info *fi)
+		     fuse_off_t offset, struct fuse_file_info *fi)
 {
 	int fd;
 	int res;
@@ -349,7 +349,7 @@ static int xmp_write(const char *path, const char *buf, size_t size,
 	return res;
 }
 
-static int xmp_statfs(const char *path, struct statvfs *stbuf)
+static int xmp_statfs(const char *path, struct fuse_statvfs *stbuf)
 {
 	int res;
 
@@ -381,7 +381,7 @@ static int xmp_fsync(const char *path, int isdatasync,
 
 #ifdef HAVE_POSIX_FALLOCATE
 static int xmp_fallocate(const char *path, int mode,
-			off_t offset, off_t length, struct fuse_file_info *fi)
+			fuse_off_t offset, fuse_off_t length, struct fuse_file_info *fi)
 {
 	int fd;
 	int res;
@@ -447,9 +447,9 @@ static int xmp_removexattr(const char *path, const char *name)
 #ifdef HAVE_COPY_FILE_RANGE
 static ssize_t xmp_copy_file_range(const char *path_in,
 				   struct fuse_file_info *fi_in,
-				   off_t offset_in, const char *path_out,
+				   fuse_off_t offset_in, const char *path_out,
 				   struct fuse_file_info *fi_out,
-				   off_t offset_out, size_t len, int flags)
+				   fuse_off_t offset_out, size_t len, int flags)
 {
 	int fd_in, fd_out;
 	ssize_t res;

--- a/example/passthrough_fh.c
+++ b/example/passthrough_fh.c
@@ -72,7 +72,7 @@ static void *xmp_init(struct fuse_conn_info *conn,
 	return NULL;
 }
 
-static int xmp_getattr(const char *path, struct stat *stbuf,
+static int xmp_getattr(const char *path, struct fuse_stat *stbuf,
 			struct fuse_file_info *fi)
 {
 	int res;
@@ -115,7 +115,7 @@ static int xmp_readlink(const char *path, char *buf, size_t size)
 struct xmp_dirp {
 	DIR *dp;
 	struct dirent *entry;
-	off_t offset;
+	fuse_off_t offset;
 };
 
 static int xmp_opendir(const char *path, struct fuse_file_info *fi)
@@ -144,7 +144,7 @@ static inline struct xmp_dirp *get_dirp(struct fuse_file_info *fi)
 }
 
 static int xmp_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-		       off_t offset, struct fuse_file_info *fi,
+		       fuse_off_t offset, struct fuse_file_info *fi,
 		       enum fuse_readdir_flags flags)
 {
 	struct xmp_dirp *d = get_dirp(fi);
@@ -162,8 +162,8 @@ static int xmp_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 		d->offset = offset;
 	}
 	while (1) {
-		struct stat st;
-		off_t nextoff;
+		struct fuse_stat st;
+		fuse_off_t nextoff;
 		enum fuse_fill_dir_flags fill_flags = 0;
 
 		if (!d->entry) {
@@ -213,7 +213,7 @@ static int xmp_releasedir(const char *path, struct fuse_file_info *fi)
 	return 0;
 }
 
-static int xmp_mknod(const char *path, mode_t mode, dev_t rdev)
+static int xmp_mknod(const char *path, fuse_mode_t mode, fuse_dev_t rdev)
 {
 	int res;
 
@@ -227,7 +227,7 @@ static int xmp_mknod(const char *path, mode_t mode, dev_t rdev)
 	return 0;
 }
 
-static int xmp_mkdir(const char *path, mode_t mode)
+static int xmp_mkdir(const char *path, fuse_mode_t mode)
 {
 	int res;
 
@@ -297,7 +297,7 @@ static int xmp_link(const char *from, const char *to)
 	return 0;
 }
 
-static int xmp_chmod(const char *path, mode_t mode,
+static int xmp_chmod(const char *path, fuse_mode_t mode,
 		     struct fuse_file_info *fi)
 {
 	int res;
@@ -312,7 +312,7 @@ static int xmp_chmod(const char *path, mode_t mode,
 	return 0;
 }
 
-static int xmp_chown(const char *path, uid_t uid, gid_t gid,
+static int xmp_chown(const char *path, fuse_uid_t uid, fuse_gid_t gid,
 		     struct fuse_file_info *fi)
 {
 	int res;
@@ -327,7 +327,7 @@ static int xmp_chown(const char *path, uid_t uid, gid_t gid,
 	return 0;
 }
 
-static int xmp_truncate(const char *path, off_t size,
+static int xmp_truncate(const char *path, fuse_off_t size,
 			 struct fuse_file_info *fi)
 {
 	int res;
@@ -344,7 +344,7 @@ static int xmp_truncate(const char *path, off_t size,
 }
 
 #ifdef HAVE_UTIMENSAT
-static int xmp_utimens(const char *path, const struct timespec ts[2],
+static int xmp_utimens(const char *path, const struct fuse_timespec ts[2],
 		       struct fuse_file_info *fi)
 {
 	int res;
@@ -361,7 +361,7 @@ static int xmp_utimens(const char *path, const struct timespec ts[2],
 }
 #endif
 
-static int xmp_create(const char *path, mode_t mode, struct fuse_file_info *fi)
+static int xmp_create(const char *path, fuse_mode_t mode, struct fuse_file_info *fi)
 {
 	int fd;
 
@@ -385,7 +385,7 @@ static int xmp_open(const char *path, struct fuse_file_info *fi)
 	return 0;
 }
 
-static int xmp_read(const char *path, char *buf, size_t size, off_t offset,
+static int xmp_read(const char *path, char *buf, size_t size, fuse_off_t offset,
 		    struct fuse_file_info *fi)
 {
 	int res;
@@ -399,7 +399,7 @@ static int xmp_read(const char *path, char *buf, size_t size, off_t offset,
 }
 
 static int xmp_read_buf(const char *path, struct fuse_bufvec **bufp,
-			size_t size, off_t offset, struct fuse_file_info *fi)
+			size_t size, fuse_off_t offset, struct fuse_file_info *fi)
 {
 	struct fuse_bufvec *src;
 
@@ -421,7 +421,7 @@ static int xmp_read_buf(const char *path, struct fuse_bufvec **bufp,
 }
 
 static int xmp_write(const char *path, const char *buf, size_t size,
-		     off_t offset, struct fuse_file_info *fi)
+		     fuse_off_t offset, struct fuse_file_info *fi)
 {
 	int res;
 
@@ -434,7 +434,7 @@ static int xmp_write(const char *path, const char *buf, size_t size,
 }
 
 static int xmp_write_buf(const char *path, struct fuse_bufvec *buf,
-		     off_t offset, struct fuse_file_info *fi)
+		     fuse_off_t offset, struct fuse_file_info *fi)
 {
 	struct fuse_bufvec dst = FUSE_BUFVEC_INIT(fuse_buf_size(buf));
 
@@ -447,7 +447,7 @@ static int xmp_write_buf(const char *path, struct fuse_bufvec *buf,
 	return fuse_buf_copy(&dst, buf, FUSE_BUF_SPLICE_NONBLOCK);
 }
 
-static int xmp_statfs(const char *path, struct statvfs *stbuf)
+static int xmp_statfs(const char *path, struct fuse_statvfs *stbuf)
 {
 	int res;
 
@@ -505,7 +505,7 @@ static int xmp_fsync(const char *path, int isdatasync,
 
 #ifdef HAVE_POSIX_FALLOCATE
 static int xmp_fallocate(const char *path, int mode,
-			off_t offset, off_t length, struct fuse_file_info *fi)
+			fuse_off_t offset, fuse_off_t length, struct fuse_file_info *fi)
 {
 	(void) path;
 
@@ -555,7 +555,7 @@ static int xmp_removexattr(const char *path, const char *name)
 
 #ifdef HAVE_LIBULOCKMGR
 static int xmp_lock(const char *path, struct fuse_file_info *fi, int cmd,
-		    struct flock *lock)
+		    struct fuse_flock *lock)
 {
 	(void) path;
 
@@ -579,9 +579,9 @@ static int xmp_flock(const char *path, struct fuse_file_info *fi, int op)
 #ifdef HAVE_COPY_FILE_RANGE
 static ssize_t xmp_copy_file_range(const char *path_in,
 				   struct fuse_file_info *fi_in,
-				   off_t off_in, const char *path_out,
+				   fuse_off_t off_in, const char *path_out,
 				   struct fuse_file_info *fi_out,
-				   off_t off_out, size_t len, int flags)
+				   fuse_off_t off_out, size_t len, int flags)
 {
 	ssize_t res;
 	(void) path_in;

--- a/example/passthrough_helpers.h
+++ b/example/passthrough_helpers.h
@@ -28,7 +28,7 @@
  * operation
  */
 static int mknod_wrapper(int dirfd, const char *path, const char *link,
-	int mode, dev_t rdev)
+	int mode, fuse_dev_t rdev)
 {
 	int res;
 

--- a/example/poll.c
+++ b/example/poll.c
@@ -63,13 +63,13 @@ static int fsel_path_index(const char *path)
 	return ch <= '9' ? ch - '0' : ch - 'A' + 10;
 }
 
-static int fsel_getattr(const char *path, struct stat *stbuf,
+static int fsel_getattr(const char *path, struct fuse_stat *stbuf,
 			struct fuse_file_info *fi)
 {
 	(void) fi;
 	int idx;
 
-	memset(stbuf, 0, sizeof(struct stat));
+	memset(stbuf, 0, sizeof(struct fuse_stat));
 
 	if (strcmp(path, "/") == 0) {
 		stbuf->st_mode = S_IFDIR | 0555;
@@ -88,7 +88,7 @@ static int fsel_getattr(const char *path, struct stat *stbuf,
 }
 
 static int fsel_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-			off_t offset, struct fuse_file_info *fi,
+			fuse_off_t offset, struct fuse_file_info *fi,
 			enum fuse_readdir_flags flags)
 {
 	char name[2] = { };
@@ -143,7 +143,7 @@ static int fsel_release(const char *path, struct fuse_file_info *fi)
 	return 0;
 }
 
-static int fsel_read(const char *path, char *buf, size_t size, off_t offset,
+static int fsel_read(const char *path, char *buf, size_t size, fuse_off_t offset,
 		     struct fuse_file_info *fi)
 {
 	int idx = fi->fh;
@@ -217,7 +217,7 @@ static struct fuse_operations fsel_oper = {
 
 static void *fsel_producer(void *data)
 {
-	const struct timespec interval = { 0, 250000000 };
+	const struct fuse_timespec interval = { 0, 250000000 };
 	unsigned idx = 0, nr = 1;
 
 	(void) data;

--- a/include/cuse_lowlevel.h
+++ b/include/cuse_lowlevel.h
@@ -18,10 +18,6 @@
 
 #include "fuse_lowlevel.h"
 
-#include <fcntl.h>
-#include <sys/types.h>
-#include <sys/uio.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -51,9 +47,9 @@ struct cuse_lowlevel_ops {
 	void (*init_done) (void *userdata);
 	void (*destroy) (void *userdata);
 	void (*open) (fuse_req_t req, struct fuse_file_info *fi);
-	void (*read) (fuse_req_t req, size_t size, off_t off,
+	void (*read) (fuse_req_t req, size_t size, fuse_off_t off,
 		      struct fuse_file_info *fi);
-	void (*write) (fuse_req_t req, const char *buf, size_t size, off_t off,
+	void (*write) (fuse_req_t req, const char *buf, size_t size, fuse_off_t off,
 		       struct fuse_file_info *fi);
 	void (*flush) (fuse_req_t req, struct fuse_file_info *fi);
 	void (*release) (fuse_req_t req, struct fuse_file_info *fi);

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -16,8 +16,7 @@
 
 #include "fuse_opt.h"
 #include "fuse_log.h"
-#include <stdint.h>
-#include <sys/types.h>
+#include "fuse_types.h"
 
 /** Major version of FUSE library interface */
 #define FUSE_MAJOR_VERSION 3
@@ -693,7 +692,7 @@ struct fuse_buf {
 	 *
 	 * Used if FUSE_BUF_FD_SEEK flag is set.
 	 */
-	off_t pos;
+	fuse_off_t pos;
 };
 
 /**

--- a/include/fuse_types.h
+++ b/include/fuse_types.h
@@ -1,0 +1,46 @@
+/*
+ * FUSE: Filesystem in Userspace
+ * Copyright (C) 2019 Bill Zissimopoulos <billziss at navimatics.com>
+ *
+ * This program can be distributed under the terms of the GNU LGPLv2.
+ * See the file COPYING.LIB
+ */
+
+#ifndef FUSE_TYPES_H_
+#define FUSE_TYPES_H_
+
+#include <fcntl.h>
+#include <stdint.h>
+#include <time.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+
+typedef uint64_t fuse_ino_t;
+
+#define fuse_uid_t                      uid_t
+#define fuse_gid_t                      gid_t
+#define fuse_pid_t                      pid_t
+
+#define fuse_dev_t                      dev_t
+#define fuse_mode_t                     mode_t
+#define fuse_nlink_t                    nlink_t
+#define fuse_off_t                      off_t
+
+#define fuse_fsblkcnt_t                 fsblkcnt_t
+#define fuse_fsfilcnt_t                 fsfilcnt_t
+#define fuse_blksize_t                  blksize_t
+#define fuse_blkcnt_t                   blkcnt_t
+
+#define fuse_timespec                   timespec
+
+#define fuse_stat                       stat
+
+#define fuse_statvfs                    statvfs
+
+#define fuse_flock                      flock
+
+#define fuse_iovec                      iovec
+
+#endif /* FUSE_TYPES_H_ */

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -163,10 +163,10 @@ static ssize_t fuse_buf_splice(const struct fuse_buf *dst, size_t dst_off,
 			       size_t len, enum fuse_buf_copy_flags flags)
 {
 	int splice_flags = 0;
-	off_t *srcpos = NULL;
-	off_t *dstpos = NULL;
-	off_t srcpos_val;
-	off_t dstpos_val;
+	fuse_off_t *srcpos = NULL;
+	fuse_off_t *dstpos = NULL;
+	fuse_off_t srcpos_val;
+	fuse_off_t dstpos_val;
 	ssize_t res;
 	size_t copied = 0;
 

--- a/lib/cuse_lowlevel.c
+++ b/lib/cuse_lowlevel.c
@@ -43,14 +43,14 @@ static void cuse_fll_open(fuse_req_t req, fuse_ino_t ino,
 }
 
 static void cuse_fll_read(fuse_req_t req, fuse_ino_t ino, size_t size,
-			  off_t off, struct fuse_file_info *fi)
+			  fuse_off_t off, struct fuse_file_info *fi)
 {
 	(void)ino;
 	req_clop(req)->read(req, size, off, fi);
 }
 
 static void cuse_fll_write(fuse_req_t req, fuse_ino_t ino, const char *buf,
-			   size_t size, off_t off, struct fuse_file_info *fi)
+			   size_t size, fuse_off_t off, struct fuse_file_info *fi)
 {
 	(void)ino;
 	req_clop(req)->write(req, buf, size, off, fi);
@@ -182,7 +182,7 @@ struct fuse_session *cuse_lowlevel_new(struct fuse_args *args,
 static int cuse_reply_init(fuse_req_t req, struct cuse_init_out *arg,
 			   char *dev_info, unsigned dev_info_len)
 {
-	struct iovec iov[3];
+	struct fuse_iovec iov[3];
 
 	iov[1].iov_base = arg;
 	iov[1].iov_len = sizeof(struct cuse_init_out);

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -52,7 +52,7 @@ struct fuse_session {
 	int got_init;
 	struct cuse_data *cuse_data;
 	void *userdata;
-	uid_t owner;
+	fuse_uid_t owner;
 	struct fuse_conn_info conn;
 	struct fuse_req list;
 	struct fuse_req interrupts;
@@ -113,7 +113,7 @@ unsigned get_max_read(struct mount_opts *o);
 void fuse_kern_unmount(const char *mountpoint, int fd);
 int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo);
 
-int fuse_send_reply_iov_nofree(fuse_req_t req, int error, struct iovec *iov,
+int fuse_send_reply_iov_nofree(fuse_req_t req, int error, struct fuse_iovec *iov,
 			       int count);
 void fuse_free_req(fuse_req_t req);
 

--- a/lib/modules/iconv.c
+++ b/lib/modules/iconv.c
@@ -99,7 +99,7 @@ err:
 	return err;
 }
 
-static int iconv_getattr(const char *path, struct stat *stbuf,
+static int iconv_getattr(const char *path, struct fuse_stat *stbuf,
 			 struct fuse_file_info *fi)
 {
 	struct iconv *ic = iconv_get();
@@ -158,7 +158,7 @@ static int iconv_opendir(const char *path, struct fuse_file_info *fi)
 }
 
 static int iconv_dir_fill(void *buf, const char *name,
-			  const struct stat *stbuf, off_t off,
+			  const struct fuse_stat *stbuf, fuse_off_t off,
 			  enum fuse_fill_dir_flags flags)
 {
 	struct iconv_dh *dh = buf;
@@ -172,7 +172,7 @@ static int iconv_dir_fill(void *buf, const char *name,
 }
 
 static int iconv_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-			 off_t offset, struct fuse_file_info *fi,
+			 fuse_off_t offset, struct fuse_file_info *fi,
 			 enum fuse_readdir_flags flags)
 {
 	struct iconv *ic = iconv_get();
@@ -202,7 +202,7 @@ static int iconv_releasedir(const char *path, struct fuse_file_info *fi)
 	return err;
 }
 
-static int iconv_mknod(const char *path, mode_t mode, dev_t rdev)
+static int iconv_mknod(const char *path, fuse_mode_t mode, fuse_dev_t rdev)
 {
 	struct iconv *ic = iconv_get();
 	char *newpath;
@@ -214,7 +214,7 @@ static int iconv_mknod(const char *path, mode_t mode, dev_t rdev)
 	return err;
 }
 
-static int iconv_mkdir(const char *path, mode_t mode)
+static int iconv_mkdir(const char *path, fuse_mode_t mode)
 {
 	struct iconv *ic = iconv_get();
 	char *newpath;
@@ -301,7 +301,7 @@ static int iconv_link(const char *from, const char *to)
 	return err;
 }
 
-static int iconv_chmod(const char *path, mode_t mode,
+static int iconv_chmod(const char *path, fuse_mode_t mode,
 		       struct fuse_file_info *fi)
 {
 	struct iconv *ic = iconv_get();
@@ -314,7 +314,7 @@ static int iconv_chmod(const char *path, mode_t mode,
 	return err;
 }
 
-static int iconv_chown(const char *path, uid_t uid, gid_t gid,
+static int iconv_chown(const char *path, fuse_uid_t uid, fuse_gid_t gid,
 		       struct fuse_file_info *fi)
 {
 	struct iconv *ic = iconv_get();
@@ -327,7 +327,7 @@ static int iconv_chown(const char *path, uid_t uid, gid_t gid,
 	return err;
 }
 
-static int iconv_truncate(const char *path, off_t size,
+static int iconv_truncate(const char *path, fuse_off_t size,
 			   struct fuse_file_info *fi)
 {
 	struct iconv *ic = iconv_get();
@@ -340,7 +340,7 @@ static int iconv_truncate(const char *path, off_t size,
 	return err;
 }
 
-static int iconv_utimens(const char *path, const struct timespec ts[2],
+static int iconv_utimens(const char *path, const struct fuse_timespec ts[2],
 			 struct fuse_file_info *fi)
 {
 	struct iconv *ic = iconv_get();
@@ -353,7 +353,7 @@ static int iconv_utimens(const char *path, const struct timespec ts[2],
 	return err;
 }
 
-static int iconv_create(const char *path, mode_t mode,
+static int iconv_create(const char *path, fuse_mode_t mode,
 			struct fuse_file_info *fi)
 {
 	struct iconv *ic = iconv_get();
@@ -379,7 +379,7 @@ static int iconv_open_file(const char *path, struct fuse_file_info *fi)
 }
 
 static int iconv_read_buf(const char *path, struct fuse_bufvec **bufp,
-			  size_t size, off_t offset, struct fuse_file_info *fi)
+			  size_t size, fuse_off_t offset, struct fuse_file_info *fi)
 {
 	struct iconv *ic = iconv_get();
 	char *newpath;
@@ -392,7 +392,7 @@ static int iconv_read_buf(const char *path, struct fuse_bufvec **bufp,
 }
 
 static int iconv_write_buf(const char *path, struct fuse_bufvec *buf,
-			   off_t offset, struct fuse_file_info *fi)
+			   fuse_off_t offset, struct fuse_file_info *fi)
 {
 	struct iconv *ic = iconv_get();
 	char *newpath;
@@ -404,7 +404,7 @@ static int iconv_write_buf(const char *path, struct fuse_bufvec *buf,
 	return err;
 }
 
-static int iconv_statfs(const char *path, struct statvfs *stbuf)
+static int iconv_statfs(const char *path, struct fuse_statvfs *stbuf)
 {
 	struct iconv *ic = iconv_get();
 	char *newpath;
@@ -518,7 +518,7 @@ static int iconv_removexattr(const char *path, const char *name)
 }
 
 static int iconv_lock(const char *path, struct fuse_file_info *fi, int cmd,
-		      struct flock *lock)
+		      struct fuse_flock *lock)
 {
 	struct iconv *ic = iconv_get();
 	char *newpath;

--- a/lib/modules/subdir.c
+++ b/lib/modules/subdir.c
@@ -50,7 +50,7 @@ static int subdir_addpath(struct subdir *d, const char *path, char **newpathp)
 	return 0;
 }
 
-static int subdir_getattr(const char *path, struct stat *stbuf,
+static int subdir_getattr(const char *path, struct fuse_stat *stbuf,
 			  struct fuse_file_info *fi)
 {
 	struct subdir *d = subdir_get();
@@ -166,7 +166,7 @@ static int subdir_opendir(const char *path, struct fuse_file_info *fi)
 }
 
 static int subdir_readdir(const char *path, void *buf,
-			  fuse_fill_dir_t filler, off_t offset,
+			  fuse_fill_dir_t filler, fuse_off_t offset,
 			  struct fuse_file_info *fi,
 			  enum fuse_readdir_flags flags)
 {
@@ -193,7 +193,7 @@ static int subdir_releasedir(const char *path, struct fuse_file_info *fi)
 	return err;
 }
 
-static int subdir_mknod(const char *path, mode_t mode, dev_t rdev)
+static int subdir_mknod(const char *path, fuse_mode_t mode, fuse_dev_t rdev)
 {
 	struct subdir *d = subdir_get();
 	char *newpath;
@@ -205,7 +205,7 @@ static int subdir_mknod(const char *path, mode_t mode, dev_t rdev)
 	return err;
 }
 
-static int subdir_mkdir(const char *path, mode_t mode)
+static int subdir_mkdir(const char *path, fuse_mode_t mode)
 {
 	struct subdir *d = subdir_get();
 	char *newpath;
@@ -287,7 +287,7 @@ static int subdir_link(const char *from, const char *to)
 	return err;
 }
 
-static int subdir_chmod(const char *path, mode_t mode,
+static int subdir_chmod(const char *path, fuse_mode_t mode,
 			struct fuse_file_info *fi)
 {
 	struct subdir *d = subdir_get();
@@ -300,7 +300,7 @@ static int subdir_chmod(const char *path, mode_t mode,
 	return err;
 }
 
-static int subdir_chown(const char *path, uid_t uid, gid_t gid,
+static int subdir_chown(const char *path, fuse_uid_t uid, fuse_gid_t gid,
 			struct fuse_file_info *fi)
 {
 	struct subdir *d = subdir_get();
@@ -313,7 +313,7 @@ static int subdir_chown(const char *path, uid_t uid, gid_t gid,
 	return err;
 }
 
-static int subdir_truncate(const char *path, off_t size,
+static int subdir_truncate(const char *path, fuse_off_t size,
 			   struct fuse_file_info *fi)
 {
 	struct subdir *d = subdir_get();
@@ -326,7 +326,7 @@ static int subdir_truncate(const char *path, off_t size,
 	return err;
 }
 
-static int subdir_utimens(const char *path, const struct timespec ts[2],
+static int subdir_utimens(const char *path, const struct fuse_timespec ts[2],
 			  struct fuse_file_info *fi)
 {
 	struct subdir *d = subdir_get();
@@ -339,7 +339,7 @@ static int subdir_utimens(const char *path, const struct timespec ts[2],
 	return err;
 }
 
-static int subdir_create(const char *path, mode_t mode,
+static int subdir_create(const char *path, fuse_mode_t mode,
 			 struct fuse_file_info *fi)
 {
 	struct subdir *d = subdir_get();
@@ -365,7 +365,7 @@ static int subdir_open(const char *path, struct fuse_file_info *fi)
 }
 
 static int subdir_read_buf(const char *path, struct fuse_bufvec **bufp,
-			   size_t size, off_t offset, struct fuse_file_info *fi)
+			   size_t size, fuse_off_t offset, struct fuse_file_info *fi)
 {
 	struct subdir *d = subdir_get();
 	char *newpath;
@@ -378,7 +378,7 @@ static int subdir_read_buf(const char *path, struct fuse_bufvec **bufp,
 }
 
 static int subdir_write_buf(const char *path, struct fuse_bufvec *buf,
-			off_t offset, struct fuse_file_info *fi)
+			fuse_off_t offset, struct fuse_file_info *fi)
 {
 	struct subdir *d = subdir_get();
 	char *newpath;
@@ -390,7 +390,7 @@ static int subdir_write_buf(const char *path, struct fuse_bufvec *buf,
 	return err;
 }
 
-static int subdir_statfs(const char *path, struct statvfs *stbuf)
+static int subdir_statfs(const char *path, struct fuse_statvfs *stbuf)
 {
 	struct subdir *d = subdir_get();
 	char *newpath;
@@ -504,7 +504,7 @@ static int subdir_removexattr(const char *path, const char *name)
 }
 
 static int subdir_lock(const char *path, struct fuse_file_info *fi, int cmd,
-		       struct flock *lock)
+		       struct fuse_flock *lock)
 {
 	struct subdir *d = subdir_get();
 	char *newpath;

--- a/test/test_setattr.c
+++ b/test/test_setattr.c
@@ -31,9 +31,9 @@
 #define FILE_NAME "truncate_me"
 
 static int got_fh;
-static mode_t file_mode = S_IFREG | 0644;
+static fuse_mode_t file_mode = S_IFREG | 0644;
 
-static int tfs_stat(fuse_ino_t ino, struct stat *stbuf) {
+static int tfs_stat(fuse_ino_t ino, struct fuse_stat *stbuf) {
     stbuf->st_ino = ino;
     if (ino == FUSE_ROOT_ID) {
         stbuf->st_mode = S_IFDIR | 0755;
@@ -75,7 +75,7 @@ err_out:
 
 static void tfs_getattr(fuse_req_t req, fuse_ino_t ino,
                         struct fuse_file_info *fi) {
-    struct stat stbuf;
+    struct fuse_stat stbuf;
 
     (void) fi;
 
@@ -97,7 +97,7 @@ static void tfs_open(fuse_req_t req, fuse_ino_t ino,
     }
 }
 
-static void tfs_setattr (fuse_req_t req, fuse_ino_t ino, struct stat *attr,
+static void tfs_setattr (fuse_req_t req, fuse_ino_t ino, struct fuse_stat *attr,
                          int to_set, struct fuse_file_info *fi) {
     if(ino != FILE_INO ||
        !(to_set & FUSE_SET_ATTR_MODE)) {

--- a/test/test_write_cache.c
+++ b/test/test_write_cache.c
@@ -58,7 +58,7 @@ static void tfs_init (void *userdata, struct fuse_conn_info *conn)
     }
 }
 
-static int tfs_stat(fuse_ino_t ino, struct stat *stbuf) {
+static int tfs_stat(fuse_ino_t ino, struct fuse_stat *stbuf) {
     stbuf->st_ino = ino;
     if (ino == FUSE_ROOT_ID) {
         stbuf->st_mode = S_IFDIR | 0755;
@@ -100,7 +100,7 @@ err_out:
 
 static void tfs_getattr(fuse_req_t req, fuse_ino_t ino,
                         struct fuse_file_info *fi) {
-    struct stat stbuf;
+    struct fuse_stat stbuf;
 
     (void) fi;
 
@@ -122,7 +122,7 @@ static void tfs_open(fuse_req_t req, fuse_ino_t ino,
 }
 
 static void tfs_write(fuse_req_t req, fuse_ino_t ino, const char *buf,
-                      size_t size, off_t off, struct fuse_file_info *fi) {
+                      size_t size, fuse_off_t off, struct fuse_file_info *fi) {
     (void) fi; (void) buf; (void) off;
     size_t expected;
 


### PR DESCRIPTION
This PR implements the proposal in #453. The motivation/rationale behind this proposal is explained there.

The PR introduces a header `fuse_types.h` and changes the types:

- `ino_t` &#x2192; `fuse_ino_t` (this was already defined, but moved to `fuse_types.h`)
- `uid_t` &#x2192; `fuse_uid_t`
- `gid_t` &#x2192; `fuse_gid_t`
- `pid_t` &#x2192; `fuse_pid_t`
- `dev_t` &#x2192; `fuse_dev_t`
- `mode_t` &#x2192; `fuse_mode_t`
- `nlink_t` &#x2192; `fuse_nlink_t`
- `off_t` &#x2192; `fuse_off_t`
- `fsblkcnt_t` &#x2192; `fuse_fsblkcnt_t`
- `fsfilcnt_t` &#x2192; `fuse_fsfilcnt_t`
- `blksize_t` &#x2192; `fuse_blksize_t`
- `blkcnt_t` &#x2192; `fuse_blkcnt_t`
- `struct timespec` &#x2192; `struct fuse_timespec`
- `struct stat` &#x2192; `struct fuse_stat`
- `struct statvfs` &#x2192; `struct fuse_statvfs`
- `struct flock` &#x2192; `struct fuse_flock`
- `struct iovec` &#x2192; `struct fuse_iovec`

On systems such as Linux and FreeBSD which have sensible definitions of `struct stat`, etc. the FUSE "type" is simply a macro that points to the system definition:

```C
#define fuse_stat stat
```
