### PR TITLE
Increase meson min version and avoid get_pkgconfig_variable warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libfuse3', ['c'], version: '3.11.0',
-        meson_version: '>= 0.42',
+        meson_version: '>= 0.51',
         default_options: [
             'buildtype=debugoptimized',
             'cpp_std=c++11',

--- a/util/meson.build
+++ b/util/meson.build
@@ -17,7 +17,7 @@ executable('mount.fuse3', ['mount.fuse.c'],
 udevrulesdir = get_option('udevrulesdir')
 if udevrulesdir == ''
   udev = dependency('udev')
-  udevrulesdir = join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
+  udevrulesdir = join_paths(udev.get_variable(pkgconfig : 'udevdir'), 'rules.d')
 endif
 
 meson.add_install_script('install_helper.sh',


### PR DESCRIPTION
meson was complaining:

Build targets in project: 27
NOTICE: Future-deprecated features used:
 * 0.56.0: {'Dependency.get_pkgconfig_variable'}


So change to .get_variable(pkgconfig : 'type' and also increase
the meson minimal version to be able to handle it.