### PR TITLE
Use the -o intr mount option on FreeBSD

### DIFF
--- a/lib/mount_bsd.c
+++ b/lib/mount_bsd.c
@@ -86,6 +86,9 @@ static const struct fuse_opt fuse_mount_opts[] = {
 	FUSE_DUAL_OPT_KEY("neglect_shares",	KEY_KERN),
 	FUSE_DUAL_OPT_KEY("push_symlinks_in",	KEY_KERN),
 	FUSE_OPT_KEY("nosync_unmount",		KEY_KERN),
+#if __FreeBSD_version >= 1200519
+	FUSE_DUAL_OPT_KEY("intr",		KEY_KERN),
+#endif
 	/* stock FBSD mountopt parsing routine lets anything be negated... */
 	/*
 	 * Linux specific mount options, but let just the mount util


### PR DESCRIPTION
FUSE file systems normally indicate their interruptibility by returning
ENOSYS to the first FUSE_INTERRUPT operation.  But that causes two
problems for file systems that aren't interruptible:

1) A process may block on a signal, even if another thread could've
handled the signal.  The kernel must know whether the FUSE thread is
interruptible before deciding which thread should receive a signal.

2) The protocol allows a FUSE daemon to simply ignore FUSE_INTERRUPT
operations.  From the kernel's point of view, that is indistinguishable
from a FUSE_INTERRUPT operation arriving after the original operation
had already completed.  Thus, the kernel can't interpret an ignored
FUSE_INTERRUPT as an indication that the daemon is non-interruptible.

With the -o nointr mount option, no FUSE_INTERRUPT operations will ever
be sent.  Most FUSE file systems should require no modifications to take
advantage of this mount option.