### PR TITLE
meson.build: fix wrong .symver detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -96,20 +96,18 @@ endif
 # to have __has_attribute, then they are too old to support symver)
 # other compilers might not have __has_attribute, but in those cases
 # it is safe for this check to fail and for us to fallback to the old _asm_
-# method for symver
+# method for symver. Anyway the attributes not supported by __has_attribute()
+# unfortunately return true giving a false positive. So let's try to build
+# using __attribute__ ((symver )) and see the result.
 code = '''
-#if defined __has_attribute
-# if !__has_attribute (symver)
-# error symver attribute not supported
-# endif
-#else
-#error __has_attribute not defined, assume we do not have symver
-#endif
+__attribute__ ((symver ("test@TEST")))
+void foo(void) {
+}
 
 int main(void) {
     return 0;
 }'''
-if cc.compiles(code, args: [ '-O0', '-c'])
+if cc.compiles(code, args: [ '-O0', '-c', '-Werror'])
      message('Compiler supports symver attribute')
      add_project_arguments('-DHAVE_SYMVER_ATTRIBUTE', language: 'c')
 else


### PR DESCRIPTION
As pointed here [1] __has_attribute() is broken for many attributes and
if it doesn't support the specific attribute it returns true, so we
can't really rely on that for this check. This lead to Buildroot
libfuse3 build failure [2] where that shows up with:
```
error: symver is only supported on ELF platforms
```
Indeed Microblaze doesn't support ELF since it doesn't include oself.h,
but __has_attribute(symver) returns true.

So let's substitute the #ifdef __has_attribute() with a stronger test on
a function foo() with __attribute__((symver ("test@TEST"))).

[1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101766
[2]: http://autobuild.buildroot.net/results/d6c/d6cfaf2aafaeda3c12d127f6a2d2e175b25e654f/build-end.log

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>