### PR TITLE
WIP: Fix dlsym usage

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -252,7 +252,7 @@ static int fuse_load_so_module(const char *module)
 	int ret = -1;
 	char *tmp;
 	struct fusemod_so *so;
-	fuse_module_factory_t factory;
+	fuse_module_factory_t* factory;
 
 	tmp = malloc(strlen(module) + 64);
 	if (!tmp) {
@@ -280,7 +280,11 @@ static int fuse_load_so_module(const char *module)
 			tmp, dlerror());
 		goto out_dlclose;
 	}
-	ret = fuse_register_module(module, factory, so);
+	if (*factory == NULL) {
+		fuse_log(FUSE_LOG_ERR, "fuse: symbol <%s> in module is NULL\n", tmp);
+		goto out_dlclose;
+	}
+	ret = fuse_register_module(module, *factory, so);
 	if (ret)
 		goto out_dlclose;
 


### PR DESCRIPTION
"fuse_module_<name>_factory" is a function pointer but is loaded like a
function, which results an crash for any external module.