### PR TITLE
Dereference fuse_module_factory_t symbol before assignment

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -249,7 +249,7 @@ static int fuse_load_so_module(const char *module)
 	int ret = -1;
 	char *tmp;
 	struct fusemod_so *so;
-	fuse_module_factory_t factory;
+	fuse_module_factory_t *factory;
 
 	tmp = malloc(strlen(module) + 64);
 	if (!tmp) {
@@ -271,13 +271,13 @@ static int fuse_load_so_module(const char *module)
 	}
 
 	sprintf(tmp, "fuse_module_%s_factory", module);
-	*(void**)(&factory) = dlsym(so->handle, tmp);
+	factory = (fuse_module_factory_t*)dlsym(so->handle, tmp);
 	if (factory == NULL) {
 		fuse_log(FUSE_LOG_ERR, "fuse: symbol <%s> not found in module: %s\n",
 			tmp, dlerror());
 		goto out_dlclose;
 	}
-	ret = fuse_register_module(module, factory, so);
+	ret = fuse_register_module(module, *factory, so);
 	if (ret)
 		goto out_dlclose;
 


### PR DESCRIPTION
When loading an external module the `fuse_load_so_module()` function assigns the address of the modules factory **symbol** to the `fuse_module_factory_t` function pointer. The pointer then points into the .data section of the module where the address of the factory function is stored. Executing the factory then leads to a segfault as the .data section is not executable.

This patch casts the symbol returned by `dlsym()` to the type it actually is and dereferences it before assigning it to the local function pointer to get the actual address of the factory function.

Fixes: #721