### PR TITLE
Minor print alignment in iconv_help()

### DIFF
--- a/lib/modules/iconv.c
+++ b/lib/modules/iconv.c
@@ -644,7 +644,7 @@ static void iconv_help(void)
 	free(old);
 	printf(
 "    -o from_code=CHARSET   original encoding of file names (default: UTF-8)\n"
-"    -o to_code=CHARSET	    new encoding of the file names (default: %s)\n",
+"    -o to_code=CHARSET     new encoding of the file names (default: %s)\n",
 		charmap);
 	free(charmap);
 }


### PR DESCRIPTION
Fixed minor print alignment issue in iconv_help(), replacing tab with space

Old
![image](https://user-images.githubusercontent.com/58009229/84963302-da89e880-b0bd-11ea-9357-99a974149dbc.png)

New
![image](https://user-images.githubusercontent.com/58009229/84963271-c219ce00-b0bd-11ea-99ff-51eab5df1a97.png)
