### PR TITLE
patch: document ignored parameter of readdir's fill parameter

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -563,6 +563,10 @@ struct fuse_operations {
 	 * passes non-zero offset to the filler function.  When the buffer
 	 * is full (or an error happens) the filler function will return
 	 * '1'.
+	 *
+	 * The file attributes argument of the fuse_fill_dir_t parameter is only used
+	 * when FUSE_READDIR_PLUS is set in the fuse_readdir_flags parameter.
+	 * Otherwise, it is ignored.
 	 */
 	int (*readdir) (const char *, void *, fuse_fill_dir_t, off_t,
 			struct fuse_file_info *, enum fuse_readdir_flags);


### PR DESCRIPTION
I'm not 100% sure about this. My reasoning is as follows:

`fuse_lib_readdir` calls `fuse_readdir_common` which calls
`readdir_fill` which uses `fill_dir` as the `fuse_fill_dir_t`.
`fill_dir` will then call `fuse_add_direntry_to_dh` and push an entry to
a linked list. That is, the `stat` that you pass to the fill function is
definitely stored in the linked list.

See https://github.com/libfuse/libfuse/blob/2b7a6f065b6e30723d6cc8668cff198dbb62b914/lib/fuse.c#L3545

However, I think that the linked list is not really used (?). If you
want to access the `stat` via the fs, then the `getattr` hook is
executed, which, however, doesn't use the linked list and just uses a
new, zeroed-out `stdbuf`.

See https://github.com/libfuse/libfuse/blob/2b7a6f065b6e30723d6cc8668cff198dbb62b914/lib/fuse.c#L2777