### PR TITLE
test/test_syscalls.c: fix test failure on xfs src dir

### DIFF
--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -1624,7 +1624,7 @@ static int test_rename_dir_loop(void)
 
 	errno = 0;
 	res = rename(PATH("a/b"), PATH2("a/d"));
-	if (res == 0 || errno != ENOTEMPTY) {
+	if (res == 0 || (errno != ENOTEMPTY && errno != EEXIST)) {
 		PERROR("rename");
 		goto fail;
 	}


### PR DESCRIPTION
rename dir loop test fails when test tmp dir is xfs with an error
 test_rename_dir_loop() - rename : File exists

That is because xfs returns EEXIST for the case of renaming over
a non-empty directory.

According to rename(2) man page, EEXIST and ENOTEMPTY are both valid
error code in this case.

Signed-off-by: Amir Goldstein <amir73il@gmail.com>