### PR TITLE
Remove unused fuse_worker bufsize

### DIFF
--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -32,7 +32,6 @@ struct fuse_worker {
 	struct fuse_worker *prev;
 	struct fuse_worker *next;
 	pthread_t thread_id;
-	size_t bufsize;
 
 	// We need to include fuse_buf so that we can properly free
 	// it when a thread is terminated by pthread_cancel().


### PR DESCRIPTION
Remove unused fuse_worker bufsize which is not used since https://github.com/libfuse/libfuse/commit/561d7054d856eea6c2d634093546d6af773dada9