### PR TITLE
Make it work even if max_idle_threads is set to 0

### DIFF
--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -179,7 +179,7 @@ static void *fuse_do_work(void *data)
 		 * is indeed a good reason to destruct threads it should be done
 		 * delayed, a moving average might be useful for that.
 		 */
-		if (mt->max_idle != -1 && mt->numavail > mt->max_idle) {
+		if (mt->max_idle != -1 && mt->numavail > mt->max_idle && mt->numworker > 1) {
 			if (mt->exit) {
 				pthread_mutex_unlock(&mt->lock);
 				return NULL;


### PR DESCRIPTION
It may happen that none of the worker threads are running if max_idle_threads is set to 0 although few people will do this. Adding a limit of keeping at least one worker thread will make our code more rigorous.

Signed-off-by: Zhansong Gao <zhsgao@hotmail.com>