### PR TITLE
fuse3: revert "fuse_daemonize(): chdir to '/' even if not running in the background"

### DIFF
--- a/lib/helper.c
+++ b/lib/helper.c
@@ -270,8 +270,6 @@ int fuse_daemonize(int foreground)
 		(void) write(waiter[1], &completed, sizeof(completed));
 		close(waiter[0]);
 		close(waiter[1]);
-	} else {
-		(void) chdir("/");
 	}
 	return 0;
 }


### PR DESCRIPTION

The nvme-cuse in SPDK 21.01 uses cuse in foreground mode. If
fuse_daemonize function calls chdir to '/', then all functions
call with relative-path parameter will report error due to
the working directory changed. The bugfix in SPDK can't fix
the all sence, like: apps call chdir self or multi-thread
race condition etc. Prefer revert patch in fuse3 to fix the
bug in cuse foreground mode.

Signed-off-by: Lixiaokeng<lixiaokeng@huawei.com>
Signed-off-by: Weifeng Su<suweifeng1@huawei.com>