### PR TITLE
Atomic create passthrough ll

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -87,8 +87,13 @@ struct fuse_file_info {
 	    on close. */
 	unsigned int noflush : 1;
 
+	/** Can be filled in by extended create, to indicate that new file was
+	    created. It must not be set if the file was found to be existing
+	    already. */
+	unsigned int file_created : 1;
+
 	/** Padding.  Reserved for future use*/
-	unsigned int padding : 24;
+	unsigned int padding : 23;
 	unsigned int padding2 : 32;
 
 	/** File handle id.  May be filled in by filesystem in create,

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -239,6 +239,7 @@ struct fuse_file_lock {
  * FOPEN_CACHE_DIR: allow caching this directory
  * FOPEN_STREAM: the file is stream-like (no file position at all)
  * FOPEN_NOFLUSH: don't flush data cache on close (unless FUSE_WRITEBACK_CACHE)
+ * FOPEN_FILE_CREATED: new file was created in create call
  */
 #define FOPEN_DIRECT_IO		(1 << 0)
 #define FOPEN_KEEP_CACHE	(1 << 1)
@@ -246,6 +247,7 @@ struct fuse_file_lock {
 #define FOPEN_CACHE_DIR		(1 << 3)
 #define FOPEN_STREAM		(1 << 4)
 #define FOPEN_NOFLUSH		(1 << 5)
+#define FOPEN_FILE_CREATED	(1 << 6)
 
 /**
  * INIT request/reply flags
@@ -433,6 +435,7 @@ enum fuse_opcode {
 	FUSE_RENAME2		= 45,
 	FUSE_LSEEK		= 46,
 	FUSE_COPY_FILE_RANGE	= 47,
+	FUSE_CREATE_EXT		= 51,
 
 	/* CUSE specific operations */
 	CUSE_INIT		= 4096

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -927,6 +927,38 @@ struct fuse_lowlevel_ops {
 			mode_t mode, struct fuse_file_info *fi);
 
 	/**
+	 * Lookup, create and open a file
+	 *
+	 * Do a lookup on the file, if it does not exits then create it with specified
+	 * mode, and then open it.
+	 *
+	 * If this method is not implemented then we fall back to create() and all
+	 * comments of create apply to it.
+	 *
+	 * If this request is answered with erro code ENOSYS, the handler is treated as not
+	 * implemented(i.e for this and future requests, create() handler is called instead).
+	 *
+	 * Note: USER SPACE implementations should first do lookup on the file. If it exist then
+	 * fill in the attributes and open it and return. If file is newly created then USER
+	 * SPACE is supposed to open it, fill in attributes and fill in `file_created` bit in
+	 * `struct fuse_file_info` for such file. This bit is used by libfuse to convey same
+	 * info to the fuse kernel.
+	 *
+	 * Valid replies:
+	 *   fuse_reply_create
+	 *   fuse_reply_err
+	 *
+	 *  @param req request handle
+	 *  @param parent inode number of the parent directory
+	 *  @param name to create
+	 *  @param mode file type and mode with which to create the new file
+	 *  @param fi file information
+	 *
+	 */
+	void (*create_ext) (fuse_req_t req, fuse_ino_t parent,
+			    const char *name, mode_t mode,
+			    struct fuse_file_info *fi);
+	/**
 	 * Test for a POSIX file lock
 	 *
 	 * Valid replies:

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -398,6 +398,8 @@ static void fill_open(struct fuse_open_out *arg,
 		arg->open_flags |= FOPEN_NONSEEKABLE;
 	if (f->noflush)
 		arg->open_flags |= FOPEN_NOFLUSH;
+	if (f->file_created)
+		arg->open_flags |= FOPEN_FILE_CREATED;
 }
 
 int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param *e)
@@ -1315,6 +1317,26 @@ static void do_create(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 			name = (char *) inarg + sizeof(struct fuse_open_in);
 
 		req->se->op.create(req, nodeid, name, arg->mode, &fi);
+	} else
+		fuse_reply_err(req, ENOSYS);
+}
+
+static void do_create_ext(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
+{
+	struct fuse_create_in *arg = (struct fuse_create_in *) inarg;
+
+	if (req->se->op.create_ext) {
+		struct fuse_file_info fi;
+		char *name = PARAM(arg);
+
+		memset(&fi, 0, sizeof(fi));
+		fi.flags = arg->flags;
+
+		if (req->se->conn.proto_minor >= 12)
+			req->ctx.umask = arg->umask;
+		else
+			name = (char *) inarg + sizeof(struct fuse_open_in);
+		req->se->op.create_ext(req, nodeid, name, arg->mode, &fi);
 	} else
 		fuse_reply_err(req, ENOSYS);
 }
@@ -2512,6 +2534,7 @@ static struct {
 	[FUSE_SETLKW]	   = { do_setlkw,      "SETLKW"	     },
 	[FUSE_ACCESS]	   = { do_access,      "ACCESS"	     },
 	[FUSE_CREATE]	   = { do_create,      "CREATE"	     },
+	[FUSE_CREATE_EXT]  = { do_create_ext,  "EXTENDED_CREATE" },
 	[FUSE_INTERRUPT]   = { do_interrupt,   "INTERRUPT"   },
 	[FUSE_BMAP]	   = { do_bmap,	       "BMAP"	     },
 	[FUSE_IOCTL]	   = { do_ioctl,       "IOCTL"	     },


### PR DESCRIPTION
These patches implements atomic create operation. passthrough_ll has been modified to handle atomic create.

Link to the kernel patch is
https://lore.kernel.org/linux-fsdevel/20220502054628.25826-1-dharamhans87@gmail.com/T/#t