### PR TITLE
fusermount3.1: refer to mount.fuse3

### DIFF
--- a/doc/fusermount3.1
+++ b/doc/fusermount3.1
@@ -29,7 +29,7 @@ lazy unmount.
 
 .SH SEE ALSO
 \fImount\fR(8),
-\fImount.fuse\fR(8),
+\fImount.fuse3\fR(8),
 
 .SH HOMEPAGE
 More information about fusermount3 and the FUSE project can be found at <\fIhttp://fuse.sourceforge.net/\fR>.


### PR DESCRIPTION
mount.fuse was renamed to mount.fuse3.