### PR TITLE
examples/cuse_client: add include file to eliminate compiler warning

### DIFF
--- a/example/cuse_client.c
+++ b/example/cuse_client.c
@@ -45,6 +45,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
+#include <unistd.h>
 #include "ioctl.h"
 
 const char *usage =

--- a/example/ioctl_client.c
+++ b/example/ioctl_client.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
+#include <unistd.h>
 #include "ioctl.h"
 
 const char *usage =


### PR DESCRIPTION
Compiler warning about close(fd), add include file to fix.
Fix issue#567

Signed-off-by: haoyixing <haoyixing@kuaishou.com>