### PR TITLE
buffer.c: correct return value when buf is NULL

### DIFF
--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -267,7 +267,7 @@ static int fuse_bufvec_advance(struct fuse_bufvec *bufv, size_t len)
 	const struct fuse_buf *buf = fuse_bufvec_current(bufv);
 
 	if (!buf)
-		return 1;
+		return 0;
 
 	bufv->off += len;
 	assert(bufv->off <= buf->size);


### PR DESCRIPTION
In commit d614415a ("buffer.c: check whether buf is
NULL in fuse_bufvec_advance func"), if fuse_bufvec_current
func returns NULL, it returns 1 directly. Actually,
we should return 0 when buf is NULL.

Fixes: d614415a ("buffer.c: check whether buf is NULL in fuse_bufvec_advance func")
Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>
Signed-off-by: Haotian Li <lihaotian9@huawei.com>