### PR TITLE
Fix a test strncpy compilation warning with recent gcc 

### DIFF
--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -1868,9 +1868,10 @@ static int test_socket(void)
 	int fd;
 	int res;
 	int err = 0;
+    const size_t test_sock_len = strlen(testsock) + 1;
 
 	start_test("socket");
-	if (strlen(testsock) + 1 > sizeof(su.sun_path)) {
+	if (test_sock_len > sizeof(su.sun_path)) {
 		fprintf(stderr, "Need to shorten mount point by %zu chars\n",
 			strlen(testsock) + 1 - sizeof(su.sun_path));
 		return -1;
@@ -1882,7 +1883,8 @@ static int test_socket(void)
 		return -1;
 	}
 	su.sun_family = AF_UNIX;
-	strncpy(su.sun_path, testsock, sizeof(su.sun_path) - 1);
+
+	strncpy(su.sun_path, testsock, test_sock_len);
 	su.sun_path[sizeof(su.sun_path) - 1] = '\0';
 	res = bind(fd, (struct sockaddr*)&su, sizeof(su));
 	if (res == -1) {


### PR DESCRIPTION
meson configure -D buildtype=debugoptimized
meson configure -D b_sanitize=address,undefined

Results in '-fsanitize=address,undefined ... -O2 -g' that made
compilation to give errors with recent gcc versions.


bernd@t1700bs build-ubuntu>ninja -v
[1/2] ccache gcc -Itest/test_syscalls.p -Itest -I../test -Iinclude -I../include -Ilib -I../lib -I. -I.. -fdiagnostics-color=always -fsanitize=address,undefined -fno-omit-frame-pointer -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -O2 -g -D_REENTRANT -DHAVE_CONFIG_H -Wno-sign-compare -Wstrict-prototypes -Wmissing-declarations -Wwrite-strings -fno-strict-aliasing -Wno-unused-result -DHAVE_SYMVER_ATTRIBUTE -MD -MQ test/test_syscalls.p/test_syscalls.c.o -MF test/test_syscalls.p/test_syscalls.c.o.d -o test/test_syscalls.p/test_syscalls.c.o -c ../test/test_syscalls.c
FAILED: test/test_syscalls.p/test_syscalls.c.o
ccache gcc -Itest/test_syscalls.p -Itest -I../test -Iinclude -I../include -Ilib -I../lib -I. -I.. -fdiagnostics-color=always -fsanitize=address,undefined -fno-omit-frame-pointer -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -O2 -g -D_REENTRANT -DHAVE_CONFIG_H -Wno-sign-compare -Wstrict-prototypes -Wmissing-declarations -Wwrite-strings -fno-strict-aliasing -Wno-unused-result -DHAVE_SYMVER_ATTRIBUTE -MD -MQ test/test_syscalls.p/test_syscalls.c.o -MF test/test_syscalls.p/test_syscalls.c.o.d -o test/test_syscalls.p/test_syscalls.c.o -c ../test/test_syscalls.c
In file included from /usr/include/string.h:519,
                 from ../test/test_syscalls.c:7:
In function ‘strncpy’,
    inlined from ‘test_socket’ at ../test/test_syscalls.c:1885:2,
    inlined from ‘main’ at ../test/test_syscalls.c:2030:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error: ‘__builtin_strncpy’ output may be truncated copying 107 bytes from a string of length 1023 [-Werror=stringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~



I disagree a bit on the gcc sanity here, as the code was behaving
correctly and even already checked the string length. But sice
the string length is already verified, that length can be used
for the final strncpy.