### PR TITLE
Fixed returning an error condition to ioctl(2)

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,5 @@
+* Fixed returning an error condition to ioctl(2)
+
 libfuse 3.10.5 (2021-09-06)
 ===========================
 

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4289,6 +4289,8 @@ static void fuse_lib_ioctl(fuse_req_t req, fuse_ino_t ino, unsigned int cmd,
 	fuse_finish_interrupt(f, req, &d);
 	free_path(f, ino, path);
 
+	if (err < 0)
+		goto err;
 	fuse_reply_ioctl(req, err, out_buf, out_bufsz);
 	goto out;
 err:


### PR DESCRIPTION
When returning a negative error code by ->ioctl() to the high level interface, no error is propagated to the low level, and the reply message to the kernel is shown as successful.

A negative result is however returned to kernel, so the kernel can detect the bad condition, but this appears to not be the case since kernel 5.15.

The proposed fix is more in line with the usual processing of errors in fuse, taking into account that ioctl(2) always returns a non-negative value in the absence of errors.