### PR TITLE
test/test_syscalls.c: clean-up unlinked files from fds list

### DIFF
--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -277,7 +277,8 @@ static int fcheck_stat(int fd, int flags, struct stat *st)
 		if (flags & O_PATH) {
 			// With O_PATH fd, the server does not have to keep
 			// the inode alive so FUSE inode may be stale or bad
-			if (errno == ESTALE || errno == EIO || errno == ENOENT)
+			if (errno == ESTALE || errno == EIO ||
+			    errno == ENOENT || errno == EBADF)
 				return 0;
 		}
 		PERROR("fstat");


### PR DESCRIPTION
Test test/test_examples.py::test_passthrough_hp[False] was failing due to lack
of file descriptors clean-up when the test file is unlinked.  This would result
in errors such as:

  3 [check_unlinked_testfile] fcheck_stat() - fstat: Bad file descriptor
  4 [check_unlinked_testfile] fcheck_stat() - fstat: Bad file descriptor
  5 [check_unlinked_testfile] fcheck_stat() - fstat: Bad file descriptor
  9 [check_unlinked_testfile] fcheck_stat() - fstat: Bad file descriptor
  ...

This patch simply replaces all the unlink() calls to files created with
create_testfile() by a new helper unlink_testfile() that will also set the ->fd
to -1.

Signed-off-by: Luís Henriques <lhenriques@suse.de>