### PR TITLE
Fixed a problem with cleaning up mount opts.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,6 +5,7 @@ libfuse 3.10.0 (2019-12-14)
   Define FUSE_USE_VERSION < 35 to get old ioctl prototype
   with int commands; define FUSE_USE_VERSION >= 35 to get
   new ioctl prototype with unsigned int commands.
+* Fixed a problem with cleaning up mount opts.
 
 libfuse 3.9.0 (2019-12-14)
 ==========================

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2975,7 +2975,8 @@ out5:
 out4:
 	fuse_opt_free_args(args);
 out3:
-	free(mo);
+	if (mo != NULL)
+		destroy_mount_opts(mo);
 out2:
 	free(se);
 out1:


### PR DESCRIPTION
There was a potential memory cleanup problem in `fuse_session_new` that this simple patch fixes.