### PR TITLE
use off_t over __off64_t

### DIFF
--- a/example/hello_ll_uds.c
+++ b/example/hello_ll_uds.c
@@ -277,8 +277,8 @@ static ssize_t stream_read(int fd, void *buf, size_t buf_len, void *userdata) {
     return  (res == -1) ? res : (res + prev_res);
 }
 
-static ssize_t stream_splice_send(int fdin, __off64_t *offin, int fdout,
-					    __off64_t *offout, size_t len,
+static ssize_t stream_splice_send(int fdin, off_t *offin, int fdout,
+					    off_t *offout, size_t len,
                                   unsigned int flags, void *userdata) {
 	(void)userdata;
 

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -130,11 +130,11 @@ struct fuse_forget_data {
 struct fuse_custom_io {
 	ssize_t (*writev)(int fd, struct iovec *iov, int count, void *userdata);
 	ssize_t (*read)(int fd, void *buf, size_t buf_len, void *userdata);
-	ssize_t (*splice_receive)(int fdin, __off64_t *offin, int fdout,
-					  __off64_t *offout, size_t len,
+	ssize_t (*splice_receive)(int fdin, off_t *offin, int fdout,
+					  off_t *offout, size_t len,
 				  	  unsigned int flags, void *userdata);
-	ssize_t (*splice_send)(int fdin, __off64_t *offin, int fdout,
-				     __off64_t *offout, size_t len,
+	ssize_t (*splice_send)(int fdin, off_t *offin, int fdout,
+				     off_t *offout, size_t len,
 			           unsigned int flags, void *userdata);
 };
 


### PR DESCRIPTION
when -D_FILE_OFFSET_BITS=64 is defined, the off_t type is 64 bits wide already. the fuse_common.h header already checks for this, and errors when it is not, so be consistent with all the other uses of off_t.

some libcs like musl do not have a 32-bit off_t type, and don't define __off64_t.