### PR TITLE
libfuse custom communication interface

### DIFF
--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1955,6 +1955,25 @@ struct fuse_session *fuse_session_new(struct fuse_args *args,
 				      size_t op_size, void *userdata);
 
 /**
+ * Set a file descriptor for the session.
+ *
+ * This function can be used if you want to have a custom communication
+ * interface instead of using a mountpoint. In practice, this means that instead
+ * of calling fuse_session_mount() and fuse_session_unmount(), one could call
+ * fuse_custom_session_fd() where fuse_session_mount() would have otherwise been
+ * called.
+ *
+ * This function does not open or close any file descriptors, meaning it is the
+ * responsibility of the caller to provide a valid file descriptor, such as a
+ * accepted socket. It is also the responsibility to close the socket.
+ *
+ * @param se session object
+ * @param fd file descriptor for the session
+ *
+ **/
+void fuse_custom_session_fd(struct fuse_session *se, int fd);
+
+/**
  * Mount a FUSE file system.
  *
  * @param mountpoint the mount point path

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3009,6 +3009,10 @@ out1:
 	return NULL;
 }
 
+void fuse_custom_session_fd(struct fuse_session *se, int fd) {
+	se->fd = fd;
+}
+
 int fuse_session_mount(struct fuse_session *se, const char *mountpoint)
 {
 	int fd;

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -39,6 +39,7 @@ FUSE_3.0 {
 		fuse_session_new;
 		fuse_main_real;
 		fuse_mount;
+		fuse_custom_session_fd;
 		fuse_session_mount;
 		fuse_new;
 		fuse_opt_insert_arg;


### PR DESCRIPTION
libfuse can be used without having a mountpoint. This can be useful in different cases, for example where you might want to use libfuse in an IPC manner with unix domain sockets. Also for potential server communication. So for instance, instead of using `fuse_session_mount` / `fuse_session_unmount`, one would call `fuse_custum_session_fd` with a fd created by the consumer of the API.

I understand if such functionality is out of scope for this library, but I'll post this PR to see what you think