### PR TITLE
Fix the typo "filed" -> "field" in fuse manpage

### DIFF
--- a/doc/mount.fuse3.8
+++ b/doc/mount.fuse3.8
@@ -126,7 +126,7 @@ default is the name of the filesystem process.
 Sets the filesystem type (third field in \fI/etc/mtab\fP). The default
 is the name of the filesystem process. If the kernel suppports it, \fI/etc/mtab\fP and \fI/proc/mounts\fP will show the filesystem type as \fBfuse.TYPE\fP
 
-If the kernel doesn't support subtypes, the source filed will be
+If the kernel doesn't support subtypes, the source field will be
 \fBTYPE#NAME\fP, or if \fBfsname\fP option is not specified, just
 \fBTYPE\fP.
 


### PR DESCRIPTION
Fix the typo "filed" -> "field" in fuse manpage.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>