### PR TITLE
Removed duplicated code.

### DIFF
--- a/example/printcap.c
+++ b/example/printcap.c
@@ -39,8 +39,6 @@ static void pc_init(void *userdata,
 	printf("Protocol version: %d.%d\n", conn->proto_major,
 	       conn->proto_minor);
 	printf("Capabilities:\n");
-	if(conn->capable & FUSE_CAP_WRITEBACK_CACHE)
-		printf("\tFUSE_CAP_WRITEBACK_CACHE\n");
 	if(conn->capable & FUSE_CAP_ASYNC_READ)
 			printf("\tFUSE_CAP_ASYNC_READ\n");
 	if(conn->capable & FUSE_CAP_POSIX_LOCKS)


### PR DESCRIPTION
The cap for FUSE_CAP_WRITEBACK_CACHE was printed twice. The other copy of these two lines where at line 72. I deleted the first copy because it was out of order with the other definitions and its formatting was not matching.