### PR TITLE
fusermount: Check for argv[0] being present

### DIFF
--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1291,7 +1291,7 @@ int main(int argc, char *argv[])
 		{"version", no_argument, NULL, 'V'},
 		{0, 0, 0, 0}};
 
-	progname = strdup(argv[0]);
+	progname = strdup(argc > 0 ? argv[0] : "fusermount");
 	if (progname == NULL) {
 		fprintf(stderr, "%s: failed to allocate memory\n", argv[0]);
 		exit(1);


### PR DESCRIPTION
It is perfectly legal to execute a program with argc == 0 and therefore
no argv.
fusermount needs to check for this case, otherwise it will pass a NULL
poiunter to strdup() and cause undefined behavior.
Especially since fusermount is setuid root, we need to extra be careful.

Signed-off-by: Richard Weinberger <richard@nod.at>