### PR TITLE
fix errno comparison

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4533,7 +4533,7 @@ static int fuse_session_loop_remember(struct fuse *f)
 
 		res = poll(&fds, 1, timeout * 1000);
 		if (res == -1) {
-			if (errno == -EINTR)
+			if (errno == EINTR)
 				continue;
 			else
 				break;


### PR DESCRIPTION
this affected `-o remember` in single-thread mode, it could prematurely exit if a signal was received

```sh
# start an example filesystem from example/
./passthrough -f -s -o remember=5 ./mnt

# make the poll() call return with EINTR
pkill -PIPE passthrough
```