### PR TITLE
Ignore "-o nonempty"

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,10 @@
+Unreleased Changes
+==================
+
+* Allow "nonempty" as a mount option, for backwards compatibility with
+  fusermount 2. The option has no effect since mounting over non-empty
+  directories is allowed by default.
+
 libfuse 3.10.1 (2020-12-07)
 ===========================
 

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -773,7 +773,8 @@ static int do_mount(const char *mnt, const char **typep, mode_t rootmode,
 			blkdev = 1;
 		} else if (opt_eq(s, len, "auto_unmount")) {
 			auto_unmount = 1;
-		} else if (!begins_with(s, "fd=") &&
+		} else if (!opt_eq(s, len, "nonempty") &&
+			   !begins_with(s, "fd=") &&
 			   !begins_with(s, "rootmode=") &&
 			   !begins_with(s, "user_id=") &&
 			   !begins_with(s, "group_id=")) {


### PR DESCRIPTION
Commit 0bef21e8543d removed "-o nonempty" since mounting over
non-empty directories is always allowed. But this broke tools which
specify "-o nonempty". Since the expected behaviour is the same
anyway, ignoring the "nonempty" option seems safe, and allows programs
specifying "-o nonempty" to continue working with fusermount3.

This would fix https://bugs.debian.org/939767

Signed-off-by: Stephen Kitt <steve@sk2.org>