### PR TITLE
fix use after free in iconv module

### DIFF
--- a/lib/modules/iconv.c
+++ b/lib/modules/iconv.c
@@ -82,7 +82,8 @@ static int iconv_convpath(struct iconv *ic, const char *path, char **newpathp,
 			if (!tmp)
 				goto err;
 
-			p = tmp + (p - newpath);
+			if (tmp != newpath)
+				p = tmp;
 			plen += inc;
 			newpath = tmp;
 		}


### PR DESCRIPTION
After realloc, newpath shouldn't be used if newpath != tmp.