### PR TITLE
Implement lseek operation

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,9 @@
+Unreleased Changes
+==================
+
+* Added support for FUSE_LSEEK operation which can be used to report holes
+  in sparse files.
+
 libfuse 3.7.0 (2019-09-27)
 ==========================
 

--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -484,6 +484,28 @@ static ssize_t xmp_copy_file_range(const char *path_in,
 }
 #endif
 
+static off_t xmp_lseek(const char *path, off_t off, int whence, struct fuse_file_info *fi)
+{
+	int fd;
+	off_t res;
+
+	if (fi == NULL)
+		fd = open(path, O_RDONLY);
+	else
+		fd = fi->fh;
+
+	if (fd == -1)
+		return -errno;
+
+	res = lseek(fd, off, whence);
+	if (res == -1)
+		res = -errno;
+
+	if (fi == NULL)
+		close(fd);
+	return res;
+}
+
 static struct fuse_operations xmp_oper = {
 	.init           = xmp_init,
 	.getattr	= xmp_getattr,
@@ -522,6 +544,7 @@ static struct fuse_operations xmp_oper = {
 #ifdef HAVE_COPY_FILE_RANGE
 	.copy_file_range = xmp_copy_file_range,
 #endif
+	.lseek		= xmp_lseek,
 };
 
 int main(int argc, char *argv[])

--- a/example/passthrough_fh.c
+++ b/example/passthrough_fh.c
@@ -596,6 +596,18 @@ static ssize_t xmp_copy_file_range(const char *path_in,
 }
 #endif
 
+static off_t xmp_lseek(const char *path, off_t off, int whence, struct fuse_file_info *fi)
+{
+	off_t res;
+	(void) path;
+
+	res = lseek(fi->fh, off, whence);
+	if (res == -1)
+		return -errno;
+
+	return res;
+}
+
 static struct fuse_operations xmp_oper = {
 	.init           = xmp_init,
 	.getattr	= xmp_getattr,
@@ -643,6 +655,7 @@ static struct fuse_operations xmp_oper = {
 #ifdef HAVE_COPY_FILE_RANGE
 	.copy_file_range = xmp_copy_file_range,
 #endif
+	.lseek		= xmp_lseek,
 };
 
 int main(int argc, char *argv[])

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -1159,6 +1159,19 @@ static void lo_copy_file_range(fuse_req_t req, fuse_ino_t ino_in, off_t off_in,
 }
 #endif
 
+static void lo_lseek(fuse_req_t req, fuse_ino_t ino, off_t off, int whence,
+		     struct fuse_file_info *fi)
+{
+	off_t res;
+
+	(void)ino;
+	res = lseek(fi->fh, off, whence);
+	if (res != -1)
+		fuse_reply_lseek(req, res);
+	else
+		fuse_reply_err(req, errno);
+}
+
 static struct fuse_lowlevel_ops lo_oper = {
 	.init		= lo_init,
 	.lookup		= lo_lookup,
@@ -1196,6 +1209,7 @@ static struct fuse_lowlevel_ops lo_oper = {
 #ifdef HAVE_COPY_FILE_RANGE
 	.copy_file_range = lo_copy_file_range,
 #endif
+	.lseek		= lo_lseek,
 };
 
 int main(int argc, char *argv[])

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -776,6 +776,11 @@ struct fuse_operations {
 				    off_t offset_in, const char *path_out,
 				    struct fuse_file_info *fi_out,
 				    off_t offset_out, size_t size, int flags);
+
+	/**
+	 * Find next data or hole after the specified offset
+	 */
+	off_t (*lseek) (const char *, off_t off, int whence, struct fuse_file_info *);
 };
 
 /** Extra context that may be needed by some filesystems
@@ -1197,6 +1202,8 @@ ssize_t fuse_fs_copy_file_range(struct fuse_fs *fs, const char *path_in,
 				const char *path_out,
 				struct fuse_file_info *fi_out, off_t off_out,
 				size_t len, int flags);
+off_t fuse_fs_lseek(struct fuse_fs *fs, const char *path, off_t off, int whence,
+		    struct fuse_file_info *fi);
 void fuse_fs_init(struct fuse_fs *fs, struct fuse_conn_info *conn,
 		struct fuse_config *cfg);
 void fuse_fs_destroy(struct fuse_fs *fs);

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1218,6 +1218,27 @@ struct fuse_lowlevel_ops {
 				 fuse_ino_t ino_out, off_t off_out,
 				 struct fuse_file_info *fi_out, size_t len,
 				 int flags);
+
+	/**
+	 * Find next data or hole after the specified offset
+	 *
+	 * If this request is answered with an error code of ENOSYS, this is
+	 * treated as a permanent failure, i.e. all future lseek() requests will
+	 * fail with the same error code without being send to the filesystem
+	 * process.
+	 *
+	 * Valid replies:
+	 *   fuse_reply_lseek
+	 *   fuse_reply_err
+	 *
+	 * @param req request handle
+	 * @param ino the inode number
+	 * @param off offset to start search from
+	 * @param whence either SEEK_DATA or SEEK_HOLE
+	 * @param fi file information
+	 */
+	void (*lseek) (fuse_req_t req, fuse_ino_t ino, off_t off, int whence,
+		       struct fuse_file_info *fi);
 };
 
 /**
@@ -1568,6 +1589,18 @@ int fuse_reply_ioctl_iov(fuse_req_t req, int result, const struct iovec *iov,
  * @param revents poll result event mask
  */
 int fuse_reply_poll(fuse_req_t req, unsigned revents);
+
+/**
+ * Reply with offset
+ *
+ * Possible requests:
+ *   lseek
+ *
+ * @param req request handle
+ * @param off offset of next data or hole
+ * @return zero for success, -errno for failure to send reply
+ */
+int fuse_reply_lseek(fuse_req_t req, off_t off);
 
 /* ----------------------------------------------------------- *
  * Notification						       *

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -127,6 +127,8 @@ FUSE_3.0 {
 		fuse_cmdline_help;
 		fuse_apply_conn_info_opts;
 		fuse_parse_conn_info_opts;
+		fuse_fs_lseek;
+		fuse_reply_lseek;
 
 	local:
 		*;

--- a/lib/modules/iconv.c
+++ b/lib/modules/iconv.c
@@ -554,6 +554,19 @@ static int iconv_bmap(const char *path, size_t blocksize, uint64_t *idx)
 	return err;
 }
 
+static off_t iconv_lseek(const char *path, off_t off, int whence,
+			 struct fuse_file_info *fi)
+{
+	struct iconv *ic = iconv_get();
+	char *newpath;
+	int res = iconv_convpath(ic, path, &newpath, 0);
+	if (!res) {
+		res = fuse_fs_lseek(ic->next, newpath, off, whence, fi);
+		free(newpath);
+	}
+	return res;
+}
+
 static void *iconv_init(struct fuse_conn_info *conn,
 			struct fuse_config *cfg)
 {
@@ -612,6 +625,7 @@ static const struct fuse_operations iconv_oper = {
 	.lock		= iconv_lock,
 	.flock		= iconv_flock,
 	.bmap		= iconv_bmap,
+	.lseek		= iconv_lseek,
 };
 
 static const struct fuse_opt iconv_opts[] = {

--- a/lib/modules/subdir.c
+++ b/lib/modules/subdir.c
@@ -540,6 +540,19 @@ static int subdir_bmap(const char *path, size_t blocksize, uint64_t *idx)
 	return err;
 }
 
+static off_t subdir_lseek(const char *path, off_t off, int whence,
+			  struct fuse_file_info *fi)
+{
+	struct subdir *ic = subdir_get();
+	char *newpath;
+	int res = subdir_addpath(ic, path, &newpath);
+	if (!res) {
+		res = fuse_fs_lseek(ic->next, newpath, off, whence, fi);
+		free(newpath);
+	}
+	return res;
+}
+
 static void *subdir_init(struct fuse_conn_info *conn,
 			 struct fuse_config *cfg)
 {
@@ -594,6 +607,7 @@ static const struct fuse_operations subdir_oper = {
 	.lock		= subdir_lock,
 	.flock		= subdir_flock,
 	.bmap		= subdir_bmap,
+	.lseek		= subdir_lseek,
 };
 
 static const struct fuse_opt subdir_opts[] = {


### PR DESCRIPTION
This PR adds support for lseek API on sparse files (SEEK_DATA and SEEK_HOLE) available in kernel starting from 4.5.

Resolves: #115 