### PR TITLE
Fixed typo in command to compile program

### DIFF
--- a/example/printcap.c
+++ b/example/printcap.c
@@ -13,7 +13,7 @@
  *
  * Compile with:
  *
- *     gcc -Wall protocol_info.c `pkg-config fuse3 --cflags --libs` -o protocol_info
+ *     gcc -Wall printcap.c `pkg-config fuse3 --cflags --libs` -o printcap
  *
  * ## Source code ##
  * \include @file


### PR DESCRIPTION
Fixed a typo in the command specified to compile the given program.