### PR TITLE
meson.build: libfuse is a C only project

### DIFF
--- a/example/meson.build
+++ b/example/meson.build
@@ -31,7 +31,7 @@ foreach ex : threaded_examples
                install: false)
 endforeach
 
-if not platform.endswith('bsd') and platform != 'dragonfly'
+if not platform.endswith('bsd') and platform != 'dragonfly' and add_languages('cpp', required : false)
     executable('passthrough_hp', 'passthrough_hp.cc',
                dependencies: [ thread_dep, libfuse_dep ],
                install: false)

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libfuse3', ['cpp', 'c'], version: '3.9.1',
+project('libfuse3', ['c'], version: '3.9.1',
         meson_version: '>= 0.42',
         default_options: [ 'buildtype=debugoptimized' ])
 


### PR DESCRIPTION
Do not mandate cpp otherwise build without a C++ compiler will fail on:

```
../output-1/build/libfuse3-3.9.1/meson.build:1:0: ERROR: Unknown compiler(s): [['/home/buildroot/autobuild/instance-2/output-1/host/bin/microblazeel-buildroot-linux-uclibc-g++']]
The follow exceptions were encountered:
Running "/home/buildroot/autobuild/instance-2/output-1/host/bin/microblazeel-buildroot-linux-uclibc-g++ --version" gave "[Errno 2] No such file or directory: '/home/buildroot/autobuild/instance-2/output-1/host/bin/microblazeel-buildroot-linux-uclibc-g++'"
```

Fixes:
 - http://autobuild.buildroot.org/results/a6e64213f2910b2b81e79cb1e96e558413d7f70a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>