### PR TITLE
Revert "libfuse custom communication interface"

### DIFF
--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1955,25 +1955,6 @@ struct fuse_session *fuse_session_new(struct fuse_args *args,
 				      size_t op_size, void *userdata);
 
 /**
- * Set a file descriptor for the session.
- *
- * This function can be used if you want to have a custom communication
- * interface instead of using a mountpoint. In practice, this means that instead
- * of calling fuse_session_mount() and fuse_session_unmount(), one could call
- * fuse_custom_session_fd() where fuse_session_mount() would have otherwise been
- * called.
- *
- * This function does not open or close any file descriptors, meaning it is the
- * responsibility of the caller to provide a valid file descriptor, such as a
- * accepted socket. It is also the responsibility to close the socket.
- *
- * @param se session object
- * @param fd file descriptor for the session
- *
- **/
-void fuse_custom_session_fd(struct fuse_session *se, int fd);
-
-/**
  * Mount a FUSE file system.
  *
  * @param mountpoint the mount point path

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3009,10 +3009,6 @@ out1:
 	return NULL;
 }
 
-void fuse_custom_session_fd(struct fuse_session *se, int fd) {
-	se->fd = fd;
-}
-
 int fuse_session_mount(struct fuse_session *se, const char *mountpoint)
 {
 	int fd;

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -39,7 +39,6 @@ FUSE_3.0 {
 		fuse_session_new;
 		fuse_main_real;
 		fuse_mount;
-		fuse_custom_session_fd;
 		fuse_session_mount;
 		fuse_new;
 		fuse_opt_insert_arg;


### PR DESCRIPTION
Reverts libfuse/libfuse#710. As discussed in #714, this isn't usable as-is.  Discussion on adding this in a more complicated matter is still ongoing, but for now I'm reverting this.

