### PR TITLE
Use sysconfdir variable for init.d scripts in install_helper

### DIFF
--- a/util/install_helper.sh
+++ b/util/install_helper.sh
@@ -40,14 +40,14 @@ install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
         "${DESTDIR}${udevrulesdir}/99-fuse3.rules"
 
 install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \
-        "${DESTDIR}/etc/init.d/fuse3"
+        "${DESTDIR}${sysconfdir}/init.d/fuse3"
 
 
 if test -x /usr/sbin/update-rc.d && test -z "${DESTDIR}"; then
     /usr/sbin/update-rc.d fuse3 start 34 S . start 41 0 6 . || /bin/true
 else
     echo "== FURTHER ACTION REQUIRED =="
-    echo "Make sure that your init system will start the ${DESTDIR}/etc/init.d/fuse3 init script"
+    echo "Make sure that your init system will start the ${DESTDIR}${sysconfdir}init.d/fuse3 init script"
 fi
 
 


### PR DESCRIPTION
No matter what collection of meson build in and project options is chosen, currently installing fuse with user permissions will always result in an error because the /etc/init.d is unconfigurable from meson.

This patch makes the init.d directory respect the sysconfdir variable