### PR TITLE
rework this code to be correct in all known cases

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,8 +95,12 @@ endif
 # it is safe for this check to fail and for us to fallback to the old _asm_
 # method for symver
 code = '''
-#if defined __has_attribute && !__has_attribute (symver)
-#error symver attribute not supported
+#if defined __has_attribute
+# if !__has_attribute (symver)
+# error symver attribute not supported
+# endif
+#else
+#error __has_attribute not defined, assume we do not have symver
 #endif
 
 int main(void) {


### PR DESCRIPTION
Woke up this morning and realized I had not quite gotten this conditional right. If __has_attribute is not defined by the compiler, we want to #error out of the check, not pass it. This change addresses that case properly (I didn't catch it before because no modern compiler that I am aware of does not support __has_attribute, but it is possible that old Linux or non-Linux OSes would not.