### PR TITLE
passthrough_ll: Use cache_readdir for directory open

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -630,7 +630,7 @@ static void lo_opendir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi
 
 	fi->fh = (uintptr_t) d;
 	if (lo->cache == CACHE_ALWAYS)
-		fi->keep_cache = 1;
+		fi->cache_readdir = 1;
 	fuse_reply_open(req, fi);
 	return;
 


### PR DESCRIPTION
Upstreamed from:
  https://www.redhat.com/archives/virtio-fs/2020-January/msg00106.html

Since keep_cache(FOPEN_KEEP_CACHE) has no effect for directory as
described in fuse_common.h, use cache_readdir(FOPEN_CACHE_DIR) for
directory open when cache=always mode.

Signed-off-by: Misono Tomohiro <misono.tomohiro@jp.fujitsu.com>