### PR TITLE
fuse_lowlevel: Remove useless NULL assert for se

### DIFF
--- a/doc/mount.fuse3.8
+++ b/doc/mount.fuse3.8
@@ -126,7 +126,7 @@ default is the name of the filesystem process.
 Sets the filesystem type (third field in \fI/etc/mtab\fP). The default
 is the name of the filesystem process. If the kernel suppports it, \fI/etc/mtab\fP and \fI/proc/mounts\fP will show the filesystem type as \fBfuse.TYPE\fP
 
-If the kernel doesn't support subtypes, the source filed will be
+If the kernel doesn't support subtypes, the source field will be
 \fBTYPE#NAME\fP, or if \fBfsname\fP option is not specified, just
 \fBTYPE\fP.
 

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -189,8 +189,6 @@ static int fuse_send_msg(struct fuse_session *se, struct fuse_chan *ch,
 	int err = errno;
 
 	if (res == -1) {
-		assert(se != NULL);
-
 		/* ENOENT means the operation was interrupted */
 		if (!fuse_session_exited(se) && err != ENOENT)
 			perror("fuse: writing device");


### PR DESCRIPTION
Remove useless NULL assert for se.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>