### PR TITLE
update mount.c, in order to pass through -n.

### DIFF
--- a/lib/mount.c
+++ b/lib/mount.c
@@ -97,6 +97,7 @@ static const struct fuse_opt fuse_mount_opts[] = {
 	FUSE_OPT_KEY("rootcontext=",		KEY_KERN_OPT),
 	FUSE_OPT_KEY("max_read=",		KEY_KERN_OPT),
 	FUSE_OPT_KEY("user=",			KEY_MTAB_OPT),
+	FUSE_OPT_KEY("-n",			KEY_MTAB_OPT),
 	FUSE_OPT_KEY("-r",			KEY_RO),
 	FUSE_OPT_KEY("ro",			KEY_KERN_FLAG),
 	FUSE_OPT_KEY("rw",			KEY_KERN_FLAG),


### PR DESCRIPTION
autofs uses automount, which calls fuse, during an sshfs call. fuse complains about -n being an unknown option (ref. https://github.com/libfuse/libfuse/issues/715)  this one line edit provides the command to be accepted, and pass through, allowing autofs-automount to operate on the mount, even though it is already in the mtab, given the nature of autofs/automount.