### PR TITLE
Fix FUSE_COPY_FILE_RANGE in the passthrough example

### DIFF
--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -477,8 +477,10 @@ static ssize_t xmp_copy_file_range(const char *path_in,
 	if (res == -1)
 		res = -errno;
 
-	close(fd_in);
-	close(fd_out);
+	if (fi_out == NULL)
+		close(fd_out);
+	if (fi_in == NULL)
+		close(fd_in);
 
 	return res;
 }


### PR DESCRIPTION
Only close the file descriptors if they were just opened.  Otherwise,
the second FUSE_COPY_FILE_RANGE operation on any given file will fail
with EBADF.