### PR TITLE
Travis-CI: Fix ImportError: No module named 'zipp'

### DIFF
--- a/test/travis-install.sh
+++ b/test/travis-install.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+sudo python3 -m pip install --upgrade pip
 # Meson 0.45 requires Python 3.5 or newer
 sudo python3 -m pip install pytest meson==0.44
 valgrind --version


### PR DESCRIPTION
Upgrade pip to fix [*]:

  [66/66] Linking target example/passthrough_hp.
  Traceback (most recent call last):
    File "/usr/lib/python3.5/runpy.py", line 174, in _run_module_as_main
      mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
    File "/usr/lib/python3.5/runpy.py", line 133, in _get_module_details
      return _get_module_details(pkg_main_name, error)
    File "/usr/lib/python3.5/runpy.py", line 109, in _get_module_details
      __import__(pkg_name)
    File "/usr/local/lib/python3.5/dist-packages/pytest/__init__.py", line 6, in <module>
      from _pytest.assertion import register_assert_rewrite
    File "/usr/local/lib/python3.5/dist-packages/_pytest/assertion/__init__.py", line 7, in <module>
      from _pytest.assertion import rewrite
    File "/usr/local/lib/python3.5/dist-packages/_pytest/assertion/rewrite.py", line 24, in <module>
      from _pytest.assertion import util
    File "/usr/local/lib/python3.5/dist-packages/_pytest/assertion/util.py", line 14, in <module>
      import _pytest._code
    File "/usr/local/lib/python3.5/dist-packages/_pytest/_code/__init__.py", line 2, in <module>
      from .code import Code  # noqa
    File "/usr/local/lib/python3.5/dist-packages/_pytest/_code/code.py", line 28, in <module>
      import pluggy
    File "/usr/local/lib/python3.5/dist-packages/pluggy/__init__.py", line 16, in <module>
      from .manager import PluginManager, PluginValidationError
    File "/usr/local/lib/python3.5/dist-packages/pluggy/manager.py", line 11, in <module>
      import importlib_metadata
    File "/usr/local/lib/python3.5/dist-packages/importlib_metadata/__init__.py", line 9, in <module>
      import zipp
  ImportError: No module named 'zipp'
  The command "test/travis-build.sh" exited with 1.

[*] https://travis-ci.org/libfuse/libfuse/builds/651523034

Signed-off-by: Philippe Mathieu-Daudé <philmd@redhat.com>