### PR TITLE
fuse_lowlevel: Remove useless NULL assert for se

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -189,8 +189,6 @@ static int fuse_send_msg(struct fuse_session *se, struct fuse_chan *ch,
 	int err = errno;
 
 	if (res == -1) {
-		assert(se != NULL);
-
 		/* ENOENT means the operation was interrupted */
 		if (!fuse_session_exited(se) && err != ENOENT)
 			perror("fuse: writing device");


### PR DESCRIPTION
Remove useless NULL assert for se.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>