### PR TITLE
Implement Atomic lookup + create

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -633,6 +633,30 @@ struct fuse_operations {
 	int (*create) (const char *, mode_t, struct fuse_file_info *);
 
 	/**
+	 *
+	 * Note: This call is an optimization to avoid lookusp before create.
+	 * If this call is implemented fuse kernel would avoid unnecessary lookups
+	 * performed before creating the file (since this is create, most likely
+	 * file does not exist yet in FS but we do lookups on such files before
+	 * actually creating them)
+	 *
+	 * Create and open a file
+	 *
+	 * There are two cases to be handled here:
+	 *  a) File does not exist yet(most likely)
+	 *  	- Create it with specified mode.
+	 *  	- Set 'file_created' bit in 'struct fuse_file_info'.
+	 *  	- Fill in the file attributes.
+	 *  	- Open it.
+	 *  b) File already exist(exception is O_EXCL)
+	 *  	- Fill in the file attributes.
+	 *  	- Do not set 'file_created' bit for such files.
+	 *  	- Open the file
+	 */
+
+	int (*atomic_create) (const char *, struct stat *, mode_t,
+			      struct fuse_file_info *);
+	/**
 	 * Perform POSIX file locking operation
 	 *
 	 * The cmd argument will be either F_GETLK, F_SETLK or F_SETLKW.
@@ -1191,6 +1215,8 @@ int fuse_fs_releasedir(struct fuse_fs *fs, const char *path,
 		       struct fuse_file_info *fi);
 int fuse_fs_create(struct fuse_fs *fs, const char *path, mode_t mode,
 		   struct fuse_file_info *fi);
+int fuse_fs_atomic_create(struct fuse_fs *fs, const char *path, struct stat *,
+			  mode_t mode, struct fuse_file_info *fi);
 int fuse_fs_lock(struct fuse_fs *fs, const char *path,
 		 struct fuse_file_info *fi, int cmd, struct flock *lock);
 int fuse_fs_flock(struct fuse_fs *fs, const char *path,

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -87,8 +87,13 @@ struct fuse_file_info {
 	    on close. */
 	unsigned int noflush : 1;
 
+	/** Can be filled in by atomic_create, to indicate that new file was
+	    created. It must not be set if the file was found to be existing
+	    already. */
+	unsigned int file_created : 1;
+
 	/** Padding.  Reserved for future use*/
-	unsigned int padding : 24;
+	unsigned int padding : 23;
 	unsigned int padding2 : 32;
 
 	/** File handle id.  May be filled in by filesystem in create,

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -239,6 +239,7 @@ struct fuse_file_lock {
  * FOPEN_CACHE_DIR: allow caching this directory
  * FOPEN_STREAM: the file is stream-like (no file position at all)
  * FOPEN_NOFLUSH: don't flush data cache on close (unless FUSE_WRITEBACK_CACHE)
+ * FOPEN_FILE_CREATED: new file was created in create call
  */
 #define FOPEN_DIRECT_IO		(1 << 0)
 #define FOPEN_KEEP_CACHE	(1 << 1)
@@ -246,6 +247,7 @@ struct fuse_file_lock {
 #define FOPEN_CACHE_DIR		(1 << 3)
 #define FOPEN_STREAM		(1 << 4)
 #define FOPEN_NOFLUSH		(1 << 5)
+#define FOPEN_FILE_CREATED	(1 << 6)
 
 /**
  * INIT request/reply flags
@@ -433,6 +435,7 @@ enum fuse_opcode {
 	FUSE_RENAME2		= 45,
 	FUSE_LSEEK		= 46,
 	FUSE_COPY_FILE_RANGE	= 47,
+	FUSE_ATOMIC_CREATE	= 51,
 
 	/* CUSE specific operations */
 	CUSE_INIT		= 4096

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -927,6 +927,38 @@ struct fuse_lowlevel_ops {
 			mode_t mode, struct fuse_file_info *fi);
 
 	/**
+	 * Lookup, create and open a file
+	 *
+	 * Do a lookup on the file, if it does not exits then create it with specified
+	 * mode, and then open it.
+	 *
+	 * If this method is not implemented then we fall back to create() and all
+	 * comments of create apply to it.
+	 *
+	 * If this request is answered with erro code ENOSYS, the handler is treated as not
+	 * implemented(i.e for this and future requests, create() handler is called instead).
+	 *
+	 * Note: USER SPACE implementations should first do lookup on the file. If it exist then
+	 * fill in the attributes and open it and return. If file is newly created then USER
+	 * SPACE is supposed to open it, fill in attributes and fill in `file_created` bit in
+	 * `struct fuse_file_info` for such file. This bit is used by libfuse to convey same
+	 * info to the fuse kernel.
+	 *
+	 * Valid replies:
+	 *   fuse_reply_create
+	 *   fuse_reply_err
+	 *
+	 *  @param req request handle
+	 *  @param parent inode number of the parent directory
+	 *  @param name to create
+	 *  @param mode file type and mode with which to create the new file
+	 *  @param fi file information
+	 *
+	 */
+	void (*atomic_create) (fuse_req_t req, fuse_ino_t parent,
+			       const char *name, mode_t mode,
+			       struct fuse_file_info *fi);
+	/**
 	 * Test for a POSIX file lock
 	 *
 	 * Valid replies:

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -2075,6 +2075,29 @@ int fuse_fs_create(struct fuse_fs *fs, const char *path, mode_t mode,
 	}
 }
 
+int fuse_fs_atomic_create(struct fuse_fs *fs, const char *path,
+			  struct stat *buf, mode_t mode,
+			  struct fuse_file_info *fi)
+{
+	fuse_get_context()->private_data = fs->user_data;
+	if (fs->op.atomic_create) {
+		int err;
+		if (fs->debug)
+			fuse_log(FUSE_LOG_DEBUG,
+				 "Atomic create flags: 0x%x %s 0%o umask=0%03o\n",
+				 fi->flags, path, mode,
+				 fuse_get_context()->umask);
+		err = fs->op.atomic_create(path, buf, mode, fi);
+
+		if (fs->debug && !err)
+			fuse_log(FUSE_LOG_DEBUG, "   Atomic create[%llu] flags: 0x%x %s\n",
+				(unsigned long long) fi->fh, fi->flags, path);
+		return err;
+	} else {
+		 return -ENOSYS;
+	}
+}
+
 int fuse_fs_lock(struct fuse_fs *fs, const char *path,
 		 struct fuse_file_info *fi, int cmd, struct flock *lock)
 {
@@ -3181,6 +3204,57 @@ static void fuse_lib_create(fuse_req_t req, fuse_ino_t parent,
 		err = fuse_fs_create(f->fs, path, mode, fi);
 		if (!err) {
 			err = lookup_path(f, parent, name, path, &e, fi);
+			if (err)
+				fuse_fs_release(f->fs, path, fi);
+			else if (!S_ISREG(e.attr.st_mode)) {
+				err = -EIO;
+				fuse_fs_release(f->fs, path, fi);
+				forget_node(f, e.ino, 1);
+			} else {
+				if (f->conf.direct_io)
+					fi->direct_io = 1;
+				if (f->conf.kernel_cache)
+					fi->keep_cache = 1;
+
+			}
+		}
+		fuse_finish_interrupt(f, req, &d);
+	}
+	if (!err) {
+		pthread_mutex_lock(&f->lock);
+		get_node(f, e.ino)->open_count++;
+		pthread_mutex_unlock(&f->lock);
+		if (fuse_reply_create(req, &e, fi) == -ENOENT) {
+			/* The open syscall was interrupted, so it
+			   must be cancelled */
+			fuse_do_release(f, e.ino, path, fi);
+			forget_node(f, e.ino, 1);
+		}
+	} else {
+		reply_err(req, err);
+	}
+
+	free_path(f, parent, path);
+}
+
+
+
+static void fuse_lib_atomic_create(fuse_req_t req, fuse_ino_t parent,
+				   const char *name, mode_t mode,
+				   struct fuse_file_info *fi)
+{
+	struct fuse *f = req_fuse_prepare(req);
+	struct fuse_intr_data d;
+	struct fuse_entry_param e;
+	char *path;
+	int err;
+
+	err = get_path_name(f, parent, name, &path);
+	if (!err) {
+		fuse_prepare_interrupt(f, req, &d);
+		err = fuse_fs_atomic_create(f->fs, path, &e.attr, mode, fi);
+		if (!err) {
+			err = do_lookup(f, parent, name, &e);
 			if (err)
 				fuse_fs_release(f->fs, path, fi);
 			else if (!S_ISREG(e.attr.st_mode)) {
@@ -4480,6 +4554,7 @@ static struct fuse_lowlevel_ops fuse_path_ops = {
 	.rename = fuse_lib_rename,
 	.link = fuse_lib_link,
 	.create = fuse_lib_create,
+	.atomic_create = fuse_lib_atomic_create,
 	.open = fuse_lib_open,
 	.read = fuse_lib_read,
 	.write_buf = fuse_lib_write_buf,


### PR DESCRIPTION
There are certain places where we can avoid costly lookup calls
into libfuse from fuse kernel. One of such place is
1) When we go for opening the file with O_CREAT flags.

Since we are going to create a file (passing O_CREAT in open),
its very much likely that file does not exist yet so lookup
performed before creating a file can be avoided. Instead this
lookup can be performed as part of create call itself.

Now with these changes, user space when receiving atomic create is
supposed to create the file if it does not exist/perform lookup on
the file if already existing, fill in the attributes, set 'file_created'
bit in 'struct fuse_file_info' and open the file. These filled in
attributes are used by fuse kernel to make inode stand/revalidate.

Link to the kernel patch is
https://lore.kernel.org/linux-fsdevel/20220502054628.25826-1-dharamhans87@gmail.com/T/#t