### PR TITLE
meson_options: Add initscriptsdir option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,3 +13,5 @@ option('examples', type : 'boolean', value : true,
 option('useroot', type : 'boolean', value : true,
        description: 'Set owner and setuid bits on installed files')
 
+option('initscriptsdir', type : 'string', value : '/etc/init.d',
+       description: 'Where to install init scripts')

--- a/util/install_helper.sh
+++ b/util/install_helper.sh
@@ -10,6 +10,7 @@ sysconfdir="$1"
 bindir="$2"
 udevrulesdir="$3"
 useroot="$4"
+initscriptsdir="$5"
 
 # Both sysconfdir and bindir are absolute paths (since they are joined
 # with --prefix in meson.build), but need to be interpreted relative
@@ -40,14 +41,14 @@ install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
         "${DESTDIR}${udevrulesdir}/99-fuse3.rules"
 
 install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
-        "${DESTDIR}/etc/init.d/fuse3"
+        "${DESTDIR}${initscriptsdir}/fuse3"
 
 
 if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
     /usr/sbin/update-rc.d fuse3 start 34 S . start 41 0 6 . || /bin/true
 else
     echo "== FURTHER ACTION REQUIRED =="
-    echo "Make sure that your init system will start the ${DESTDIR}/etc/init.d/fuse3 init script"
+    echo "Make sure that your init system will start the ${DESTDIR}${initscriptsdir}/fuse3 init script"
 fi
 
 

--- a/util/meson.build
+++ b/util/meson.build
@@ -24,6 +24,7 @@ meson.add_install_script('install_helper.sh',
                          join_paths(get_option('prefix'), get_option('sysconfdir')),
                          join_paths(get_option('prefix'), get_option('bindir')),
                          udevrulesdir,
-                         '@0@'.format(get_option('useroot')))
+                         '@0@'.format(get_option('useroot')),
+                         get_option('initscriptsdir'))
 
 


### PR DESCRIPTION
Add meson option 'initscriptsdir' to explicitly define location of
system initialization scripts. 'initscriptsdir' is '/etc/init.d' by
default.
Option usage:
meson --prefix=/usr/local -Dinitscriptsdir=/custom/init.d libfuse-src-dir build-dir
DESTDIR="${PWD}/install-dir" ninja -C build-dir

As a result, init script will be installed into
"${PWD}/install-dir/custom/init.d" location.

Fixes #489