### PR TITLE
Define fuse_session_loop_mt as a macro on uclibc and MacOS

### DIFF
--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -471,7 +471,7 @@ struct fuse_lowlevel_ops {
 	 *  - When writeback caching is disabled, the filesystem is
 	 *    expected to properly handle the O_APPEND flag and ensure
 	 *    that each write is appending to the end of the file.
-	 *
+	 * 
          *  - When writeback caching is enabled, the kernel will
 	 *    handle O_APPEND. However, unless all changes to the file
 	 *    come through the kernel this will not work reliably. The
@@ -1975,7 +1975,7 @@ int fuse_session_loop(struct fuse_session *se);
  * fuse_session_loop().
  *
  * @param se the session
- * @param config session loop configuration
+ * @param config session loop configuration 
  * @return see fuse_session_loop()
  */
 #if FUSE_USE_VERSION < 32

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -471,7 +471,7 @@ struct fuse_lowlevel_ops {
 	 *  - When writeback caching is disabled, the filesystem is
 	 *    expected to properly handle the O_APPEND flag and ensure
 	 *    that each write is appending to the end of the file.
-	 * 
+	 *
          *  - When writeback caching is enabled, the kernel will
 	 *    handle O_APPEND. However, unless all changes to the file
 	 *    come through the kernel this will not work reliably. The
@@ -1975,14 +1975,19 @@ int fuse_session_loop(struct fuse_session *se);
  * fuse_session_loop().
  *
  * @param se the session
- * @param config session loop configuration 
+ * @param config session loop configuration
  * @return see fuse_session_loop()
  */
 #if FUSE_USE_VERSION < 32
 int fuse_session_loop_mt_31(struct fuse_session *se, int clone_fd);
 #define fuse_session_loop_mt(se, clone_fd) fuse_session_loop_mt_31(se, clone_fd)
 #else
+#if (!defined(__UCLIBC__) && !defined(__APPLE__))
 int fuse_session_loop_mt(struct fuse_session *se, struct fuse_loop_config *config);
+#else
+int fuse_session_loop_mt_32(struct fuse_session *se, struct fuse_loop_config *config);
+#define fuse_session_loop_mt(se, config) fuse_session_loop_mt_32(se, config)
+#endif
 #endif
 
 /**

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -146,6 +146,7 @@ FUSE_3.2 {
 	global:
 		fuse_session_loop_mt;
 		fuse_session_loop_mt_31;
+                fuse_session_loop_mt_32;
 		fuse_loop_mt;
 		fuse_loop_mt_31;
 } FUSE_3.1;

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -146,7 +146,7 @@ FUSE_3.2 {
 	global:
 		fuse_session_loop_mt;
 		fuse_session_loop_mt_31;
-                fuse_session_loop_mt_32;
+		fuse_session_loop_mt_32;
 		fuse_loop_mt;
 		fuse_loop_mt_31;
 } FUSE_3.1;


### PR DESCRIPTION
On uclibc and MacOS we don't use versioned symbols. Hence,
there's no definition for fuse_session_loop_mt on those cases
and the linker won't be able to resolve calls to fuse_session_loop_mt()

Signed-off-by: Asaf Kahlon <asafka7@gmail.com>