### PR TITLE
Define FUSE_USE_VERSION in Doxygen.

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -987,7 +987,7 @@ INCLUDE_FILE_PATTERNS  =
 # undefined via #undef or recursively expanded use the := operator
 # instead of the = operator.
 
-PREDEFINED             =
+PREDEFINED             = FUSE_USE_VERSION=35
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then
 # this tag can be used to specify a list of macro names that should be expanded.

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -990,6 +990,11 @@ struct fuse_lowlevel_ops {
 	void (*bmap) (fuse_req_t req, fuse_ino_t ino, size_t blocksize,
 		      uint64_t idx);
 
+#if FUSE_USE_VERSION < 35
+	void (*ioctl) (fuse_req_t req, fuse_ino_t ino, int cmd,
+		       void *arg, struct fuse_file_info *fi, unsigned flags,
+		       const void *in_buf, size_t in_bufsz, size_t out_bufsz);
+#else
 	/**
 	 * Ioctl
 	 *
@@ -1018,11 +1023,6 @@ struct fuse_lowlevel_ops {
 	 * Note : the unsigned long request submitted by the application
 	 * is truncated to 32 bits.
 	 */
-#if FUSE_USE_VERSION < 35
-	void (*ioctl) (fuse_req_t req, fuse_ino_t ino, int cmd,
-		       void *arg, struct fuse_file_info *fi, unsigned flags,
-		       const void *in_buf, size_t in_bufsz, size_t out_bufsz);
-#else
 	void (*ioctl) (fuse_req_t req, fuse_ino_t ino, unsigned int cmd,
 		       void *arg, struct fuse_file_info *fi, unsigned flags,
 		       const void *in_buf, size_t in_bufsz, size_t out_bufsz);


### PR DESCRIPTION
We currently do not pass anything in PREDEFINED and that means
FUSE_USE_VERSION is undefined.

Add that definition so that Doxygen built-in C pre-processor can use
FUSE_USE_VERSION value to find the correct comment to parse.

tested with doxygen doc/Doxyfile and now ioctl definitions appear.
