### PR TITLE
Fix: a potential crash on failure to setlocale

### DIFF
--- a/lib/modules/iconv.c
+++ b/lib/modules/iconv.c
@@ -672,7 +672,7 @@ static struct fuse_fs *iconv_new(struct fuse_args *args,
 {
 	struct fuse_fs *fs;
 	struct iconv *ic;
-	char *old = NULL;
+	const char *old = NULL;
 	const char *from;
 	const char *to;
 
@@ -694,7 +694,7 @@ static struct fuse_fs *iconv_new(struct fuse_args *args,
 	to = ic->to_code ? ic->to_code : "";
 	/* FIXME: detect charset equivalence? */
 	if (!to[0])
-		old = strdup(setlocale(LC_CTYPE, ""));
+		old = setlocale(LC_CTYPE, "");
 	ic->tofs = iconv_open(from, to);
 	if (ic->tofs == (iconv_t) -1) {
 		fuse_log(FUSE_LOG_ERR, "fuse-iconv: cannot convert from %s to %s\n",
@@ -709,7 +709,6 @@ static struct fuse_fs *iconv_new(struct fuse_args *args,
 	}
 	if (old) {
 		setlocale(LC_CTYPE, old);
-		free(old);
 		old = NULL;
 	}
 
@@ -730,7 +729,6 @@ out_free:
 	free(ic);
 	if (old) {
 		setlocale(LC_CTYPE, old);
-		free(old);
 	}
 	return NULL;
 }


### PR DESCRIPTION
setlocale() can fail, returning NULL, which will lead
to a crash in iconv_new(). Fix it like in iconv_help().

Signed-off-by: Lixiaokeng <lixiaokeng@huawei.com>