### PR TITLE
Fix memory leaks in examples

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -1126,7 +1126,11 @@ static cxxopts::ParseResult parse_options(int argc, char **argv) {
 
     fs.debug = options.count("debug") != 0;
     fs.nosplice = options.count("nosplice") != 0;
-    fs.source = std::string {realpath(argv[1], NULL)};
+    char* resolved_path = realpath(argv[1], NULL);
+    if (resolved_path == NULL)
+        warn("WARNING: realpath() failed with");
+    fs.source = std::string {resolved_path};
+    free(resolved_path);
 
     return options;
 }

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -171,6 +171,17 @@ static void lo_init(void *userdata,
 	}
 }
 
+static void lo_destroy(void *userdata)
+{
+	struct lo_data *lo = (struct lo_data*) userdata;
+
+	while (lo->root.next != &lo->root) {
+		struct lo_inode* next = lo->root.next;
+		lo->root.next = next->next;
+		free(next);
+	}
+}
+
 static void lo_getattr(fuse_req_t req, fuse_ino_t ino,
 			     struct fuse_file_info *fi)
 {
@@ -1113,6 +1124,7 @@ static void lo_lseek(fuse_req_t req, fuse_ino_t ino, off_t off, int whence,
 
 static const struct fuse_lowlevel_ops lo_oper = {
 	.init		= lo_init,
+	.destroy	= lo_destroy,
 	.lookup		= lo_lookup,
 	.mkdir		= lo_mkdir,
 	.mknod		= lo_mknod,


### PR DESCRIPTION
This PR fixes two memory leaks in the examples `passthrough_hp` and `passthrough_ll`. These leaks were found using address sanitizer. Now, the only remaining leaks detected by asan are located in the option parser logic.