### PR TITLE
Avoid ENOENT response when recently invalidated fuse_ino_t is received from the kernel

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -1037,7 +1037,7 @@ static int try_get_path(struct fuse *f, fuse_ino_t nodeid, const char *name,
 
 	for (node = get_node(f, nodeid); node->nodeid != FUSE_ROOT_ID;
 	     node = node->parent) {
-		err = -ENOENT;
+		err = -ESTALE;
 		if (node->name == NULL || node->parent == NULL)
 			goto out_unlock;
 
@@ -1246,7 +1246,7 @@ static int get_path_nullok(struct fuse *f, fuse_ino_t nodeid, char **path)
 		*path = NULL;
 	} else {
 		err = get_path_common(f, nodeid, NULL, path, NULL);
-		if (err == -ENOENT)
+		if (err == -ESTALE)
 			err = 0;
 	}
 


### PR DESCRIPTION
When a file is replaced by rename, a parallel open of the filename being replaced (in a race with the rename) may fail with ENOENT, making it appear (incorrectly) as though the rename was not atomic.  This happens because the call to fuse_lib_open receives the fuse_ino_t of the file being replaced, which becomes invalidated by the rename operation.  When encountering the node which now has no parent, try_get_path returns -ENOENT which then becomes the error result of the file open syscall.

If the reply sent by fuse_lib_open is instead -ESTALE, the renamed file will be opened instead which is the expected behavior.  Changing the response in try_get_path also fixes similar rename atomicity races for other operations.

As described in a mailing list post:

https://marc.info/?l=fuse-devel&m=164149468119994&w=2

Fixes #637 