### PR TITLE
Atomic open+lookup

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -369,6 +369,43 @@ static void lo_lookup(fuse_req_t req, fuse_ino_t parent, const char *name)
 		fuse_reply_entry(req, &e);
 }
 
+static bool lo_do_open(fuse_req_t req, fuse_ino_t ino,
+		       struct fuse_file_info *fi);
+static void unref_inode(struct lo_data *lo,
+			struct lo_inode *inode, uint64_t n);
+
+static void lo_atomic_open(fuse_req_t req, fuse_ino_t parent,
+			   const char *name, struct fuse_file_info *fi)
+{
+	struct fuse_entry_param e;
+	int saveerr;
+	bool success;
+	struct lo_data *lo = lo_data(req);
+
+	if (lo_debug(req))
+		fuse_log(FUSE_LOG_DEBUG, "lo_atomic_open(parent=%" PRIu64,
+			 "name=%s)\n", parent, name);
+
+	saveerr = lo_do_lookup(req, parent, name, &e);
+	if (saveerr)
+		goto out_err;
+
+	success = lo_do_open(req, e.ino, fi);
+	if (!success) {
+		saveerr = errno;
+		struct lo_inode *ino = lo_inode(req, e.ino);
+		unref_inode(lo, ino, 1);
+		goto out_err;
+	}
+
+	fuse_reply_create(req, &e, fi);
+	return;
+
+out_err:
+	fuse_reply_err(req, saveerr);
+}
+
+
 static void lo_mknod_symlink(fuse_req_t req, fuse_ino_t parent,
 			     const char *name, mode_t mode, dev_t rdev,
 			     const char *link)
@@ -659,7 +696,7 @@ static void lo_do_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
 					err = errno;
 					goto error;
 				} else {  // End of stream
-					break; 
+					break;
 				}
 			}
 		}
@@ -691,11 +728,11 @@ static void lo_do_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
 						    &st, nextoff);
 		}
 		if (entsize > rem) {
-			if (entry_ino != 0) 
+			if (entry_ino != 0)
 				lo_forget_one(req, entry_ino, 1);
 			break;
 		}
-		
+
 		p += entsize;
 		rem -= entsize;
 
@@ -780,15 +817,12 @@ static void lo_fsyncdir(fuse_req_t req, fuse_ino_t ino, int datasync,
 	fuse_reply_err(req, res == -1 ? errno : 0);
 }
 
-static void lo_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
+static bool lo_do_open(fuse_req_t req, fuse_ino_t ino,
+		       struct fuse_file_info *fi)
 {
 	int fd;
 	char buf[64];
 	struct lo_data *lo = lo_data(req);
-
-	if (lo_debug(req))
-		fuse_log(FUSE_LOG_DEBUG, "lo_open(ino=%" PRIu64 ", flags=%d)\n",
-			ino, fi->flags);
 
 	/* With writeback cache, kernel may send read requests even
 	   when userspace opened write-only */
@@ -809,14 +843,28 @@ static void lo_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	sprintf(buf, "/proc/self/fd/%i", lo_fd(req, ino));
 	fd = open(buf, fi->flags & ~O_NOFOLLOW);
 	if (fd == -1)
-		return (void) fuse_reply_err(req, errno);
+		return false;
 
 	fi->fh = fd;
 	if (lo->cache == CACHE_NEVER)
 		fi->direct_io = 1;
 	else if (lo->cache == CACHE_ALWAYS)
 		fi->keep_cache = 1;
-	fuse_reply_open(req, fi);
+	return true;
+}
+
+static void lo_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
+{
+	if (lo_debug(req))
+		fuse_log(FUSE_LOG_DEBUG, "lo_open(ino=%" PRIu64 ", flags=%d)\n",
+			 ino, fi->flags);
+
+	bool success = lo_do_open(req, ino, fi);
+
+	if (success)
+		fuse_reply_open(req, fi);
+	else
+		fuse_reply_err(req, errno);
 }
 
 static void lo_release(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
@@ -1145,6 +1193,7 @@ static const struct fuse_lowlevel_ops lo_oper = {
 	.fsyncdir	= lo_fsyncdir,
 	.create		= lo_create,
 	.open		= lo_open,
+	.atomic_open	= lo_atomic_open,
 	.release	= lo_release,
 	.flush		= lo_flush,
 	.fsync		= lo_fsync,

--- a/example/printcap.c
+++ b/example/printcap.c
@@ -81,6 +81,8 @@ static void pc_init(void *userdata,
 			printf("\tFUSE_CAP_NO_OPENDIR_SUPPORT\n");
 	if(conn->capable & FUSE_CAP_EXPLICIT_INVAL_DATA)
 			printf("\tFUSE_CAP_EXPLICIT_INVAL_DATA\n");
+	if(conn->capable & FUSE_CAP_ATOMIC_OPEN)
+			printf("\tFUSE_CAP_ATOMIC_OPEN\n");
 	fuse_session_exit(se);
 }
 

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -438,6 +438,16 @@ struct fuse_operations {
 	 */
 	int (*open) (const char *, struct fuse_file_info *);
 
+	/** Open the file and fill in the attributes.
+	 *
+	 * Note that all rules which apply on open also apply here.
+	 * It fills in file attributes along with opening the file
+	 * which are used by libfuse and fuse kernel (Thus we avoid
+	 * unnecessary lookup calls into libfuse from fuse kernel).
+	 */
+	int (*atomic_open) (const char *, struct stat *buf,
+			    struct fuse_file_info *);
+
 	/** Read data from an open file
 	 *
 	 * Read should return exactly the number of bytes requested except
@@ -1225,6 +1235,8 @@ ssize_t fuse_fs_copy_file_range(struct fuse_fs *fs, const char *path_in,
 				size_t len, int flags);
 off_t fuse_fs_lseek(struct fuse_fs *fs, const char *path, off_t off, int whence,
 		    struct fuse_file_info *fi);
+int fuse_fs_atomic_open(struct fuse_fs *fs, const char *path,
+			struct stat *buf, struct fuse_file_info *fi);
 void fuse_fs_init(struct fuse_fs *fs, struct fuse_conn_info *conn,
 		struct fuse_config *cfg);
 void fuse_fs_destroy(struct fuse_fs *fs);

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -395,6 +395,15 @@ struct fuse_loop_config {
 #define FUSE_CAP_EXPLICIT_INVAL_DATA    (1 << 25)
 
 /**
+ * Indicates support for atomic open supported in FUSE user space.
+ *
+ * If this flag is set then avoid separate lookup which is used before open
+ * call, instead perform lookup as part of open call into libfuse.
+ */
+#define FUSE_CAP_ATOMIC_OPEN           (1 << 26)
+
+
+/**
  * Ioctl flags
  *
  * FUSE_IOCTL_COMPAT: 32bit compat ioctl on 64bit machine

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -274,6 +274,7 @@ struct fuse_file_lock {
  * FUSE_CACHE_SYMLINKS: cache READLINK responses
  * FUSE_NO_OPENDIR_SUPPORT: kernel supports zero-message opendir
  * FUSE_EXPLICIT_INVAL_DATA: only invalidate cached pages on explicit request
+ * FUSE_DO_ATOMIC_OPEN: do atomic open (LOOKUP+OPEN in one)
  */
 #define FUSE_ASYNC_READ		(1 << 0)
 #define FUSE_POSIX_LOCKS	(1 << 1)
@@ -302,6 +303,7 @@ struct fuse_file_lock {
 #define FUSE_NO_OPENDIR_SUPPORT (1 << 24)
 #define FUSE_EXPLICIT_INVAL_DATA (1 << 25)
 #define FUSE_INIT_EXT		(1 << 30)
+#define FUSE_DO_ATOMIC_OPEN	(1ULL << 34)
 
 /**
  * CUSE INIT request/reply flags
@@ -423,6 +425,7 @@ enum fuse_opcode {
 	FUSE_RENAME2		= 45,
 	FUSE_LSEEK		= 46,
 	FUSE_COPY_FILE_RANGE	= 47,
+	FUSE_ATOMIC_OPEN	= 51,
 
 	/* CUSE specific operations */
 	CUSE_INIT		= 4096

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -301,6 +301,7 @@ struct fuse_file_lock {
 #define FUSE_CACHE_SYMLINKS	(1 << 23)
 #define FUSE_NO_OPENDIR_SUPPORT (1 << 24)
 #define FUSE_EXPLICIT_INVAL_DATA (1 << 25)
+#define FUSE_INIT_EXT		(1 << 30)
 
 /**
  * CUSE INIT request/reply flags
@@ -637,6 +638,8 @@ struct fuse_init_in {
 	uint32_t	minor;
 	uint32_t	max_readahead;
 	uint32_t	flags;
+	uint32_t	flags2;
+	uint32_t	unused[11];
 };
 
 #define FUSE_COMPAT_INIT_OUT_SIZE 8
@@ -652,8 +655,9 @@ struct fuse_init_out {
 	uint32_t	max_write;
 	uint32_t	time_gran;
 	uint16_t	max_pages;
-	uint16_t	padding;
-	uint32_t	unused[8];
+	uint16_t	map_alignment;
+	uint32_t	flags2;
+	uint32_t	unused[7];
 };
 
 #define CUSE_INIT_INFO_MAX 4096

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1245,6 +1245,24 @@ struct fuse_lowlevel_ops {
 	 */
 	void (*lseek) (fuse_req_t req, fuse_ino_t ino, off_t off, int whence,
 		       struct fuse_file_info *fi);
+	/**
+	 * Open the file and return attributes
+	 *
+	 * This function implementation avoids unnecessary lookups from fuse
+	 * kernel into libfuse. Right now lookup call into libfuse which is
+	 * executed separately during file open is now being combined with
+	 * open.
+	 *
+	 * Valid replies:
+	 *	fuse_reply_atomic_open
+	 *	fuse_reply_err
+	 * @param req request handle
+	 * @param parent inode number of the parent directory
+	 * @param name file to be opened
+	 * @param fi file information
+	 */
+	void (*atomic_open) (fuse_req_t req, fuse_ino_t parent,
+			     const char *name, struct fuse_file_info *fi);
 };
 
 /**
@@ -1296,6 +1314,23 @@ void fuse_reply_none(fuse_req_t req);
  * @return zero for success, -errno for failure to send reply
  */
 int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param *e);
+
+/**
+ * Reply with directory entry and attributes
+ *
+ * Possible requests:
+ *   open
+ *
+ * Side effects:
+ *   increments the lookup count on success
+ *
+ * @param req request handle
+ * @param e the entry parameters
+ * @param fi file information
+ * @return zero for success, -errno for failure to send reply
+ */
+int fuse_reply_atomic_open(fuse_req_t req, const struct fuse_entry_param *e,
+			   const struct fuse_file_info *fi);
 
 /**
  * Reply with a directory entry and open parameters

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -1772,6 +1772,31 @@ int fuse_fs_open(struct fuse_fs *fs, const char *path,
 	}
 }
 
+int fuse_fs_atomic_open(struct fuse_fs *fs, const char *path,
+			struct stat *buf, struct fuse_file_info *fi)
+{
+	fuse_get_context()->private_data = fs->user_data;
+	if (fs->op.atomic_open) {
+		int err;
+
+		if (fs->debug)
+			fuse_log(FUSE_LOG_DEBUG, "open flags: 0x%x %s\n", fi->flags,
+				 path);
+
+		err = fs->op.atomic_open(path, buf, fi);
+
+		if (fs->debug && !err)
+			fuse_log(FUSE_LOG_DEBUG, "   open[%llu] flags: 0x%x "
+				 "getattr[%s] %s\n",
+				 (unsigned long long) fi->fh, fi->flags,
+				 file_info_string(fi, (char *)buf,
+				 sizeof(buf)), path);
+		return err;
+	} else {
+		return -ENOSYS;
+	}
+}
+
 static void fuse_free_buf(struct fuse_bufvec *buf)
 {
 	if (buf != NULL) {
@@ -2682,13 +2707,13 @@ static void fuse_lib_destroy(void *data)
 	f->fs = NULL;
 }
 
-static void fuse_lib_lookup(fuse_req_t req, fuse_ino_t parent,
-			    const char *name)
+static void fuse_do_get_node_dot_dotdot(fuse_req_t req, fuse_ino_t parent,
+					const char *name,
+					fuse_ino_t *ret_parent,
+					struct node **ret_dot)
 {
 	struct fuse *f = req_fuse_prepare(req);
 	struct fuse_entry_param e;
-	char *path;
-	int err;
 	struct node *dot = NULL;
 
 	if (name[0] == '.') {
@@ -2715,7 +2740,20 @@ static void fuse_lib_lookup(fuse_req_t req, fuse_ino_t parent,
 			name = NULL;
 		}
 	}
+	*ret_parent = parent;
+	*ret_dot = dot;
+}
 
+static void fuse_lib_lookup(fuse_req_t req, fuse_ino_t parent,
+			    const char *name)
+{
+	struct fuse *f = req_fuse_prepare(req);
+	struct fuse_entry_param e;
+	char *path;
+	int err;
+	struct node *dot = NULL;
+
+	fuse_do_get_node_dot_dotdot(req, parent, name, &parent, &dot);
 	err = get_path_name(f, parent, name, &path);
 	if (!err) {
 		struct fuse_intr_data d;
@@ -3288,6 +3326,67 @@ static void fuse_lib_open(fuse_req_t req, fuse_ino_t ino,
 		reply_err(req, err);
 
 	free_path(f, ino, path);
+}
+
+static void fuse_lib_atomic_open(fuse_req_t req, fuse_ino_t parent,
+				 const char *name, struct fuse_file_info *fi)
+{
+	struct fuse *f = req_fuse_prepare(req);
+	struct fuse_intr_data d;
+	struct fuse_entry_param e;
+	char *path;
+	int err;
+	struct node *dot = NULL;
+
+	fuse_do_get_node_dot_dotdot(req, parent, name, &parent, &dot);
+	err = get_path_name(f, parent, name, &path);
+	if (!err) {
+		fuse_prepare_interrupt(f, req, &d);
+
+		err = fuse_fs_atomic_open(f->fs, path, &e.attr, fi);
+		if (!err) {
+			err = do_lookup(f, parent, name, &e);
+			if (err == 0 && f->conf.debug) {
+				fuse_log(FUSE_LOG_DEBUG, "   NODEID: %llu\n",
+					 (unsigned long long) e.ino);
+			}
+		}
+		if (!err) {
+			if (S_ISREG(e.attr.st_mode)) {
+				if (f->conf.direct_io)
+					fi->direct_io = 1;
+				if (f->conf.kernel_cache)
+					fi->keep_cache = 1;
+				if (f->conf.auto_cache)
+					open_auto_cache(f, e.ino, path, fi);
+			}
+		} else if (err == -ENOENT && f->conf.negative_timeout != 0.0) {
+			e.ino = 0;
+			e.entry_timeout = f->conf.negative_timeout;
+			err = 0;
+		}
+		fuse_finish_interrupt(f, req, &d);
+	}
+	if (dot) {
+		pthread_mutex_lock(&f->lock);
+		unref_node(f, dot);
+		pthread_mutex_unlock(&f->lock);
+	}
+	if (!err) {
+		pthread_mutex_lock(&f->lock);
+		get_node(f, e.ino)->open_count++;
+		pthread_mutex_unlock(&f->lock);
+		if (fuse_reply_atomic_open(req, &e, fi) == -ENOENT) {
+			/* The atomic open syscall was interrupted, so it
+			 * must be cancelled.
+			 */
+			fuse_do_release(f, e.ino, path, fi);
+			forget_node(f, e.ino, 1);
+		}
+	} else {
+		reply_err(req, err);
+	}
+	free_path(f, parent, path);
 }
 
 static void fuse_lib_read(fuse_req_t req, fuse_ino_t ino, size_t size,
@@ -4477,6 +4576,7 @@ static struct fuse_lowlevel_ops fuse_path_ops = {
 	.link = fuse_lib_link,
 	.create = fuse_lib_create,
 	.open = fuse_lib_open,
+	.atomic_open = fuse_lib_atomic_open,
 	.read = fuse_lib_read,
 	.write_buf = fuse_lib_write_buf,
 	.flush = fuse_lib_flush,

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -429,6 +429,12 @@ int fuse_reply_create(fuse_req_t req, const struct fuse_entry_param *e,
 			     entrysize + sizeof(struct fuse_open_out));
 }
 
+int fuse_reply_atomic_open(fuse_req_t req, const struct fuse_entry_param *e,
+			   const struct fuse_file_info *f)
+{
+	return fuse_reply_create(req, e, f);
+}
+
 int fuse_reply_attr(fuse_req_t req, const struct stat *attr,
 		    double attr_timeout)
 {
@@ -1330,6 +1336,28 @@ static void do_open(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		fuse_reply_open(req, &fi);
 }
 
+static void do_atomic_open(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
+{
+	struct fuse_create_in *arg = (struct fuse_create_in *) inarg;
+
+	if (req->se->op.atomic_open) {
+		struct fuse_file_info fi;
+		char *name = PARAM(arg);
+
+		memset(&fi, 0, sizeof(fi));
+		fi.flags = arg->flags;
+
+		if (req->se->conn.proto_minor >= 12)
+			req->ctx.umask = arg->umask;
+		else
+			name = (char *) inarg + sizeof(struct fuse_open_in);
+
+		req->se->op.atomic_open(req, nodeid, name, &fi);
+
+	} else
+		fuse_reply_err(req, ENOSYS);
+}
+
 static void do_read(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 {
 	struct fuse_read_in *arg = (struct fuse_read_in *) inarg;
@@ -1973,6 +2001,8 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 			se->conn.capable |= FUSE_CAP_NO_OPENDIR_SUPPORT;
 		if (inargflags & FUSE_EXPLICIT_INVAL_DATA)
 			se->conn.capable |= FUSE_CAP_EXPLICIT_INVAL_DATA;
+		if (inargflags & FUSE_DO_ATOMIC_OPEN)
+			se->conn.capable |= FUSE_CAP_ATOMIC_OPEN;
 		if (!(inargflags & FUSE_MAX_PAGES)) {
 			size_t max_bufsize =
 				FUSE_DEFAULT_MAX_PAGES_PER_REQ * getpagesize()
@@ -2020,8 +2050,9 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 	LL_SET_DEFAULT(se->op.readdirplus, FUSE_CAP_READDIRPLUS);
 	LL_SET_DEFAULT(se->op.readdirplus && se->op.readdir,
 		       FUSE_CAP_READDIRPLUS_AUTO);
+	LL_SET_DEFAULT(se->op.atomic_open, FUSE_CAP_ATOMIC_OPEN);
 	se->conn.time_gran = 1;
-	
+
 	if (bufsize < FUSE_MIN_READ_BUFFER) {
 		fuse_log(FUSE_LOG_ERR, "fuse: warning: buffer size too small: %zu\n",
 			bufsize);
@@ -2097,7 +2128,8 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		outargflags |= FUSE_CACHE_SYMLINKS;
 	if (se->conn.want & FUSE_CAP_EXPLICIT_INVAL_DATA)
 		outargflags |= FUSE_EXPLICIT_INVAL_DATA;
-
+	if (se->conn.want & FUSE_CAP_ATOMIC_OPEN)
+		outargflags |= FUSE_DO_ATOMIC_OPEN;
 	outarg.flags = outargflags;
 
 	if (inargflags & FUSE_INIT_EXT)
@@ -2244,7 +2276,7 @@ int fuse_lowlevel_notify_inval_inode(struct fuse_session *se, fuse_ino_t ino,
 
 	if (se->conn.proto_minor < 12)
 		return -ENOSYS;
-	
+
 	outarg.ino = ino;
 	outarg.off = off;
 	outarg.len = len;
@@ -2263,7 +2295,7 @@ int fuse_lowlevel_notify_inval_entry(struct fuse_session *se, fuse_ino_t parent,
 
 	if (!se)
 		return -EINVAL;
-	
+
 	if (se->conn.proto_minor < 12)
 		return -ENOSYS;
 
@@ -2513,6 +2545,7 @@ static struct {
 	[FUSE_RENAME2]     = { do_rename2,      "RENAME2"    },
 	[FUSE_COPY_FILE_RANGE] = { do_copy_file_range, "COPY_FILE_RANGE" },
 	[FUSE_LSEEK]	   = { do_lseek,       "LSEEK"	     },
+	[FUSE_ATOMIC_OPEN] = { do_atomic_open, "ATOMIC_OPEN" },
 	[CUSE_INIT]	   = { cuse_lowlevel_init, "CUSE_INIT"   },
 };
 

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1898,7 +1898,8 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 	struct fuse_session *se = req->se;
 	size_t bufsize = se->bufsize;
 	size_t outargsize = sizeof(outarg);
-
+	uint64_t inargflags = 0;
+	uint64_t outargflags = 0;
 	(void) nodeid;
 	if (se->debug) {
 		fuse_log(FUSE_LOG_DEBUG, "INIT: %u.%u\n", arg->major, arg->minor);
@@ -1933,43 +1934,46 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 	if (arg->minor >= 6) {
 		if (arg->max_readahead < se->conn.max_readahead)
 			se->conn.max_readahead = arg->max_readahead;
-		if (arg->flags & FUSE_ASYNC_READ)
+		inargflags = arg->flags;
+		if (inargflags & FUSE_INIT_EXT)
+			inargflags = inargflags | (uint64_t) arg->flags2 << 32;
+		if (inargflags & FUSE_ASYNC_READ)
 			se->conn.capable |= FUSE_CAP_ASYNC_READ;
-		if (arg->flags & FUSE_POSIX_LOCKS)
+		if (inargflags & FUSE_POSIX_LOCKS)
 			se->conn.capable |= FUSE_CAP_POSIX_LOCKS;
-		if (arg->flags & FUSE_ATOMIC_O_TRUNC)
+		if (inargflags & FUSE_ATOMIC_O_TRUNC)
 			se->conn.capable |= FUSE_CAP_ATOMIC_O_TRUNC;
-		if (arg->flags & FUSE_EXPORT_SUPPORT)
+		if (inargflags & FUSE_EXPORT_SUPPORT)
 			se->conn.capable |= FUSE_CAP_EXPORT_SUPPORT;
-		if (arg->flags & FUSE_DONT_MASK)
+		if (inargflags & FUSE_DONT_MASK)
 			se->conn.capable |= FUSE_CAP_DONT_MASK;
-		if (arg->flags & FUSE_FLOCK_LOCKS)
+		if (inargflags & FUSE_FLOCK_LOCKS)
 			se->conn.capable |= FUSE_CAP_FLOCK_LOCKS;
-		if (arg->flags & FUSE_AUTO_INVAL_DATA)
+		if (inargflags & FUSE_AUTO_INVAL_DATA)
 			se->conn.capable |= FUSE_CAP_AUTO_INVAL_DATA;
-		if (arg->flags & FUSE_DO_READDIRPLUS)
+		if (inargflags & FUSE_DO_READDIRPLUS)
 			se->conn.capable |= FUSE_CAP_READDIRPLUS;
-		if (arg->flags & FUSE_READDIRPLUS_AUTO)
+		if (inargflags & FUSE_READDIRPLUS_AUTO)
 			se->conn.capable |= FUSE_CAP_READDIRPLUS_AUTO;
-		if (arg->flags & FUSE_ASYNC_DIO)
+		if (inargflags & FUSE_ASYNC_DIO)
 			se->conn.capable |= FUSE_CAP_ASYNC_DIO;
-		if (arg->flags & FUSE_WRITEBACK_CACHE)
+		if (inargflags & FUSE_WRITEBACK_CACHE)
 			se->conn.capable |= FUSE_CAP_WRITEBACK_CACHE;
-		if (arg->flags & FUSE_NO_OPEN_SUPPORT)
+		if (inargflags & FUSE_NO_OPEN_SUPPORT)
 			se->conn.capable |= FUSE_CAP_NO_OPEN_SUPPORT;
-		if (arg->flags & FUSE_PARALLEL_DIROPS)
+		if (inargflags & FUSE_PARALLEL_DIROPS)
 			se->conn.capable |= FUSE_CAP_PARALLEL_DIROPS;
-		if (arg->flags & FUSE_POSIX_ACL)
+		if (inargflags & FUSE_POSIX_ACL)
 			se->conn.capable |= FUSE_CAP_POSIX_ACL;
-		if (arg->flags & FUSE_HANDLE_KILLPRIV)
+		if (inargflags & FUSE_HANDLE_KILLPRIV)
 			se->conn.capable |= FUSE_CAP_HANDLE_KILLPRIV;
-		if (arg->flags & FUSE_CACHE_SYMLINKS)
+		if (inargflags & FUSE_CACHE_SYMLINKS)
 			se->conn.capable |= FUSE_CAP_CACHE_SYMLINKS;
-		if (arg->flags & FUSE_NO_OPENDIR_SUPPORT)
+		if (inargflags & FUSE_NO_OPENDIR_SUPPORT)
 			se->conn.capable |= FUSE_CAP_NO_OPENDIR_SUPPORT;
-		if (arg->flags & FUSE_EXPLICIT_INVAL_DATA)
+		if (inargflags & FUSE_EXPLICIT_INVAL_DATA)
 			se->conn.capable |= FUSE_CAP_EXPLICIT_INVAL_DATA;
-		if (!(arg->flags & FUSE_MAX_PAGES)) {
+		if (!(inargflags & FUSE_MAX_PAGES)) {
 			size_t max_bufsize =
 				FUSE_DEFAULT_MAX_PAGES_PER_REQ * getpagesize()
 				+ FUSE_BUFFER_HEADER_SIZE;
@@ -2060,39 +2064,44 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		outarg.flags |= FUSE_MAX_PAGES;
 		outarg.max_pages = (se->conn.max_write - 1) / getpagesize() + 1;
 	}
-
+	outargflags = outarg.flags;
 	/* Always enable big writes, this is superseded
 	   by the max_write option */
-	outarg.flags |= FUSE_BIG_WRITES;
+	outargflags |= FUSE_BIG_WRITES;
 
 	if (se->conn.want & FUSE_CAP_ASYNC_READ)
-		outarg.flags |= FUSE_ASYNC_READ;
+		outargflags |= FUSE_ASYNC_READ;
 	if (se->conn.want & FUSE_CAP_POSIX_LOCKS)
-		outarg.flags |= FUSE_POSIX_LOCKS;
+		outargflags |= FUSE_POSIX_LOCKS;
 	if (se->conn.want & FUSE_CAP_ATOMIC_O_TRUNC)
-		outarg.flags |= FUSE_ATOMIC_O_TRUNC;
+		outargflags |= FUSE_ATOMIC_O_TRUNC;
 	if (se->conn.want & FUSE_CAP_EXPORT_SUPPORT)
-		outarg.flags |= FUSE_EXPORT_SUPPORT;
+		outargflags |= FUSE_EXPORT_SUPPORT;
 	if (se->conn.want & FUSE_CAP_DONT_MASK)
-		outarg.flags |= FUSE_DONT_MASK;
+		outargflags |= FUSE_DONT_MASK;
 	if (se->conn.want & FUSE_CAP_FLOCK_LOCKS)
-		outarg.flags |= FUSE_FLOCK_LOCKS;
+		outargflags |= FUSE_FLOCK_LOCKS;
 	if (se->conn.want & FUSE_CAP_AUTO_INVAL_DATA)
-		outarg.flags |= FUSE_AUTO_INVAL_DATA;
+		outargflags |= FUSE_AUTO_INVAL_DATA;
 	if (se->conn.want & FUSE_CAP_READDIRPLUS)
-		outarg.flags |= FUSE_DO_READDIRPLUS;
+		outargflags |= FUSE_DO_READDIRPLUS;
 	if (se->conn.want & FUSE_CAP_READDIRPLUS_AUTO)
-		outarg.flags |= FUSE_READDIRPLUS_AUTO;
+		outargflags |= FUSE_READDIRPLUS_AUTO;
 	if (se->conn.want & FUSE_CAP_ASYNC_DIO)
-		outarg.flags |= FUSE_ASYNC_DIO;
+		outargflags |= FUSE_ASYNC_DIO;
 	if (se->conn.want & FUSE_CAP_WRITEBACK_CACHE)
-		outarg.flags |= FUSE_WRITEBACK_CACHE;
+		outargflags |= FUSE_WRITEBACK_CACHE;
 	if (se->conn.want & FUSE_CAP_POSIX_ACL)
-		outarg.flags |= FUSE_POSIX_ACL;
+		outargflags |= FUSE_POSIX_ACL;
 	if (se->conn.want & FUSE_CAP_CACHE_SYMLINKS)
-		outarg.flags |= FUSE_CACHE_SYMLINKS;
+		outargflags |= FUSE_CACHE_SYMLINKS;
 	if (se->conn.want & FUSE_CAP_EXPLICIT_INVAL_DATA)
-		outarg.flags |= FUSE_EXPLICIT_INVAL_DATA;
+		outargflags |= FUSE_EXPLICIT_INVAL_DATA;
+
+	outarg.flags = outargflags;
+
+	if (inargflags & FUSE_INIT_EXT)
+		outarg.flags2 = outargflags >> 32;
 	outarg.max_readahead = se->conn.max_readahead;
 	outarg.max_write = se->conn.max_write;
 	if (se->conn.proto_minor >= 13) {


### PR DESCRIPTION
This patch series prepares the ground and implement atomic lookup + open in libfuse. Also it modifies passthrough_ll to handle the same. Code changes to implement atomic open in fuse kernel has been raised through following patch series
https://lore.kernel.org/linux-fsdevel/20220322115148.3870-1-dharamhans87@gmail.com/
https://lore.kernel.org/linux-fsdevel/20220322115148.3870-2-dharamhans87@gmail.com/
https://lore.kernel.org/linux-fsdevel/20220322115148.3870-3-dharamhans87@gmail.com/
https://lore.kernel.org/linux-fsdevel/20220322121212.5087-1-dharamhans87@gmail.com/