### PR TITLE
examples: mark ops variables constant

### DIFF
--- a/example/hello.c
+++ b/example/hello.c
@@ -128,7 +128,7 @@ static int hello_read(const char *path, char *buf, size_t size, off_t offset,
 	return size;
 }
 
-static struct fuse_operations hello_oper = {
+static const struct fuse_operations hello_oper = {
 	.init           = hello_init,
 	.getattr	= hello_getattr,
 	.readdir	= hello_readdir,

--- a/example/hello_ll.c
+++ b/example/hello_ll.c
@@ -153,7 +153,7 @@ static void hello_ll_read(fuse_req_t req, fuse_ino_t ino, size_t size,
 	reply_buf_limited(req, hello_str, strlen(hello_str), off, size);
 }
 
-static struct fuse_lowlevel_ops hello_ll_oper = {
+static const struct fuse_lowlevel_ops hello_ll_oper = {
 	.lookup		= hello_ll_lookup,
 	.getattr	= hello_ll_getattr,
 	.readdir	= hello_ll_readdir,

--- a/example/invalidate_path.c
+++ b/example/invalidate_path.c
@@ -153,7 +153,7 @@ static int xmp_read(const char *path, char *buf, size_t size, off_t offset,
 	}
 }
 
-static struct fuse_operations xmp_oper = {
+static const struct fuse_operations xmp_oper = {
 		.init     = xmp_init,
 		.getattr  = xmp_getattr,
 		.readdir  = xmp_readdir,

--- a/example/ioctl.c
+++ b/example/ioctl.c
@@ -214,7 +214,7 @@ static int fioc_ioctl(const char *path, unsigned int cmd, void *arg,
 	return -EINVAL;
 }
 
-static struct fuse_operations fioc_oper = {
+static const struct fuse_operations fioc_oper = {
 	.getattr	= fioc_getattr,
 	.readdir	= fioc_readdir,
 	.truncate	= fioc_truncate,

--- a/example/notify_inval_entry.c
+++ b/example/notify_inval_entry.c
@@ -222,7 +222,7 @@ static void tfs_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
     }
 }
 
-static struct fuse_lowlevel_ops tfs_oper = {
+static const struct fuse_lowlevel_ops tfs_oper = {
     .lookup	= tfs_lookup,
     .getattr	= tfs_getattr,
     .readdir	= tfs_readdir,

--- a/example/notify_inval_inode.c
+++ b/example/notify_inval_inode.c
@@ -239,7 +239,7 @@ static void tfs_read(fuse_req_t req, fuse_ino_t ino, size_t size,
     reply_buf_limited(req, file_contents, file_size, off, size);
 }
 
-static struct fuse_lowlevel_ops tfs_oper = {
+static const struct fuse_lowlevel_ops tfs_oper = {
     .lookup	= tfs_lookup,
     .getattr	= tfs_getattr,
     .readdir	= tfs_readdir,

--- a/example/notify_store_retrieve.c
+++ b/example/notify_store_retrieve.c
@@ -269,7 +269,7 @@ static void tfs_retrieve_reply(fuse_req_t req, void *cookie, fuse_ino_t ino,
 }
 
 
-static struct fuse_lowlevel_ops tfs_oper = {
+static const struct fuse_lowlevel_ops tfs_oper = {
     .lookup	= tfs_lookup,
     .getattr	= tfs_getattr,
     .readdir	= tfs_readdir,

--- a/example/null.c
+++ b/example/null.c
@@ -104,7 +104,7 @@ static int null_write(const char *path, const char *buf, size_t size,
 	return size;
 }
 
-static struct fuse_operations null_oper = {
+static const struct fuse_operations null_oper = {
 	.getattr	= null_getattr,
 	.truncate	= null_truncate,
 	.open		= null_open,

--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -506,7 +506,7 @@ static off_t xmp_lseek(const char *path, off_t off, int whence, struct fuse_file
 	return res;
 }
 
-static struct fuse_operations xmp_oper = {
+static const struct fuse_operations xmp_oper = {
 	.init           = xmp_init,
 	.getattr	= xmp_getattr,
 	.access		= xmp_access,

--- a/example/passthrough_fh.c
+++ b/example/passthrough_fh.c
@@ -608,7 +608,7 @@ static off_t xmp_lseek(const char *path, off_t off, int whence, struct fuse_file
 	return res;
 }
 
-static struct fuse_operations xmp_oper = {
+static const struct fuse_operations xmp_oper = {
 	.init           = xmp_init,
 	.getattr	= xmp_getattr,
 	.access		= xmp_access,

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -1174,7 +1174,7 @@ static void lo_lseek(fuse_req_t req, fuse_ino_t ino, off_t off, int whence,
 		fuse_reply_err(req, errno);
 }
 
-static struct fuse_lowlevel_ops lo_oper = {
+static const struct fuse_lowlevel_ops lo_oper = {
 	.init		= lo_init,
 	.lookup		= lo_lookup,
 	.mkdir		= lo_mkdir,

--- a/example/poll.c
+++ b/example/poll.c
@@ -206,7 +206,7 @@ static int fsel_poll(const char *path, struct fuse_file_info *fi,
 	return 0;
 }
 
-static struct fuse_operations fsel_oper = {
+static const struct fuse_operations fsel_oper = {
 	.getattr	= fsel_getattr,
 	.readdir	= fsel_readdir,
 	.open		= fsel_open,

--- a/example/printcap.c
+++ b/example/printcap.c
@@ -85,7 +85,7 @@ static void pc_init(void *userdata,
 }
 
 
-static struct fuse_lowlevel_ops pc_oper = {
+static const struct fuse_lowlevel_ops pc_oper = {
 	.init		= pc_init,
 };
 


### PR DESCRIPTION
Placing 400 bytes read-only data into data segment is not so good, especially in examples.