### PR TITLE
Fix several fd leakage problems 、memory leakage problems and accessing NULL pointer problems

### DIFF
--- a/example/cuse_client.c
+++ b/example/cuse_client.c
@@ -121,16 +121,17 @@ int main(int argc, char **argv)
 		if (!argc) {
 			if (ioctl(fd, FIOC_GET_SIZE, &size)) {
 				perror("ioctl");
-				return 1;
+				goto error;
 			}
 			printf("%zu\n", size);
 		} else {
 			size = param[0];
 			if (ioctl(fd, FIOC_SET_SIZE, &size)) {
 				perror("ioctl");
-				return 1;
+				goto error;
 			}
 		}
+		close(fd);
 		return 0;
 
 	case 'r':
@@ -138,13 +139,18 @@ int main(int argc, char **argv)
 		rc = do_rw(fd, cmd == 'r', param[0], param[1],
 			   &prev_size, &new_size);
 		if (rc < 0)
-			return 1;
+			goto error;
 		fprintf(stderr, "transferred %d bytes (%zu -> %zu)\n",
 			rc, prev_size, new_size);
+		close(fd);
 		return 0;
 	}
 
- usage:
+usage:
 	fprintf(stderr, "%s", usage);
+	return 1;
+
+error:
+	close(fd);
 	return 1;
 }

--- a/example/ioctl_client.c
+++ b/example/ioctl_client.c
@@ -41,6 +41,7 @@ int main(int argc, char **argv)
 {
 	size_t size;
 	int fd;
+	int ret = 0;
 
 	if (argc < 2) {
 		fprintf(stderr, "%s", usage);
@@ -56,15 +57,19 @@ int main(int argc, char **argv)
 	if (argc == 2) {
 		if (ioctl(fd, FIOC_GET_SIZE, &size)) {
 			perror("ioctl");
-			return 1;
+			ret = 1;
+			goto out;
 		}
 		printf("%zu\n", size);
 	} else {
 		size = strtoul(argv[2], NULL, 0);
 		if (ioctl(fd, FIOC_SET_SIZE, &size)) {
 			perror("ioctl");
-			return 1;
+			ret = 1;
+			goto out;
 		}
 	}
-	return 0;
+out:
+	close(fd);
+	return ret;
 }

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -266,6 +266,9 @@ static int fuse_bufvec_advance(struct fuse_bufvec *bufv, size_t len)
 {
 	const struct fuse_buf *buf = fuse_bufvec_current(bufv);
 
+	if (!buf)
+		return 1;
+
 	bufv->off += len;
 	assert(bufv->off <= buf->size);
 	if (bufv->off == buf->size) {

--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -779,6 +779,7 @@ static int test_copy_file_range(void)
 	res = close(fd_in);
 	if (res == -1) {
 		PERROR("close");
+		close(fd_out);
 		return -1;
 	}
 	res = close(fd_out);
@@ -932,8 +933,10 @@ static int test_create_unlink(void)
 		return -1;
 	}
 	res = check_nonexist(testfile);
-	if (res == -1)
+	if (res == -1) {
+		close(fd);
 		return -1;
+	}
 	res = write(fd, data, datalen);
 	if (res == -1) {
 		PERROR("write");
@@ -1766,8 +1769,10 @@ static int test_socket(void)
 	}
 
 	res = check_type(testsock, S_IFSOCK);
-	if (res == -1)
+	if (res == -1) {
+		close(fd);
 		return -1;
+	}
 	err += check_nlink(testsock, 1);
 	close(fd);
 	res = unlink(testsock);

--- a/util/mount.fuse.c
+++ b/util/mount.fuse.c
@@ -233,6 +233,7 @@ int main(int argc, char *argv[])
 {
 	char *type = NULL;
 	char *source;
+	char *dup_source = NULL;
 	const char *mountpoint;
 	char *basename;
 	char *options = NULL;
@@ -243,6 +244,7 @@ int main(int argc, char *argv[])
 	int suid = 1;
 	int pass_fuse_fd = 0;
 	int drop_privileges = 0;
+	char *dev_fd_mountpoint = NULL;
 
 	progname = argv[0];
 	basename = strrchr(argv[0], '/');
@@ -340,6 +342,7 @@ int main(int argc, char *argv[])
 				}
 				opt = strtok(NULL, ",");
 			}
+			free(opts);
 		}
 	}
 
@@ -360,7 +363,8 @@ int main(int argc, char *argv[])
 
 	if (!type) {
 		if (source) {
-			type = xstrdup(source);
+			dup_source = xstrdup(source);
+			type = dup_source;
 			source = strchr(type, '#');
 			if (source)
 				*source++ = '\0';
@@ -410,7 +414,7 @@ int main(int argc, char *argv[])
 
 	if (pass_fuse_fd)  {
 		int fuse_fd = prepare_fuse_fd(mountpoint, type, options);
-		char *dev_fd_mountpoint = xrealloc(NULL, 20);
+		dev_fd_mountpoint = xrealloc(NULL, 20);
 		snprintf(dev_fd_mountpoint, 20, "/dev/fd/%u", fuse_fd);
 		mountpoint = dev_fd_mountpoint;
 	}
@@ -428,6 +432,11 @@ int main(int argc, char *argv[])
 		add_arg(&command, "-o");
 		add_arg(&command, options);
 	}
+
+	free(options);
+	free(dev_fd_mountpoint);
+	free(dup_source);
+	free(setuid_name);
 
 	execl("/bin/sh", "/bin/sh", "-c", command, NULL);
 	fprintf(stderr, "%s: failed to execute /bin/sh: %s\n", progname,

--- a/util/mount.fuse.c
+++ b/util/mount.fuse.c
@@ -398,7 +398,7 @@ int main(int argc, char *argv[])
 #endif
 
 		struct passwd *pwd = getpwnam(setuid_name);
-		if (setgid(pwd->pw_gid) == -1 || setuid(pwd->pw_uid) == -1) {
+		if (!pwd || setgid(pwd->pw_gid) == -1 || setuid(pwd->pw_uid) == -1) {
 			fprintf(stderr, "%s: Failed to setuid to %s: %s\n",
 				progname, setuid_name, strerror(errno));
 			exit(1);


### PR DESCRIPTION
Coverity checker reports several kinds of problesm: 
1. fd leakage problems
2. memory leakage problems
3. accessing NULL pointer problems

In this pr, we fix these problems to make coverity checker happy.

Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>
Signed-off-by: Haotian Li <lihaotian9@huawei.com>
