### PR TITLE
fix: reduce memset syscall and set buf default value

### DIFF
--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -111,7 +111,7 @@ static ssize_t fuse_buf_fd_to_fd(const struct fuse_buf *dst, size_t dst_off,
 				 const struct fuse_buf *src, size_t src_off,
 				 size_t len)
 {
-	char buf[4096];
+	char buf[4096] = {0,};
 	struct fuse_buf tmp = {
 		.size = sizeof(buf),
 		.flags = 0,

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -418,13 +418,12 @@ int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param *e)
 int fuse_reply_create(fuse_req_t req, const struct fuse_entry_param *e,
 		      const struct fuse_file_info *f)
 {
-	char buf[sizeof(struct fuse_entry_out) + sizeof(struct fuse_open_out)];
+	char buf[sizeof(struct fuse_entry_out) + sizeof(struct fuse_open_out)] = {0,};
 	size_t entrysize = req->se->conn.proto_minor < 9 ?
 		FUSE_COMPAT_ENTRY_OUT_SIZE : sizeof(struct fuse_entry_out);
 	struct fuse_entry_out *earg = (struct fuse_entry_out *) buf;
 	struct fuse_open_out *oarg = (struct fuse_open_out *) (buf + entrysize);
 
-	memset(buf, 0, sizeof(buf));
 	fill_entry(earg, e);
 	fill_open(oarg, f);
 	return send_reply_ok(req, buf,

--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -273,7 +273,7 @@ int fuse_mnt_remove_mount(const char *progname, const char *mnt)
 
 char *fuse_mnt_resolve_path(const char *progname, const char *orig)
 {
-	char buf[PATH_MAX];
+	char buf[PATH_MAX] = {0,};
 	char *copy;
 	char *dst;
 	char *end;
@@ -340,7 +340,7 @@ char *fuse_mnt_resolve_path(const char *progname, const char *orig)
 
 int fuse_mnt_check_fuseblk(void)
 {
-	char buf[256];
+	char buf[256] = {0,};
 	FILE *f = fopen("/proc/filesystems", "r");
 	if (!f)
 		return 1;


### PR DESCRIPTION
reduce memset in fuse_reply_create initialize buf.
set buffer default value with buf[0] = \0

Log:
```
test/test_ctests.py::test_write_cache[False] PASSED                                      [  2%]
test/test_ctests.py::test_write_cache[True] PASSED                                       [  4%]
test/test_ctests.py::test_notify1[True-notify_inval_inode] PASSED                        [  6%]
test/test_ctests.py::test_notify1[True-invalidate_path] PASSED                           [  8%]
test/test_ctests.py::test_notify1[True-notify_store_retrieve] PASSED                     [ 10%]
test/test_ctests.py::test_notify1[False-notify_inval_inode] PASSED                       [ 12%]
test/test_ctests.py::test_notify1[False-invalidate_path] PASSED                          [ 14%]
test/test_ctests.py::test_notify1[False-notify_store_retrieve] PASSED                    [ 17%]
test/test_ctests.py::test_notify_file_size[True] PASSED                                  [ 19%]
test/test_ctests.py::test_notify_file_size[False] PASSED                                 [ 21%]
test/test_examples.py::test_hello[hello-options0-invoke_directly] PASSED                 [ 23%]
test/test_examples.py::test_hello[hello-options0-invoke_mount_fuse] PASSED               [ 25%]
test/test_examples.py::test_hello[hello-options0-invoke_mount_fuse_drop_privileges] PASSED [ 27%]
test/test_examples.py::test_hello[hello-options1-invoke_directly] PASSED                 [ 29%]
test/test_examples.py::test_hello[hello-options1-invoke_mount_fuse] PASSED               [ 31%]
test/test_examples.py::test_hello[hello-options1-invoke_mount_fuse_drop_privileges] PASSED [ 34%]
test/test_examples.py::test_hello[hello_ll-options0-invoke_directly] PASSED              [ 36%]
test/test_examples.py::test_hello[hello_ll-options0-invoke_mount_fuse] PASSED            [ 38%]
test/test_examples.py::test_hello[hello_ll-options0-invoke_mount_fuse_drop_privileges] PASSED [ 40%]
test/test_examples.py::test_hello[hello_ll-options1-invoke_directly] PASSED              [ 42%]
test/test_examples.py::test_hello[hello_ll-options1-invoke_mount_fuse] PASSED            [ 44%]
test/test_examples.py::test_hello[hello_ll-options1-invoke_mount_fuse_drop_privileges] PASSED [ 46%]
test/test_examples.py::test_passthrough[False-passthrough-False] PASSED                  [ 48%]
test/test_examples.py::test_passthrough[False-passthrough-True] SKIPPED                  [ 51%]
test/test_examples.py::test_passthrough[False-passthrough_plus-False] PASSED             [ 53%]
test/test_examples.py::test_passthrough[False-passthrough_plus-True] SKIPPED             [ 55%]
test/test_examples.py::test_passthrough[False-passthrough_fh-False] PASSED               [ 57%]
test/test_examples.py::test_passthrough[False-passthrough_fh-True] SKIPPED               [ 59%]
test/test_examples.py::test_passthrough[False-passthrough_ll-False] PASSED               [ 61%]
test/test_examples.py::test_passthrough[False-passthrough_ll-True] PASSED                [ 63%]
test/test_examples.py::test_passthrough[True-passthrough-False] PASSED                   [ 65%]
test/test_examples.py::test_passthrough[True-passthrough-True] SKIPPED                   [ 68%]
test/test_examples.py::test_passthrough[True-passthrough_plus-False] PASSED              [ 70%]
test/test_examples.py::test_passthrough[True-passthrough_plus-True] SKIPPED              [ 72%]
test/test_examples.py::test_passthrough[True-passthrough_fh-False] PASSED                [ 74%]
test/test_examples.py::test_passthrough[True-passthrough_fh-True] SKIPPED                [ 76%]
test/test_examples.py::test_passthrough[True-passthrough_ll-False] PASSED                [ 78%]
test/test_examples.py::test_passthrough[True-passthrough_ll-True] PASSED                 [ 80%]
test/test_examples.py::test_passthrough_hp[False] PASSED                                 [ 82%]
test/test_examples.py::test_passthrough_hp[True] PASSED                                  [ 85%]
test/test_examples.py::test_ioctl PASSED                                                 [ 87%]
test/test_examples.py::test_poll PASSED                                                  [ 89%]
test/test_examples.py::test_null PASSED                                                  [ 91%]
test/test_examples.py::test_notify_inval_entry[True] PASSED                              [ 93%]
test/test_examples.py::test_notify_inval_entry[False] PASSED                             [ 95%]
test/test_examples.py::test_cuse PASSED                                                  [ 97%]
test/test_examples.py::test_printcap PASSED                                              [100%]

=================================== short test summary info ====================================
SKIPPED [6] test/test_examples.py:143: example does not support writeback caching
================================ 41 passed, 6 skipped in 42.90s ================================
```