### PR TITLE
Greater control of custom IO

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,9 @@
+libfuse next.release.version (xxxx-xx-xx)
+=========================================
+* There is a new low-level API function `fuse_session_custom_io` that allows to implement
+  a daemon with a custom io. This can be used to create a daemon that can process incoming
+  FUSE requests to other destinations than `/dev/fuse`.
+
 libfuse 3.12.0 (2022-09-08)
 ===========================
 

--- a/example/hello_ll_uds.c
+++ b/example/hello_ll_uds.c
@@ -1,6 +1,7 @@
 /*
   FUSE: Filesystem in Userspace
   Copyright (C) 2001-2007  Miklos Szeredi <miklos@szeredi.hu>
+  Copyright (C) 2022  Tofik Sonono <tofik.sonono@intel.com>
 
   This program can be distributed under the terms of the GNU GPLv2.
   See the file COPYING.
@@ -8,11 +9,12 @@
 
 /** @file
  *
- * minimal example filesystem using low-level API
+ * minimal example filesystem using low-level API and a custom io. This custom
+ * io is implemented using UNIX domain sockets (of type SOCK_STREAM)
  *
  * Compile with:
  *
- *     gcc -Wall hello_ll.c `pkg-config fuse3 --cflags --libs` -o hello_ll
+ *     gcc -Wall hello_ll_uds.c `pkg-config fuse3 --cflags --libs` -o hello_ll_uds
  *
  * ## Source code ##
  * \include hello_ll.c
@@ -20,7 +22,13 @@
 
 #define FUSE_USE_VERSION 34
 
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <fuse_lowlevel.h>
+#include <fuse_kernel.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -28,6 +36,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <assert.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 
 static const char *hello_str = "Hello World!\n";
 static const char *hello_name = "hello";
@@ -161,19 +171,154 @@ static const struct fuse_lowlevel_ops hello_ll_oper = {
 	.read		= hello_ll_read,
 };
 
+static int create_socket(const char *socket_path) {
+	struct sockaddr_un addr;
+
+	if (strnlen(socket_path, sizeof(addr.sun_path)) >=
+		sizeof(addr.sun_path)) {
+		printf("Socket path may not be longer than %lu characters\n",
+			 sizeof(addr.sun_path) - 1);
+		return -1;
+	}
+
+	if (remove(socket_path) == -1 && errno != ENOENT) {
+		printf("Could not delete previous socket file entry at %s. Error: "
+			 "%s\n", socket_path, strerror(errno));
+		return -1;
+	}
+
+	memset(&addr, 0, sizeof(struct sockaddr_un));
+	strcpy(addr.sun_path, socket_path);
+
+	int sfd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (sfd == -1) {
+		printf("Could not create socket. Error: %s\n", strerror(errno));
+		return -1;
+	}
+
+	addr.sun_family = AF_UNIX;
+	if (bind(sfd, (struct sockaddr *) &addr,
+		   sizeof(struct sockaddr_un)) == -1) {
+		printf("Could not bind socket. Error: %s\n", strerror(errno));
+		return -1;
+	}
+
+	if (listen(sfd, 1) == -1)
+		return -1;
+
+	printf("Awaiting connection on socket at %s...\n", socket_path);
+	int cfd = accept(sfd, NULL, NULL);
+	if (cfd == -1) {
+		printf("Could not accept connection. Error: %s\n",
+			 strerror(errno));
+		return -1;
+	} else {
+		printf("Accepted connection!\n");
+	}
+	return cfd;
+}
+
+static ssize_t stream_writev(int fd, struct iovec *iov, int count,
+                             void *userdata) {
+	(void)userdata;
+
+	ssize_t written = 0;
+	int cur = 0;
+	for (;;) {
+		written = writev(fd, iov+cur, count-cur);
+		if (written < 0)
+			return written;
+
+		while (cur < count && written >= iov[cur].iov_len)
+			written -= iov[cur++].iov_len;
+		if (cur == count)
+			break;
+
+		iov[cur].iov_base = (char *)iov[cur].iov_base + written;
+		iov[cur].iov_len -= written;
+	}
+	return written;
+}
+
+
+static ssize_t readall(int fd, void *buf, size_t len) {
+	size_t count = 0;
+
+	while (count < len) {
+		int i = read(fd, (char *)buf + count, len - count);
+		if (!i)
+			break;
+
+		if (i < 0)
+			return i;
+
+		count += i;
+	}
+	return count;
+}
+
+static ssize_t stream_read(int fd, void *buf, size_t buf_len, void *userdata) {
+    (void)userdata;
+
+	int res = readall(fd, buf, sizeof(struct fuse_in_header));
+	if (res == -1)
+    	return res;
+
+
+    uint32_t packet_len = ((struct fuse_in_header *)buf)->len;
+    if (packet_len > buf_len)
+    	return -1;
+
+    int prev_res = res;
+
+    res = readall(fd, (char *)buf + sizeof(struct fuse_in_header),
+                  packet_len - sizeof(struct fuse_in_header));
+
+    return  (res == -1) ? res : (res + prev_res);
+}
+
+static ssize_t stream_splice_send(int fdin, __off64_t *offin, int fdout,
+					    __off64_t *offout, size_t len,
+                                  unsigned int flags, void *userdata) {
+	(void)userdata;
+
+	size_t count = 0;
+	while (count < len) {
+		int i = splice(fdin, offin, fdout, offout, len - count, flags);
+		if (i < 1)
+			return i;
+
+		count += i;
+	}
+	return count;
+}
+
+static void fuse_cmdline_help_uds(void)
+{
+	printf("    -h   --help            print help\n"
+	       "    -V   --version         print version\n"
+	       "    -d   -o debug          enable debug output (implies -f)\n");
+}
+
 int main(int argc, char *argv[])
 {
 	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
 	struct fuse_session *se;
 	struct fuse_cmdline_opts opts;
-	struct fuse_loop_config config;
+	const struct fuse_custom_io io = {
+		.writev = stream_writev,
+		.read = stream_read,
+		.splice_receive = NULL,
+		.splice_send = stream_splice_send,
+	};
+	int cfd = -1;
 	int ret = -1;
 
 	if (fuse_parse_cmdline(&args, &opts) != 0)
 		return 1;
 	if (opts.show_help) {
-		printf("usage: %s [options] <mountpoint>\n\n", argv[0]);
-		fuse_cmdline_help();
+		printf("usage: %s [options]\n\n", argv[0]);
+		fuse_cmdline_help_uds();
 		fuse_lowlevel_help();
 		ret = 0;
 		goto err_out1;
@@ -181,13 +326,6 @@ int main(int argc, char *argv[])
 		printf("FUSE library version %s\n", fuse_pkgversion());
 		fuse_lowlevel_version();
 		ret = 0;
-		goto err_out1;
-	}
-
-	if(opts.mountpoint == NULL) {
-		printf("usage: %s [options] <mountpoint>\n", argv[0]);
-		printf("       %s --help\n", argv[0]);
-		ret = 1;
 		goto err_out1;
 	}
 
@@ -199,21 +337,15 @@ int main(int argc, char *argv[])
 	if (fuse_set_signal_handlers(se) != 0)
 	    goto err_out2;
 
-	if (fuse_session_mount(se, opts.mountpoint) != 0)
-	    goto err_out3;
+	cfd = create_socket("/tmp/libfuse-hello-ll.sock");
+	if (cfd == -1)
+		goto err_out3;
 
-	fuse_daemonize(opts.foreground);
+	if (fuse_session_custom_io(se, &io, cfd) != 0)
+		goto err_out3;
 
-	/* Block until ctrl+c or fusermount -u */
-	if (opts.singlethread)
-		ret = fuse_session_loop(se);
-	else {
-		config.clone_fd = opts.clone_fd;
-		config.max_idle_threads = opts.max_idle_threads;
-		ret = fuse_session_loop_mt(se, &config);
-	}
-
-	fuse_session_unmount(se);
+	/* Block until ctrl+c */
+	ret = fuse_session_loop(se);
 err_out3:
 	fuse_remove_signal_handlers(se);
 err_out2:

--- a/example/meson.build
+++ b/example/meson.build
@@ -1,7 +1,7 @@
 examples = [ 'passthrough', 'passthrough_fh',
-             'hello', 'hello_ll', 'printcap',
-             'ioctl_client', 'poll_client', 'ioctl',
-             'cuse', 'cuse_client' ]
+             'hello', 'hello_ll', 'hello_ll_uds',
+             'printcap', 'ioctl_client', 'poll_client',
+             'ioctl', 'cuse', 'cuse_client' ]
 
 if not platform.endswith('bsd') and platform != 'dragonfly'
     examples += 'passthrough_ll'
@@ -19,11 +19,6 @@ threaded_examples = [ 'notify_inval_inode',
                       'poll' ]
 
 foreach ex : examples
-    if ex == 'hello_ll'
-        executable(ex + '_uds', ex + '.c',
-                   dependencies: [ libfuse_dep ],
-                   install: false, c_args: [ '-DIO_UDS_STREAMS' ])
-    endif
     executable(ex, ex + '.c',
                dependencies: [ libfuse_dep ],
                install: false)

--- a/example/meson.build
+++ b/example/meson.build
@@ -19,6 +19,11 @@ threaded_examples = [ 'notify_inval_inode',
                       'poll' ]
 
 foreach ex : examples
+    if ex == 'hello_ll'
+        executable(ex + '_uds', ex + '.c',
+                   dependencies: [ libfuse_dep ],
+                   install: false, c_args: [ '-DIO_UDS_STREAMS' ])
+    endif
     executable(ex, ex + '.c',
                dependencies: [ libfuse_dep ],
                install: false)

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -45,6 +45,7 @@ struct fuse_session {
 	char *mountpoint;
 	volatile int exited;
 	int fd;
+	struct fuse_custom_io *io;
 	struct mount_opts *mo;
 	int debug;
 	int deny_others;

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -39,6 +39,7 @@ FUSE_3.0 {
 		fuse_session_new;
 		fuse_main_real;
 		fuse_mount;
+		fuse_session_custom_io;
 		fuse_session_mount;
 		fuse_new;
 		fuse_opt_insert_arg;

--- a/test/meson.build
+++ b/test/meson.build
@@ -15,7 +15,7 @@ td += executable('readdir_inode', 'readdir_inode.c',
                  install: false)
 
 test_scripts = [ 'conftest.py', 'pytest.ini', 'test_examples.py',
-                 'util.py', 'test_ctests.py' ]
+                 'util.py', 'test_ctests.py', 'test_custom_io.py' ]
 td += custom_target('test_scripts', input: test_scripts,
                       output: test_scripts, build_by_default: true,
                       command: ['cp', '-fPp',

--- a/test/test_custom_io.py
+++ b/test/test_custom_io.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+if __name__ == '__main__':
+    import sys
+
+    import pytest
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+
+import os
+import socket
+import struct
+import subprocess
+import sys
+import time
+from os.path import join as pjoin
+
+import pytest
+
+from util import base_cmdline, basename
+
+FUSE_OP_INIT = 26
+
+FUSE_MAJOR_VERSION = 7
+FUSE_MINOR_VERSION = 38
+
+fuse_in_header_fmt = '<IIQQIIII'
+fuse_out_header_fmt = '<IiQ'
+
+fuse_init_in_fmt = '<IIIII44x'
+fuse_init_out_fmt = '<IIIIHHIIHHI28x'
+
+
+def sock_recvall(sock: socket.socket, bufsize: int) -> bytes:
+    buf = bytes()
+    while len(buf) < bufsize:
+        buf += sock.recv(bufsize - len(buf))
+    return buf
+
+
+def tst_init(sock: socket.socket):
+    unique_req = 10
+    dummy_init_req_header = struct.pack(
+        fuse_in_header_fmt, struct.calcsize(fuse_in_header_fmt) +
+        struct.calcsize(fuse_init_in_fmt), FUSE_OP_INIT, unique_req, 0, 0, 0,
+        0, 0)
+    dummy_init_req_payload = struct.pack(
+        fuse_init_in_fmt, FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION, 0, 0, 0)
+    dummy_init_req = dummy_init_req_header + dummy_init_req_payload
+
+    sock.sendall(dummy_init_req)
+
+    response_header = sock_recvall(sock, struct.calcsize(fuse_out_header_fmt))
+    packet_len, _, unique_res = struct.unpack(
+        fuse_out_header_fmt, response_header)
+    assert unique_res == unique_req
+
+    response_payload = sock_recvall(sock, packet_len - len(response_header))
+    response_payload = struct.unpack(fuse_init_out_fmt, response_payload)
+    assert response_payload[0] == FUSE_MAJOR_VERSION
+
+
+def test_hello_uds(output_checker):
+    cmdline = base_cmdline + [pjoin(basename, 'example', 'hello_ll_uds')]
+    print(cmdline)
+    uds_process = subprocess.Popen(cmdline, stdout=output_checker.fd,
+                                   stderr=output_checker.fd)
+    time.sleep(1)
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(1)
+    sock.connect("/tmp/libfuse-hello-ll.sock")
+
+    tst_init(sock)
+
+    sock.close()
+    uds_process.terminate()
+    try:
+        uds_process.wait(1)
+    except subprocess.TimeoutExpired:
+        uds_process.kill()
+    os.remove("/tmp/libfuse-hello-ll.sock")


### PR DESCRIPTION
Follow-up to  https://github.com/libfuse/libfuse/pull/710

The IO for FUSE requests and responses can be further customized by allowing to write custom functions for reading/writing the responses. This includes overriding the splice IO. Also extended the hello_ll example (with #ifdefs) to provide an example of utilizing the custom IO (and a test for it). When no custom IO is provided, libfuse will behave the same as it did before any changes in this PR were made.

As it turns out, the changes in https://github.com/libfuse/libfuse/pull/710 are not enough to provide the user necessary control of the IO handling of the request and response data. Different types of file descriptor require different mechanisms of IO interaction. For example, some file descriptor types have boundaries (SOCK_DGRAM, EOF, etc...), while other types of might be unbounded (SOCK_STREAMS, ...). For unbounded communication, one call to `read` does not necessarily return all the data expected, especially in cases where the request are large. This requires further calls to `read` in a loop. You also would have to read the header of the FUSE request first, and then read the remaining packet data to ensure that you get all of the data in the request.

The `fuse_custom_session_fd()` (renamed `fuse_session_custom_io()` in this PR) function has not been part or a libfuse release yet (only part of the master branch), so my hope is that it's not considered a breaking change to modify that function.