### PR TITLE
install_helper: fix sysconf dir for init.d script

### DIFF
--- a/util/install_helper.sh
+++ b/util/install_helper.sh
@@ -38,16 +38,3 @@ fi
 
 install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
         "${DESTDIR}${udevrulesdir}/99-fuse3.rules"
-
-install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
-        "${DESTDIR}/etc/init.d/fuse3"
-
-
-if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
-    /usr/sbin/update-rc.d fuse3 start 34 S . start 41 0 6 . || /bin/true
-else
-    echo "== FURTHER ACTION REQUIRED =="
-    echo "Make sure that your init system will start the ${DESTDIR}/etc/init.d/fuse3 init script"
-fi
-
-


### PR DESCRIPTION
Fixes the following build error in Buildroot as a host package:

```
Running custom install script 'install_helper.sh /host/etc /host/bin /host/lib/udev/rules.d false
+ sysconfdir=/host/etc
+ bindir=/host/bin
+ udevrulesdir=/host/lib/udev/rules.d
+ useroot=false
+ '[' -z '' ']'
+ DESTDIR=
+ install -D -m 644 /build/host-libfuse3-3.10.3/util/fuse.conf /host/etc/fuse.conf
+ false
+ install -D -m 644 /build/host-libfuse3-3.10.3/util/udev.rules /host/lib/udev/rules.d/99-fuse3.rules
+ install -D -m 755 /build/host-libfuse3-3.10.3/util/init_script /etc/init.d/fuse3
install: cannot create regular file '/etc/init.d/fuse3': Permission denied
FAILED: install script 'install_helper.sh /host/etc /host/bin /host/lib/udev/rules.d false' exit code 1, stopped
FAILED: meson-install
```

As far as I can tell, this is correct - and the current implementation is wrong - because it should be installing the init.d script to sysconfdir.