### PR TITLE
Implement GCC 10 style symbol versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: bionic
 
 language:
     - c
@@ -13,8 +13,10 @@ addons:
     - valgrind
     - clang
     - libstdc++-7-dev 
+    - libstdc++-10-dev
     - gcc
     - gcc-7
+    - gcc-10
     - python3-pip
     - python3-setuptools
     - ninja-build

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4569,7 +4569,7 @@ int fuse_loop(struct fuse *f)
 	return fuse_session_loop(f->se);
 }
 
-FUSE_SYMVER(".symver fuse_loop_mt_32,fuse_loop_mt@@FUSE_3.2");
+FUSE_SYMVER("fuse_loop_mt_32", "fuse_loop_mt@@FUSE_3.2")
 int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config *config)
 {
 	if (f == NULL)
@@ -4585,7 +4585,7 @@ int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config *config)
 }
 
 int fuse_loop_mt_31(struct fuse *f, int clone_fd);
-FUSE_SYMVER(".symver fuse_loop_mt_31,fuse_loop_mt@FUSE_3.0");
+FUSE_SYMVER("fuse_loop_mt_31", "fuse_loop_mt@FUSE_3.0")
 int fuse_loop_mt_31(struct fuse *f, int clone_fd)
 {
 	struct fuse_loop_config config;
@@ -4870,7 +4870,7 @@ void fuse_stop_cleanup_thread(struct fuse *f)
 }
 
 
-FUSE_SYMVER(".symver fuse_new_31,fuse_new@@FUSE_3.1");
+FUSE_SYMVER("fuse_new_31", "fuse_new@@FUSE_3.1")
 struct fuse *fuse_new_31(struct fuse_args *args,
 		      const struct fuse_operations *op,
 		      size_t op_size, void *user_data)
@@ -5024,7 +5024,7 @@ out:
 /* Emulates 3.0-style fuse_new(), which processes --help */
 struct fuse *fuse_new_30(struct fuse_args *args, const struct fuse_operations *op,
 			 size_t op_size, void *private_data);
-FUSE_SYMVER(".symver fuse_new_30,fuse_new@FUSE_3.0");
+FUSE_SYMVER("fuse_new_30", "fuse_new@FUSE_3.0")
 struct fuse *fuse_new_30(struct fuse_args *args,
 			 const struct fuse_operations *op,
 			 size_t op_size, void *user_data)

--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -304,7 +304,7 @@ static void fuse_join_worker(struct fuse_mt *mt, struct fuse_worker *w)
 	free(w);
 }
 
-FUSE_SYMVER(".symver fuse_session_loop_mt_32,fuse_session_loop_mt@@FUSE_3.2");
+FUSE_SYMVER("fuse_session_loop_mt_32", "fuse_session_loop_mt@@FUSE_3.2")
 int fuse_session_loop_mt_32(struct fuse_session *se, struct fuse_loop_config *config)
 {
 	int err;
@@ -352,7 +352,7 @@ int fuse_session_loop_mt_32(struct fuse_session *se, struct fuse_loop_config *co
 }
 
 int fuse_session_loop_mt_31(struct fuse_session *se, int clone_fd);
-FUSE_SYMVER(".symver fuse_session_loop_mt_31,fuse_session_loop_mt@FUSE_3.0");
+FUSE_SYMVER("fuse_session_loop_mt_31", "fuse_session_loop_mt@FUSE_3.0")
 int fuse_session_loop_mt_31(struct fuse_session *se, int clone_fd)
 {
 	struct fuse_loop_config config;

--- a/lib/fuse_misc.h
+++ b/lib/fuse_misc.h
@@ -20,7 +20,7 @@
 #  define FUSE_SYMVER(sym1, sym2) __asm__("\t.symver " sym1 "," sym2);
 # endif
 #else
-#define FUSE_SYMVER(sym2)
+#define FUSE_SYMVER(sym1, sym2)
 #endif
 
 #ifndef USE_UCLIBC

--- a/lib/fuse_misc.h
+++ b/lib/fuse_misc.h
@@ -14,9 +14,13 @@
     - not supported on MacOSX (in MachO binary format)
 */
 #if (!defined(__UCLIBC__) && !defined(__APPLE__))
-#define FUSE_SYMVER(x) __asm__(x)
+# if HAVE_SYMVER_ATTRIBUTE
+#  define FUSE_SYMVER(sym1, sym2) __attribute__ ((symver (sym2)))
+# else
+#  define FUSE_SYMVER(sym1, sym2) __asm__("\t.symver " sym1 "," sym2);
+# endif
 #else
-#define FUSE_SYMVER(x)
+#define FUSE_SYMVER(sym2)
 #endif
 
 #ifndef USE_UCLIBC

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,23 @@ if not cc.compiles(code, args: [ '-O0', '-Werror=unused-result' ])
      add_project_arguments('-Wno-unused-result', language: 'c')
 endif
 
+# gcc-10 and newer support the symver attribute which we need to use if we
+# want to support LTO
+code = '''
+__attribute__((symver ("get@@TEST_0"))) int get_4() {
+    return 4;
+}
+int main(void) {
+    (void) get_4();
+    return 0;
+}'''
+if cc.compiles(code, args: [ '-O0', '-c'])
+     message('Compiler supports symver attribute')
+     add_project_arguments('-DHAVE_SYMVER_ATTRIBUTE', language: 'c')
+else
+     message('Compiler does not support symver attribute')
+endif
+
 # '.' will refer to current build directory, which contains config.h
 include_dirs = include_directories('include', 'lib', '.')
 

--- a/test/travis-build.sh
+++ b/test/travis-build.sh
@@ -25,13 +25,18 @@ chmod 0755 "${TEST_DIR}"
 cd "${TEST_DIR}"
 
 # Standard build
-for CC in gcc gcc-7 clang; do
+for CC in gcc gcc-7 gcc-10 clang; do
     mkdir build-${CC}; cd build-${CC}
     if [ "${CC}" == "clang" ]; then
         export CXX="clang++"
     fi
     if [ ${CC} == 'gcc-7' ]; then
         build_opts='-D b_lundef=false'
+    else
+        build_opts=''
+    fi
+    if [ ${CC} == 'gcc-10' ]; then
+        build_opts='-Dc_args="-flto=auto -ffat-lto-objects"'
     else
         build_opts=''
     fi


### PR DESCRIPTION
Previously, libfuse was using top level ASM constructs to implement symbol versioning. These constructs are incompatible with Link Time Optimization (LTO). GCC v10 introduces a new mechanism for symbol versioning which works with LTO.

This PR adds a meson check to verify that the build compiler supports the symver attribute and if not, falls back to the ASM constructs.

I am submitting this change on behalf of Jeff Law <law@redhat.com> with his permission.