### PR TITLE
Add support for FOPEN_NOFLUSH flag

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,8 @@
+Unreleased Changes
+==================
+
+* Add support for flag FOPEN_NOFLUSH for avoiding flush on close.
+
 libfuse 3.10.5 (2021-09-06)
 ===========================
 

--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -856,6 +856,7 @@ static void sfs_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi) {
     lock_guard<mutex> g {inode.m};
     inode.nopen++;
     fi->keep_cache = (fs.timeout != 0);
+    fi->noflush = (fs.timeout == 0 && (fi->flags & O_ACCMODE) == O_RDONLY);
     fi->fh = fd;
     fuse_reply_open(req, fi);
 }

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -248,6 +248,14 @@ struct fuse_config {
 	int auto_cache;
 
 	/**
+	 * By default, fuse waits for all pending writes to complete
+	 * and calls the FLUSH operation on close(2) of every fuse fd.
+	 * With this option, wait and FLUSH are not done for read-only
+	 * fuse fd, similar to the behavior of NFS/SMB clients.
+	 */
+	int no_rofd_flush;
+
+	/**
 	 * The timeout in seconds for which file attributes are cached
 	 * for the purpose of checking if auto_cache should flush the
 	 * file data on open.

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -83,8 +83,12 @@ struct fuse_file_info {
 	    nothing when set by open()). */
 	unsigned int cache_readdir : 1;
 
+	/** Can be filled in by open, to indicate that flush is not needed
+	    on close. */
+	unsigned int noflush : 1;
+
 	/** Padding.  Reserved for future use*/
-	unsigned int padding : 25;
+	unsigned int padding : 24;
 	unsigned int padding2 : 32;
 
 	/** File handle id.  May be filled in by filesystem in create,

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -238,12 +238,14 @@ struct fuse_file_lock {
  * FOPEN_NONSEEKABLE: the file is not seekable
  * FOPEN_CACHE_DIR: allow caching this directory
  * FOPEN_STREAM: the file is stream-like (no file position at all)
+ * FOPEN_NOFLUSH: don't flush data cache on close (unless FUSE_WRITEBACK_CACHE)
  */
 #define FOPEN_DIRECT_IO		(1 << 0)
 #define FOPEN_KEEP_CACHE	(1 << 1)
 #define FOPEN_NONSEEKABLE	(1 << 2)
 #define FOPEN_CACHE_DIR		(1 << 3)
 #define FOPEN_STREAM		(1 << 4)
+#define FOPEN_NOFLUSH		(1 << 5)
 
 /**
  * INIT request/reply flags

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -3272,6 +3272,10 @@ static void fuse_lib_open(fuse_req_t req, fuse_ino_t ino,
 
 			if (f->conf.auto_cache)
 				open_auto_cache(f, ino, path, fi);
+
+			if (f->conf.no_rofd_flush &&
+			    (fi->flags & O_ACCMODE) == O_RDONLY)
+				fi->noflush = 1;
 		}
 		fuse_finish_interrupt(f, req, &d);
 	}
@@ -4653,6 +4657,7 @@ static const struct fuse_opt fuse_lib_opts[] = {
 	FUSE_LIB_OPT("kernel_cache",	      kernel_cache, 1),
 	FUSE_LIB_OPT("auto_cache",	      auto_cache, 1),
 	FUSE_LIB_OPT("noauto_cache",	      auto_cache, 0),
+	FUSE_LIB_OPT("no_rofd_flush",	      no_rofd_flush, 1),
 	FUSE_LIB_OPT("umask=",		      set_mode, 1),
 	FUSE_LIB_OPT("umask=%o",	      umask, 0),
 	FUSE_LIB_OPT("uid=",		      set_uid, 1),
@@ -4705,6 +4710,7 @@ void fuse_lib_help(struct fuse_args *args)
 	printf(
 "    -o kernel_cache        cache files in kernel\n"
 "    -o [no]auto_cache      enable caching based on modification times (off)\n"
+"    -o no_rofd_flush       disable flushing of read-only fd on close (off)\n"
 "    -o umask=M             set file permissions (octal)\n"
 "    -o uid=N               set file owner\n"
 "    -o gid=N               set file group\n"

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -395,6 +395,8 @@ static void fill_open(struct fuse_open_out *arg,
 		arg->open_flags |= FOPEN_CACHE_DIR;
 	if (f->nonseekable)
 		arg->open_flags |= FOPEN_NONSEEKABLE;
+	if (f->noflush)
+		arg->open_flags |= FOPEN_NOFLUSH;
 }
 
 int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param *e)

--- a/test/test_ctests.py
+++ b/test/test_ctests.py
@@ -33,6 +33,11 @@ def test_write_cache(tmpdir, writeback, output_checker):
                 mnt_dir ]
     if writeback:
         cmdline.append('-owriteback_cache')
+    elif LooseVersion(platform.release()) >= '5.16':
+        # Test that close(rofd) does not block waiting for pending writes.
+        # This test requires kernel commit a390ccb316be ("fuse: add FOPEN_NOFLUSH")
+        # so opt-in for this test from kernel 5.16.
+        cmdline.append('--delay_ms=200')
     subprocess.check_call(cmdline, stdout=output_checker.fd, stderr=output_checker.fd)
 
 


### PR DESCRIPTION
The support for the flag was added by commit a390ccb316be ("fuse: add FOPEN_NOFLUSH") to kernel v5.16-rc1