### PR TITLE
Remove trailing comma in enums

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -48,7 +48,7 @@ enum fuse_readdir_flags {
 	 * FUSE_FILL_DIR_FLAGS for the filler function.  The filesystem may also
 	 * just ignore this flag completely.
 	 */
-	FUSE_READDIR_PLUS = (1 << 0),
+	FUSE_READDIR_PLUS = (1 << 0)
 };
 
 enum fuse_fill_dir_flags {
@@ -61,7 +61,7 @@ enum fuse_fill_dir_flags {
 	 * It is okay to set FUSE_FILL_DIR_PLUS if FUSE_READDIR_PLUS is not set
 	 * and vice versa.
 	 */
-	FUSE_FILL_DIR_PLUS = (1 << 1),
+	FUSE_FILL_DIR_PLUS = (1 << 1)
 };
 
 /** Function to add an entry in a readdir() operation

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -635,7 +635,7 @@ enum fuse_buf_flags {
 	 * until .size bytes have been copied or an error or EOF is
 	 * detected.
 	 */
-	FUSE_BUF_FD_RETRY	= (1 << 3),
+	FUSE_BUF_FD_RETRY	= (1 << 3)
 };
 
 /**
@@ -677,7 +677,7 @@ enum fuse_buf_copy_flags {
 	 * is full or empty).  See SPLICE_F_NONBLOCK in the splice(2)
 	 * man page.
 	 */
-	FUSE_BUF_SPLICE_NONBLOCK= (1 << 4),
+	FUSE_BUF_SPLICE_NONBLOCK= (1 << 4)
 };
 
 /**

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -424,7 +424,7 @@ enum fuse_opcode {
 	FUSE_COPY_FILE_RANGE	= 47,
 
 	/* CUSE specific operations */
-	CUSE_INIT		= 4096,
+	CUSE_INIT		= 4096
 };
 
 enum fuse_notify_code {
@@ -434,7 +434,7 @@ enum fuse_notify_code {
 	FUSE_NOTIFY_STORE = 4,
 	FUSE_NOTIFY_RETRIEVE = 5,
 	FUSE_NOTIFY_DELETE = 6,
-	FUSE_NOTIFY_CODE_MAX,
+	FUSE_NOTIFY_CODE_MAX
 };
 
 /* The read buffer is required to be at least 8k, but may be much larger */


### PR DESCRIPTION
I got hit by compiler errors. They are illegal in C89/90.