### PR TITLE
Add support for FUSE_EXPLICIT_INVAL_DATA

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,9 @@
+Unreleased Changes
+==========================
+
+* Added support for FUSE_EXPLICIT_INVAL_DATA to enable
+  only invalidate cached pages on explicit request.
+
 libfuse 3.8.0 (2019-11-03)
 ==========================
 

--- a/example/printcap.c
+++ b/example/printcap.c
@@ -79,6 +79,8 @@ static void pc_init(void *userdata,
 			printf("\tFUSE_CAP_POSIX_ACL\n");
 	if(conn->capable & FUSE_CAP_NO_OPENDIR_SUPPORT)
 			printf("\tFUSE_CAP_NO_OPENDIR_SUPPORT\n");
+	if(conn->capable & FUSE_CAP_EXPLICIT_INVAL_DATA)
+			printf("\tFUSE_CAP_EXPLICIT_INVAL_DATA\n");
 	fuse_session_exit(se);
 }
 

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -359,6 +359,29 @@ struct fuse_loop_config {
 #define FUSE_CAP_NO_OPENDIR_SUPPORT    (1 << 24)
 
 /**
+ * Indicates support for invalidating cached pages only on explicit request.
+ *
+ * If this flag is set in the `capable` field of the `fuse_conn_info` structure,
+ * then the FUSE kernel module supports invalidating cached pages only on
+ * explicit request by the filesystem through fuse_lowlevel_notify_inval_inode()
+ * or fuse_invalidate_path().
+ *
+ * By setting this flag in the `want` field of the `fuse_conn_info` structure,
+ * the filesystem is responsible for invalidating cached pages through explicit
+ * requests to the kernel.
+ *
+ * Note that setting this flag does not prevent the cached pages from being
+ * flushed by OS itself and/or through user actions.
+ *
+ * Note that if both FUSE_CAP_EXPLICIT_INVAL_DATA and FUSE_CAP_AUTO_INVAL_DATA
+ * are set in the `capable` field of the `fuse_conn_info` structure then
+ * FUSE_CAP_AUTO_INVAL_DATA takes precedence.
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_EXPLICIT_INVAL_DATA    (1 << 25)
+
+/**
  * Ioctl flags
  *
  * FUSE_IOCTL_COMPAT: 32bit compat ioctl on 64bit machine

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1965,6 +1965,8 @@ static void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 			se->conn.capable |= FUSE_CAP_HANDLE_KILLPRIV;
 		if (arg->flags & FUSE_NO_OPENDIR_SUPPORT)
 			se->conn.capable |= FUSE_CAP_NO_OPENDIR_SUPPORT;
+		if (arg->flags & FUSE_EXPLICIT_INVAL_DATA)
+			se->conn.capable |= FUSE_CAP_EXPLICIT_INVAL_DATA;
 		if (!(arg->flags & FUSE_MAX_PAGES)) {
 			size_t max_bufsize =
 				FUSE_DEFAULT_MAX_PAGES_PER_REQ * getpagesize()
@@ -2085,6 +2087,8 @@ static void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		outarg.flags |= FUSE_WRITEBACK_CACHE;
 	if (se->conn.want & FUSE_CAP_POSIX_ACL)
 		outarg.flags |= FUSE_POSIX_ACL;
+	if (se->conn.want & FUSE_CAP_EXPLICIT_INVAL_DATA)
+		outarg.flags |= FUSE_EXPLICIT_INVAL_DATA;
 	outarg.max_readahead = se->conn.max_readahead;
 	outarg.max_write = se->conn.max_write;
 	if (se->conn.proto_minor >= 13) {


### PR DESCRIPTION
Enable only invalidate cached pages on explicit request.
Let me know if anything needs to be changed. Thanks!

Issue: #473 