### PR TITLE
doc: Add "fuse (4)" to SEE ALSO sections in man pages

### DIFF
--- a/doc/fusermount3.1
+++ b/doc/fusermount3.1
@@ -30,6 +30,7 @@ lazy unmount.
 .SH SEE ALSO
 \fImount\fR(8),
 \fImount.fuse3\fR(8),
+\fIfuse\fR(4),
 
 .SH HOMEPAGE
 More information about fusermount3 and the FUSE project can be found at <\fIhttp://fuse.sourceforge.net/\fR>.

--- a/doc/mount.fuse3.8
+++ b/doc/mount.fuse3.8
@@ -255,3 +255,4 @@ Debian GNU/Linux distribution.
 .BR fusermount3 (1)
 .BR fusermount (1)
 .BR mount (8)
+.BR fuse (4)


### PR DESCRIPTION
fuse (4) is an excellent introduction to the FUSE protocol,
and it lists fusermount (1) and mount.fuse (8) in its
SEE ALSO section.

I (the author of gocryptfs) was not aware of this man
page till March 2021, which suggest that it should be
made more discoverable.

So link back to fuse (4) in our SEE ALSO sections.