### PR TITLE
Document possible NULL paths when directories are removed

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -560,10 +560,16 @@ struct fuse_operations {
 			struct fuse_file_info *, enum fuse_readdir_flags);
 
 	/** Release directory
+	 *
+	 * If the directory has been removed after the call to opendir, the
+	 * path parameter will be NULL.
 	 */
 	int (*releasedir) (const char *, struct fuse_file_info *);
 
 	/** Synchronize directory contents
+	 *
+	 * If the directory has been removed after the call to opendir, the
+	 * path parameter will be NULL.
 	 *
 	 * If the datasync parameter is non-zero, then only the user data
 	 * should be flushed, not the meta data


### PR DESCRIPTION
When directories with open handles are removed, the releasedir and fsyncdir operations might be called with a NULL path. That is because there is no hiding behavior like for regular files and the nodes get removed immediately.

This was also discussed on the mailing list:
https://sourceforge.net/p/fuse/mailman/fuse-devel/thread/FR2P281MB0757789828DD816269D15F0A96649%40FR2P281MB0757.DEUP281.PROD.OUTLOOK.COM/