### PR TITLE
Fix the fuse_parse_cmdline@FUSE_3.0 ABI compat symbol

### DIFF
--- a/lib/helper.c
+++ b/lib/helper.c
@@ -233,7 +233,7 @@ int fuse_parse_cmdline_312(struct fuse_args *args,
  */
 int fuse_parse_cmdline_30(struct fuse_args *args,
 		       struct fuse_cmdline_opts *opts);
-FUSE_SYMVER("fuse_parse_cmdline_37", "fuse_parse_cmdline@FUSE_3.0")
+FUSE_SYMVER("fuse_parse_cmdline_30", "fuse_parse_cmdline@FUSE_3.0")
 int fuse_parse_cmdline_30(struct fuse_args *args,
 			  struct fuse_cmdline_opts *out_opts)
 {


### PR DESCRIPTION
There was a simple typo and sym1 didn't match the function name with the older __asm__(".symver " sym1 "," sym2) way to define ABI compatibility. 
Witht the newer "__attribute__ ((symver (sym2)))" sym1 is not used at all and in manual testing the issue didn't come up therefore.