### PR TITLE
fix memleak in cuse_lowlevel_setup

### DIFF
--- a/lib/cuse_lowlevel.c
+++ b/lib/cuse_lowlevel.c
@@ -319,6 +319,7 @@ struct fuse_session *cuse_lowlevel_setup(int argc, char *argv[],
 	if (res == -1)
 		goto err_sig;
 
+	fuse_opt_free_args(&args);
 	return se;
 
 err_sig:


### PR DESCRIPTION
Local variable args is not freed on cuse_lowlevel_setup success.
It causes memory leak:

```
==317489==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 2 object(s) allocated from:
    #0 0x7f5dfc14d048 in __interceptor_realloc (/lib64/libasan.so.5+0xf0048)
    #1 0x7f5dfbd2efe2 in fuse_opt_add_arg (/lib64/libfuse3.so.3+0x19fe2)

Indirect leak of 10 byte(s) in 2 object(s) allocated from:
    #0 0x7f5dfc098e60 in strdup (/lib64/libasan.so.5+0x3be60)
    #1 0x7f5dfbd2efc6 in fuse_opt_add_arg (/lib64/libfuse3.so.3+0x19fc6)

SUMMARY: AddressSanitizer: 42 byte(s) leaked in 4 allocation(s).
```