### PR TITLE
Make ioctl prototype conditional on FUSE_USE_VERSION.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,11 @@
+libfuse 3.10.0 (2019-12-14)
+==========================
+
+* Make ioctl prototype conditional on FUSE_USE_VERSION.
+  Define FUSE_USE_VERSION < 35 to get old ioctl prototype
+  with int commands; define FUSE_USE_VERSION >= 35 to get
+  new ioctl prototype with unsigned int commands.
+
 libfuse 3.9.0 (2019-12-14)
 ==========================
 

--- a/example/ioctl.c
+++ b/example/ioctl.c
@@ -22,7 +22,7 @@
  * \include ioctl.c
  */
 
-#define FUSE_USE_VERSION 31
+#define FUSE_USE_VERSION 35
 
 #include <fuse.h>
 #include <stdlib.h>

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -680,8 +680,13 @@ struct fuse_operations {
 	 * Note : the unsigned long request submitted by the application
 	 * is truncated to 32 bits.
 	 */
+#if FUSE_USE_VERSION < 35
+	int (*ioctl) (const char *, int cmd, void *arg,
+		      struct fuse_file_info *, unsigned int flags, void *data);
+#else
 	int (*ioctl) (const char *, unsigned int cmd, void *arg,
 		      struct fuse_file_info *, unsigned int flags, void *data);
+#endif
 
 	/**
 	 * Poll for IO readiness events
@@ -1189,9 +1194,15 @@ int fuse_fs_removexattr(struct fuse_fs *fs, const char *path,
 			const char *name);
 int fuse_fs_bmap(struct fuse_fs *fs, const char *path, size_t blocksize,
 		 uint64_t *idx);
+#if FUSE_USE_VERSION < 35
+int fuse_fs_ioctl(struct fuse_fs *fs, const char *path, int cmd,
+		  void *arg, struct fuse_file_info *fi, unsigned int flags,
+		  void *data);
+#else
 int fuse_fs_ioctl(struct fuse_fs *fs, const char *path, unsigned int cmd,
 		  void *arg, struct fuse_file_info *fi, unsigned int flags,
 		  void *data);
+#endif
 int fuse_fs_poll(struct fuse_fs *fs, const char *path,
 		 struct fuse_file_info *fi, struct fuse_pollhandle *ph,
 		 unsigned *reventsp);

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -14,7 +14,7 @@
  * Low level API
  *
  * IMPORTANT: you should define FUSE_USE_VERSION before including this
- * header.  To use the newest API define it to 31 (recommended for any
+ * header.  To use the newest API define it to 35 (recommended for any
  * new application).
  */
 
@@ -1018,9 +1018,15 @@ struct fuse_lowlevel_ops {
 	 * Note : the unsigned long request submitted by the application
 	 * is truncated to 32 bits.
 	 */
+#if FUSE_USE_VERSION < 35
+	void (*ioctl) (fuse_req_t req, fuse_ino_t ino, int cmd,
+		       void *arg, struct fuse_file_info *fi, unsigned flags,
+		       const void *in_buf, size_t in_bufsz, size_t out_bufsz);
+#else
 	void (*ioctl) (fuse_req_t req, fuse_ino_t ino, unsigned int cmd,
 		       void *arg, struct fuse_file_info *fi, unsigned flags,
 		       const void *in_buf, size_t in_bufsz, size_t out_bufsz);
+#endif
 
 	/**
 	 * Poll for IO readiness

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -37,7 +37,7 @@ libfuse = library('fuse3', libfuse_sources, version: meson.project_version(),
                   soversion: '3', include_directories: include_dirs,
                   dependencies: deps, install: true,
                   link_depends: 'fuse_versionscript',
-                  c_args: [ '-DFUSE_USE_VERSION=34',
+                  c_args: [ '-DFUSE_USE_VERSION=35',
                             '-DFUSERMOUNT_DIR="@0@"'.format(fusermount_path) ],
                   link_args: ['-Wl,--version-script,' + meson.current_source_dir()
                               + '/fuse_versionscript' ])

--- a/util/meson.build
+++ b/util/meson.build
@@ -11,7 +11,7 @@ executable('mount.fuse3', ['mount.fuse.c'],
            link_with: [ libfuse ],
            install: true,
            install_dir: get_option('sbindir'),
-           c_args: '-DFUSE_USE_VERSION=34')
+           c_args: '-DFUSE_USE_VERSION=35')
 
 
 udevrulesdir = get_option('udevrulesdir')


### PR DESCRIPTION
Define FUSE_USE_VERSION < 35 to get old ioctl prototype
with int commands; define FUSE_USE_VERSION >= 35 to get
new ioctl prototype with unsigned int commands.

Fixes #463.