### PR TITLE
fuse-loop/fuse_do_work: Avoid lots of thread creations/destructions

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,58 @@
+libfuse 3.12.0 (<unreleased>)
+===========================
+* The 'max_idle_threads' parameter has performance implication
+  due to run time thread creation and destruction per request
+  and it is deprecated in favor of the new max_threads parameter.
+
+  * API changes:
+    In order to avoid future version symboling and also to
+    allow to set fuse_loop_config defaults an API change has been
+    introduced beginning with API version (FUSE_USE_VERSION) 312.
+    'struct fuse_loop_config' is now private and has to be
+    constructed using fuse_loop_cfg_create(). Besides allocating
+    memory this function also sets struct member default.
+    Desctruction (free) is done through fuse_loop_cfg_destroy().
+    Struct parameters can be changed using fuse_loop_cfg_set_*()
+    functions.
+    New  functions regarding the fuse-loop configuration are:
+      fuse_loop_cfg_create
+      fuse_loop_cfg_destroy
+      fuse_loop_cfg_set_idle_threads
+      fuse_loop_cfg_set_max_threads
+      fuse_loop_cfg_set_clone_fd
+      fuse_loop_cfg_convert (internal for API/ABI compatibility)
+    Functions details can be found in fuse_common.h
+
+    In API version 312 the fuse_session_loop_mt() function now
+    also accepts struct fuse_loop_config * as NULL pointer and
+    uses defaults then.
+
+  * Users of fuse_parse_cmdline() get the new option
+    'max_threads' with API version 312.
+
+  * File system conversion help:
+    - See example/passthrough_hp.cc
+
+    #define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 12)
+
+    ...
+    main(int argc, char *argv[])
+    ...
+    struct fuse_loop_config *loop_config;
+    ...
+    loop_config = fuse_loop_cfg_create();
+    ...
+    ret = fuse_session_loop_mt(se, loop_config);
+    ...
+    fuse_loop_cfg_destroy(loop_config);
+
+  * Further notes:
+    Using max_threads == 1 and calling fuse_session_loop_mt() works,
+    it will run single threaded similar to fuse_session_loop(). In
+    fact, fuse_session_loop() might get deprecated in future
+    versions.
+
+
 libfuse 3.11.0 (2022-05-02)
 ===========================
 

--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -43,7 +43,7 @@
  * \include passthrough_hp.cc
  */
 
-#define FUSE_USE_VERSION 35
+#define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 12)
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -1228,6 +1228,8 @@ static void maximize_fd_limit() {
 
 int main(int argc, char *argv[]) {
 
+    struct fuse_loop_config *loop_config = NULL;
+
     // Parse command line options
     auto options {parse_options(argc, argv)};
 
@@ -1274,15 +1276,15 @@ int main(int argc, char *argv[]) {
     umask(0);
 
     // Mount and run main loop
-    struct fuse_loop_config loop_config;
-    loop_config.clone_fd = 0;
-    loop_config.max_idle_threads = 10;
+    loop_config = fuse_loop_cfg_create();
+
     if (fuse_session_mount(se, argv[2]) != 0)
         goto err_out3;
     if (options.count("single"))
         ret = fuse_session_loop(se);
     else
-        ret = fuse_session_loop_mt(se, &loop_config);
+        ret = fuse_session_loop_mt(se, loop_config);
+
 
     fuse_session_unmount(se);
 
@@ -1291,6 +1293,8 @@ err_out3:
 err_out2:
     fuse_session_destroy(se);
 err_out1:
+
+    fuse_loop_cfg_destroy(loop_config);
     fuse_opt_free_args(&args);
 
     return ret ? 1 : 0;

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -1041,7 +1041,7 @@ int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config *config);
  * in the callback function of fuse_operations is also thread-safe.
  *
  * @param f the FUSE handle
- * @param config loop configuration
+ * @param config loop configuration, may be NULL and defaults will be used then
  * @return see fuse_session_loop()
  *
  * See also: fuse_loop()

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -1011,6 +1011,9 @@ void fuse_exit(struct fuse *f);
 #if FUSE_USE_VERSION < 32
 int fuse_loop_mt_31(struct fuse *f, int clone_fd);
 #define fuse_loop_mt(f, clone_fd) fuse_loop_mt_31(f, clone_fd)
+#elif FUSE_USE_VERSION < FUSE_MAKE_VERSION(3, 12)
+int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config *config);
+#define fuse_loop_mt(f, config) fuse_loop_mt_32(f, config)
 #else
 /**
  * FUSE event loop with multiple threads

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -857,13 +857,19 @@ struct fuse_loop_config *fuse_loop_cfg_create(void);
 void fuse_loop_cfg_destroy(struct fuse_loop_config *config);
 
 /**
- * fuse_loop_config2 setter to set the number of max idle threads.
+ * fuse_loop_config setter to set the number of max idle threads.
  */
 void fuse_loop_cfg_set_idle_threads(struct fuse_loop_config *config,
 				    unsigned int value);
 
 /**
- * fuse_loop_config2 setter to enable the clone_fd feature
+ * fuse_loop_config setter to set the number of max threads.
+ */
+void fuse_loop_cfg_set_max_threads(struct fuse_loop_config *config,
+				   unsigned int value);
+
+/**
+ * fuse_loop_config setter to enable the clone_fd feature
  */
 void fuse_loop_cfg_set_clone_fd(struct fuse_loop_config *config,
 				unsigned int value);

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -23,7 +23,7 @@
 #define FUSE_MAJOR_VERSION 3
 
 /** Minor version of FUSE library interface */
-#define FUSE_MINOR_VERSION 11
+#define FUSE_MINOR_VERSION 12
 
 #define FUSE_MAKE_VERSION(maj, min)  ((maj) * 100 + (min))
 #define FUSE_VERSION FUSE_MAKE_VERSION(FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION)
@@ -104,11 +104,20 @@ struct fuse_file_info {
 	uint32_t poll_events;
 };
 
+
+
 /**
  * Configuration parameters passed to fuse_session_loop_mt() and
  * fuse_loop_mt().
+ * Deprecated and replaced by a newer private struct in FUSE API
+ * version 312 (FUSE_MAKE_VERSION(3, 12)
  */
+#if FUSE_USE_VERSION < FUSE_MAKE_VERSION(3, 12)
+struct fuse_loop_config_v1; /* forward declarition */
 struct fuse_loop_config {
+#else
+struct fuse_loop_config_v1 {
+#endif
 	/**
 	 * whether to use separate device fds for each thread
 	 * (may increase performance)
@@ -127,6 +136,7 @@ struct fuse_loop_config {
 	 */
 	unsigned int max_idle_threads;
 };
+
 
 /**************************************************************************
  * Capability bits for 'fuse_conn_info.capable' and 'fuse_conn_info.want' *
@@ -833,6 +843,39 @@ int fuse_set_signal_handlers(struct fuse_session *se);
  * fuse_set_signal_handlers()
  */
 void fuse_remove_signal_handlers(struct fuse_session *se);
+
+/**
+ * Create and set default config for fuse_session_loop_mt and fuse_loop_mt.
+ *
+ * @return anonymous config struct
+ */
+struct fuse_loop_config *fuse_loop_cfg_create(void);
+
+/**
+ * Free the config data structure
+ */
+void fuse_loop_cfg_destroy(struct fuse_loop_config *config);
+
+/**
+ * fuse_loop_config2 setter to set the number of max idle threads.
+ */
+void fuse_loop_cfg_set_idle_threads(struct fuse_loop_config *config,
+				    unsigned int value);
+
+/**
+ * fuse_loop_config2 setter to enable the clone_fd feature
+ */
+void fuse_loop_cfg_set_clone_fd(struct fuse_loop_config *config,
+				unsigned int value);
+
+/**
+ * Convert old config to more recernt fuse_loop_config2
+ *
+ * @param config current config2 type
+ * @param v1_conf older config1 type (below FUSE API 312)
+ */
+void fuse_loop_cfg_convert(struct fuse_loop_config *config,
+			   struct fuse_loop_config_v1 *v1_conf);
 
 /* ----------------------------------------------------------- *
  * Compatibility stuff					       *

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1968,26 +1968,29 @@ int fuse_session_mount(struct fuse_session *se, const char *mountpoint);
 int fuse_session_loop(struct fuse_session *se);
 
 #if FUSE_USE_VERSION < 32
-int fuse_session_loop_mt_31(struct fuse_session *se, int clone_fd);
-#define fuse_session_loop_mt(se, clone_fd) fuse_session_loop_mt_31(se, clone_fd)
+	int fuse_session_loop_mt_31(struct fuse_session *se, int clone_fd);
+	#define fuse_session_loop_mt(se, clone_fd) fuse_session_loop_mt_31(se, clone_fd)
+#elif FUSE_USE_VERSION < FUSE_MAKE_VERSION(3, 12)
+	int fuse_session_loop_mt_32(struct fuse_session *se, struct fuse_loop_config *config);
+	#define fuse_session_loop_mt(se, config) fuse_session_loop_mt_32(se, config)
 #else
-#if (!defined(__UCLIBC__) && !defined(__APPLE__))
-/**
- * Enter a multi-threaded event loop.
- *
- * For a description of the return value and the conditions when the
- * event loop exits, refer to the documentation of
- * fuse_session_loop().
- *
- * @param se the session
- * @param config session loop configuration 
- * @return see fuse_session_loop()
- */
-int fuse_session_loop_mt(struct fuse_session *se, struct fuse_loop_config *config);
-#else
-int fuse_session_loop_mt_32(struct fuse_session *se, struct fuse_loop_config *config);
-#define fuse_session_loop_mt(se, config) fuse_session_loop_mt_32(se, config)
-#endif
+	#if (!defined(__UCLIBC__) && !defined(__APPLE__))
+		/**
+		 * Enter a multi-threaded event loop.
+		 *
+		 * For a description of the return value and the conditions when the
+		 * event loop exits, refer to the documentation of
+		 * fuse_session_loop().
+		 *
+		 * @param se the session
+		 * @param config session loop configuration
+		 * @return see fuse_session_loop()
+		 */
+		int fuse_session_loop_mt(struct fuse_session *se, struct fuse_loop_config *config);
+	#else
+		int fuse_session_loop_mt_312(struct fuse_session *se, struct fuse_loop_config *config);
+		#define fuse_session_loop_mt(se, config) fuse_session_loop_mt_312(se, config)
+	#endif
 #endif
 
 /**

--- a/lib/cuse_lowlevel.c
+++ b/lib/cuse_lowlevel.c
@@ -351,10 +351,9 @@ int cuse_lowlevel_main(int argc, char *argv[], const struct cuse_info *ci,
 		return 1;
 
 	if (multithreaded) {
-		struct fuse_loop_config config;
-		config.clone_fd = 0;
-		config.max_idle_threads = 10;
-		res = fuse_session_loop_mt_32(se, &config);
+		struct fuse_loop_config *config = fuse_loop_cfg_create();
+		res = fuse_session_loop_mt(se, config);
+		fuse_loop_cfg_destroy(config);
 	}
 	else
 		res = fuse_session_loop(se);

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4580,8 +4580,8 @@ int fuse_loop(struct fuse *f)
 	return fuse_session_loop(f->se);
 }
 
-FUSE_SYMVER("fuse_loop_mt_32", "fuse_loop_mt@@FUSE_3.2")
-int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config *config)
+FUSE_SYMVER("fuse_loop_mt_312", "fuse_loop_mt@@FUSE_3.12")
+int fuse_loop_mt_312(struct fuse *f, struct fuse_loop_config *config)
 {
 	if (f == NULL)
 		return -1;
@@ -4590,8 +4590,25 @@ int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config *config)
 	if (res)
 		return -1;
 
-	res = fuse_session_loop_mt_32(fuse_get_session(f), config);
+	res = fuse_session_loop_mt_312(fuse_get_session(f), config);
 	fuse_stop_cleanup_thread(f);
+	return res;
+}
+
+int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config_v1 *config_v1);
+FUSE_SYMVER("fuse_loop_mt_32", "fuse_loop_mt@FUSE_3.2")
+int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config_v1 *config_v1)
+{
+	struct fuse_loop_config *config = fuse_loop_cfg_create();
+	if (config == NULL)
+		return ENOMEM;
+
+	fuse_loop_cfg_convert(config, config_v1);
+
+	int res = fuse_loop_mt_312(f, config);
+
+	fuse_loop_cfg_destroy(config);
+
 	return res;
 }
 
@@ -4599,10 +4616,19 @@ int fuse_loop_mt_31(struct fuse *f, int clone_fd);
 FUSE_SYMVER("fuse_loop_mt_31", "fuse_loop_mt@FUSE_3.0")
 int fuse_loop_mt_31(struct fuse *f, int clone_fd)
 {
-	struct fuse_loop_config config;
-	config.clone_fd = clone_fd;
-	config.max_idle_threads = 10;
-	return fuse_loop_mt_32(f, &config);
+	int err;
+	struct fuse_loop_config *config = fuse_loop_cfg_create();
+
+	if (config == NULL)
+		return ENOMEM;
+
+	fuse_loop_cfg_set_clone_fd(config, clone_fd);
+
+	err = fuse_loop_mt_312(f, config);
+
+	fuse_loop_cfg_destroy(config);
+
+	return err;
 }
 
 void fuse_exit(struct fuse *f)

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -87,6 +87,50 @@ struct fuse_module {
 	int ctr;
 };
 
+/**
+ * Configuration parameters passed to fuse_session_loop_mt() and
+ * fuse_loop_mt().
+ *
+ * Internal API to avoid exposing the plain data structure and
+ * causing compat issues after adding or removing struct members.
+ *
+ */
+#if FUSE_USE_VERSION >= FUSE_MAKE_VERSION(3, 12)
+struct fuse_loop_config
+{
+	/* verififier that a correct struct was was passed. This is especially
+	 * needed, as versions below (3, 12) were using a public struct
+	 * (now called  fuse_loop_config_v1), which was hard to extend with
+	 * additional parameters, without risking that file system implementations
+	 * would not have noticed and might either pass uninitialized members
+	 * or even too small structs.
+	 * fuse_loop_config_v1 has clone_fd at this offset, which should be either 0
+	 * or 1. v2 or even higher version just need to set a value here
+	 * which not conflicting and very unlikely as having been set by
+	 * file system implementation.
+	 */
+	int version_id;
+
+	/**
+	 * whether to use separate device fds for each thread
+	 * (may increase performance)
+	 */
+	int clone_fd;
+	/**
+	 * The maximum number of available worker threads before they
+	 * start to get deleted when they become idle. If not
+	 * specified, the default is 10.
+	 *
+	 * Adjusting this has performance implications; a very small number
+	 * of threads in the pool will cause a lot of thread creation and
+	 * deletion overhead and performance may suffer. When set to 0, a new
+	 * thread will be created to service every operation.
+	 * The special value of -1 means that this parameter is disabled.
+	 */
+	int max_idle_threads;
+};
+#endif
+
 /* ----------------------------------------------------------- *
  * Channel interface (when using -o clone_fd)		       *
  * ----------------------------------------------------------- */
@@ -128,8 +172,16 @@ void fuse_session_process_buf_int(struct fuse_session *se,
 
 struct fuse *fuse_new_31(struct fuse_args *args, const struct fuse_operations *op,
 		      size_t op_size, void *private_data);
-int fuse_loop_mt_32(struct fuse *f, struct fuse_loop_config *config);
-int fuse_session_loop_mt_32(struct fuse_session *se, struct fuse_loop_config *config);
+int fuse_loop_mt_312(struct fuse *f, struct fuse_loop_config *config);
+int fuse_session_loop_mt_312(struct fuse_session *se, struct fuse_loop_config *config);
+
+/**
+ * Internal verifier for the given config.
+ *
+ * @return negative standard error code or 0 on success
+ */
+int fuse_loop_cfg_verify(struct fuse_loop_config *config);
+
 
 #define FUSE_MAX_MAX_PAGES 256
 #define FUSE_DEFAULT_MAX_PAGES_PER_REQ 32

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -128,6 +128,13 @@ struct fuse_loop_config
 	 * The special value of -1 means that this parameter is disabled.
 	 */
 	int max_idle_threads;
+
+	/**
+	 *  max number of threads taking and processing kernel requests
+	 *
+	 *  As of now threads are created dynamically
+	 */
+	unsigned int max_threads;
 };
 #endif
 

--- a/lib/fuse_misc.h
+++ b/lib/fuse_misc.h
@@ -11,6 +11,9 @@
 /*
   Versioned symbols cannot be used in some cases because it
     - not supported on MacOSX (in MachO binary format)
+
+  Note: "@@" denotes the default symbol, "@" is binary a compat version.
+
 */
 #ifndef __APPLE__
 # if HAVE_SYMVER_ATTRIBUTE

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -178,8 +178,12 @@ FUSE_3.12 {
 		fuse_loop_cfg_create;
 		fuse_loop_cfg_destroy;
 		fuse_loop_cfg_set_idle_threads;
+		fuse_loop_cfg_set_max_threads;
 		fuse_loop_cfg_set_clone_fd;
 		fuse_loop_cfg_convert;
+		fuse_parse_cmdline;
+		fuse_parse_cmdline_30;
+		fuse_parse_cmdline_312;
 } FUSE_3.4;
 
 # Local Variables:

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -168,6 +168,20 @@ FUSE_3.7 {
 		fuse_log;
 } FUSE_3.4;
 
+FUSE_3.12 {
+	global:
+		fuse_session_loop_mt;
+		fuse_session_loop_mt_312;
+		fuse_loop_mt;
+		fuse_loop_mt_32;
+		fuse_loop_mt_312;
+		fuse_loop_cfg_create;
+		fuse_loop_cfg_destroy;
+		fuse_loop_cfg_set_idle_threads;
+		fuse_loop_cfg_set_clone_fd;
+		fuse_loop_cfg_convert;
+} FUSE_3.4;
+
 # Local Variables:
 # indent-tabs-mode: t
 # End:

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -37,7 +37,7 @@ libfuse = library('fuse3', libfuse_sources, version: meson.project_version(),
                   soversion: '3', include_directories: include_dirs,
                   dependencies: deps, install: true,
                   link_depends: 'fuse_versionscript',
-                  c_args: [ '-DFUSE_USE_VERSION=35',
+                  c_args: [ '-DFUSE_USE_VERSION=312',
                             '-DFUSERMOUNT_DIR="@0@"'.format(fusermount_path) ],
                   link_args: ['-Wl,--version-script,' + meson.current_source_dir()
                               + '/fuse_versionscript' ])

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libfuse3', ['c'], version: '3.11.0',
+project('libfuse3', ['c'], version: '3.12.0',
         meson_version: '>= 0.42',
         default_options: [
             'buildtype=debugoptimized',

--- a/util/meson.build
+++ b/util/meson.build
@@ -11,7 +11,7 @@ executable('mount.fuse3', ['mount.fuse.c'],
            link_with: [ libfuse ],
            install: true,
            install_dir: get_option('sbindir'),
-           c_args: '-DFUSE_USE_VERSION=35')
+           c_args: '-DFUSE_USE_VERSION=312')
 
 
 udevrulesdir = get_option('udevrulesdir')


### PR DESCRIPTION
On benchmarking metadata operations with a single threaded bonnie++
and "max_idle_threads" limited to 1, 'top' was showing suspicious
160% cpu usage.
Profiling the system with flame graphs showed that an astonishing
amount of CPU time was spent in thread creation and destruction.

After verifying the code it turned out that fuse_do_work() was
creating a new thread every time all existing idle threads
were already busy. And then just a few lines later after processing
the current request it noticed that it had created too many threads
and destructed the current thread. I.e. there was a thread
creation/destruction ping-pong.

Code is changed to only create new threads if the max number of
threads is not reached.

Furthermore, thread destruction is disabled, as creation/destruction
is expensive in general.

With this change cpu usage of passthrough_hp went from ~160% to
~80% (with different values of max_idle_threads). And bonnie
values got approximately faster by 90%. This is a with single
threaded bonnie++
bonnie++ -x 4 -q -s0  -d <path> -n 30:1:1:10 -r 0

Without this patch, using the default max_idle_threads=10 and just
a single bonnie++ the thread creation/destruction code path is not
triggered.  Just one libfuse and one application thread is just
a corner case - the requirement for the issue was just
n-application-threads >= max_idle_threads.


Signed-off-by: Bernd Schubert <bschubert@ddn.com>