### PR TITLE
Update comment for the copy_file_range operation

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -772,9 +772,10 @@ struct fuse_operations {
 	 * additional cost of transferring data through the FUSE kernel module
 	 * to user space (glibc) and then back into the FUSE filesystem again.
 	 *
-	 * In case this method is not implemented, glibc falls back to reading
-	 * data from the source and writing to the destination. Effectively
-	 * doing an inefficient copy of the data.
+	 * In case this method is not implemented, applications are expected to
+	 * fall back to a regular file copy.   (Some glibc versions did this
+	 * emulation automatically, but the emulation has been removed from all
+	 * glibc release branches.)
 	 */
 	ssize_t (*copy_file_range) (const char *path_in,
 				    struct fuse_file_info *fi_in,


### PR DESCRIPTION
copy_file_range was first implemented with copy-based emulation in
glibc 2.27, but the emulation was subsequently removed again because
correct emulation depends on why the application attempted to make a
copy.  Therefore, file systems cannot rely on low-level userspace
performing emulation.