### PR TITLE
Fix build failure with uclibc using HAVE_SYMVER_ATTRIBUTE macro and

### DIFF
--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1914,11 +1914,19 @@ int fuse_parse_cmdline(struct fuse_args *args,
 #if FUSE_USE_VERSION < FUSE_MAKE_VERSION(3, 12)
 int fuse_parse_cmdline_30(struct fuse_args *args,
 			   struct fuse_cmdline_opts *opts);
-#define fuse_parse_cmdline(args, opts) fuse_parse_cmdline_30(args, opts)
+static int fuse_parse_cmdline(struct fuse_args *args,
+			      struct fuse_cmdline_opts *opts)
+{
+	return fuse_parse_cmdline_30(args, opts);
+}
 #else
 int fuse_parse_cmdline_312(struct fuse_args *args,
 			   struct fuse_cmdline_opts *opts);
-#define fuse_parse_cmdline(args, opts) fuse_parse_cmdline_312(args, opts)
+static int fuse_parse_cmdline(struct fuse_args *args,
+			      struct fuse_cmdline_opts *opts)
+{
+	return fuse_parse_cmdline_312(args, opts);
+}
 #endif
 #endif
 

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -251,18 +251,6 @@ int fuse_parse_cmdline_30(struct fuse_args *args,
 	return rc;
 }
 
-/**
- * Compatibility ABI symbol for systems that do not support version symboling
- */
-#if (defined(__UCLIBC__) || defined(__APPLE__))
-int fuse_parse_cmdline(struct fuse_args *args,
-		       struct fuse_cmdline_opts *opts)
-{
-	return fuse_parse_cmdline_30(args, out_opts);
-}
-#endif
-
-
 int fuse_daemonize(int foreground)
 {
 	if (!foreground) {


### PR DESCRIPTION
moving handling to helper.c file

Building with uclibc leads to failure:
```
FAILED: lib/libfuse3.so.3.12.0.p/helper.c.o.
/home/giuliobenetti/git/upstream/test-libfuse3/bootlin-armv5-uclibc/host/bin/arm-linux-gcc -Ilib/libf
In file included from ../lib/fuse_i.h:10,
                 from ../lib/helper.c:14:
../include/fuse_lowlevel.h:1921:40: error: redefinition of ‘fuse_parse_cmdline_312’
 1921 | #define fuse_parse_cmdline(args, opts) fuse_parse_cmdline_312(args, opts)
      |                                        ^~~~~~~~~~~~~~~~~~~~~~
../lib/helper.c:258:5: note: in expansion of macro ‘fuse_parse_cmdline’
  258 | int fuse_parse_cmdline(struct fuse_args *args,
      |     ^~~~~~~~~~~~~~~~~~
../lib/helper.c:208:5: note: previous definition of ‘fuse_parse_cmdline_312’ was here
  208 | int fuse_parse_cmdline_312(struct fuse_args *args,
```
This happens because uclibc, depending on version, can support symver, so if symver is supported and uclibc is used function fuse_parse_cmdline_312() will be defined twice:
1. the function itself with symver
2. fuse_parse_cmdline() as the #define of fuse_parse_cmdline_312() and its prototype
This leads to have the redefinition of ‘fuse_parse_cmdline_312’.

To solve this let's check against HAVE_SYMVER_ATTRIBUTE instead of __UCLIBC__ and __APPLE__ and move all the checks of FUSE_USE_VERSION to helper.c file instead of fuse_lowlevel.h with #define fuse_parse_cmdline that defines fuse_parse_cmdline_312() twice in helper.c leading to the error above.

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>