### PR TITLE
Use destroy_req instead of free to destroy fuse_req

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1762,7 +1762,9 @@ static struct fuse_req *check_interrupt(struct fuse_session *se,
 		if (curr->u.i.unique == req->unique) {
 			req->interrupted = 1;
 			list_del_req(curr);
-			free(curr);
+			fuse_chan_put(curr->ch);
+			curr->ch = NULL;
+			destroy_req(curr);
 			return NULL;
 		}
 	}


### PR DESCRIPTION
If we get the interrupt before the fuse op, the fuse_req is deleted without
decrementing the refcount on the cloned file descriptor. This leads to a
leak of the cloned /dev/fuse file descriptor.