### PR TITLE
libfuse: Assign NULL to "old" to avoid free it twice

### DIFF
--- a/lib/modules/iconv.c
+++ b/lib/modules/iconv.c
@@ -705,6 +705,7 @@ static struct fuse_fs *iconv_new(struct fuse_args *args,
 	if (old) {
 		setlocale(LC_CTYPE, old);
 		free(old);
+		old = NULL;
 	}
 
 	ic->next = next[0];


### PR DESCRIPTION
Assign NULL to "old" at the first free(), to avoid the possible 2nd free() for it.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>