### PR TITLE
Avoid closing se->fd twice in fuse_lowlevel.c

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3040,6 +3040,7 @@ void fuse_session_unmount(struct fuse_session *se)
 {
 	if (se->mountpoint != NULL) {
 		fuse_kern_unmount(se->mountpoint, se->fd);
+		se->fd = -1;
 		free(se->mountpoint);
 		se->mountpoint = NULL;
 	}


### PR DESCRIPTION
If fuse_session_unmount is called before fuse_session_destroy, both
would try to close(se->fd). Avoid that by resetting it in
fuse_session_unmount.