### PR TITLE
Include limits.h because of PATH_MAX usage.

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -67,6 +67,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <limits.h>
 
 // C++ includes
 #include <cstddef>


### PR DESCRIPTION
Fixes build with musl libc on Alpine Linux.