### PR TITLE
Do not run unlinked files test on passthrough_hp with old kernels

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -17,6 +17,8 @@ import tempfile
 import time
 import errno
 import sys
+import platform
+from distutils.version import LooseVersion
 from tempfile import NamedTemporaryFile
 from contextlib import contextmanager
 from util import (wait_for_mount, umount, cleanup, base_cmdline,
@@ -240,6 +242,11 @@ def test_passthrough_hp(short_tmpdir, cache, output_checker):
         if not cache:
             syscall_test_cmd = [ os.path.join(basename, 'test', 'test_syscalls'),
                              mnt_dir, ':' + src_dir ]
+            # unlinked testfiles check fails without kernel fix
+            # "fuse: fix illegal access to inode with reused nodeid"
+            # so opt-in for this test from kernel 5.14
+            if LooseVersion(platform.release()) >= '5.14':
+                syscall_test_cmd.append('-u')
             subprocess.check_call(syscall_test_cmd)
     except:
         cleanup(mount_process, mnt_dir)

--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -47,6 +47,7 @@ static int testdata2len = sizeof(testdata2) - 1;
 static unsigned int testnum = 0;
 static unsigned int select_test = 0;
 static unsigned int skip_test = 0;
+static unsigned int unlinked_test = 0;
 
 #define MAX_ENTRIES 1024
 #define MAX_TESTS 100
@@ -566,6 +567,9 @@ static int check_unlinked_testfiles(void)
 	int fd;
 	int res, err = 0;
 	int num = testnum;
+
+	if (!unlinked_test)
+		return 0;
 
 	testnum = 0;
 	while (testnum < num) {
@@ -1958,7 +1962,7 @@ int main(int argc, char *argv[])
 
 	umask(0);
 	if (argc < 2 || argc > 4) {
-		fprintf(stderr, "usage: %s testdir [:realdir] [[-]test#]\n", argv[0]);
+		fprintf(stderr, "usage: %s testdir [:realdir] [[-]test#] [-u]\n", argv[0]);
 		return 1;
 	}
 	basepath = argv[1];
@@ -1971,12 +1975,17 @@ int main(int argc, char *argv[])
 		} else {
 			if (arg[0] == '-') {
 				arg++;
-				skip_test = strtoul(arg, &endptr, 10);
+				if (arg[0] == 'u') {
+					unlinked_test = 1;
+					endptr = arg + 1;
+				} else {
+					skip_test = strtoul(arg, &endptr, 10);
+				}
 			} else {
 				select_test = strtoul(arg, &endptr, 10);
 			}
 			if (arg[0] == '\0' || *endptr != '\0') {
-				fprintf(stderr, "invalid number: '%s'\n", arg);
+				fprintf(stderr, "invalid option: '%s'\n", argv[a]);
 				return 1;
 			}
 		}


### PR DESCRIPTION
test_syscalls unlinked testfiles check fails on passthourhg_hp without
the kernel commit "fuse: fix illegal access to inode with reused nodeid"
queued for kernel 5.14 [1].

Make this check opt-in and do not run it with kernel version before 5.14.

[1] https://lore.kernel.org/linux-fsdevel/CAJfpegtGKjeK8E5QsHKF0=re1J9wVHuGRVgg9NDJ_OOwQdCUNg@mail.gmail.com/

Signed-off-by: Amir Goldstein <amir73il@gmail.com>