### PR TITLE
Install a the configure_file (config.h) and use in headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 sudo: required
-dist: bionic
+dist: jammy
 
-before_install:
-    - curl https://spot.fedorapeople.org/spotfoss-ppa.key | sudo apt-key add -
-    - wget https://launchpad.net/~spotfoss/+archive/ubuntu/ppa/+files/valgrind_3.16.1-2_amd64.deb
-    - sudo apt install ./valgrind_3.16.1-2_amd64.deb
 language:
     - c
     - c++
@@ -15,14 +11,15 @@ addons:
     packages:
     - doxygen
     - clang
-    - libstdc++-7-dev 
+    - libstdc++-9-dev
     - libstdc++-10-dev
     - gcc
-    - gcc-7
+    - gcc-9
     - gcc-10
     - python3-pip
     - python3-setuptools
     - ninja-build
+    - valgrind
 install: test/travis-install.sh
 script: test/travis-build.sh
 

--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -25,10 +25,6 @@
 
 #define FUSE_USE_VERSION 31
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #define _GNU_SOURCE
 
 #ifdef linux

--- a/example/passthrough_fh.c
+++ b/example/passthrough_fh.c
@@ -25,10 +25,6 @@
 
 #define FUSE_USE_VERSION 31
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #define _GNU_SOURCE
 
 #include <fuse.h>

--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -45,10 +45,6 @@
 
 #define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 12)
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -37,8 +37,6 @@
 #define _GNU_SOURCE
 #define FUSE_USE_VERSION 34
 
-#include "config.h"
-
 #include <fuse_lowlevel.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/example/poll.c
+++ b/example/poll.c
@@ -23,8 +23,6 @@
 
 #define FUSE_USE_VERSION 31
 
-#include <config.h>
-
 #include <fuse.h>
 #include <unistd.h>
 #include <ctype.h>

--- a/example/poll_client.c
+++ b/example/poll_client.c
@@ -19,7 +19,7 @@
  * \include poll_client.c
  */
 
-#include <config.h>
+#include <fuse_config.h>
 
 #include <sys/select.h>
 #include <sys/time.h>

--- a/example/printcap.c
+++ b/example/printcap.c
@@ -21,8 +21,6 @@
 
 #define FUSE_USE_VERSION 31
 
-#include <config.h>
-
 #include <fuse_lowlevel.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -14,6 +14,7 @@
 #ifndef FUSE_COMMON_H_
 #define FUSE_COMMON_H_
 
+#include "fuse_config.h"
 #include "fuse_opt.h"
 #include "fuse_log.h"
 #include <stdint.h>

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -11,7 +11,7 @@
 
 #define _GNU_SOURCE
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_i.h"
 #include "fuse_lowlevel.h"
 #include <string.h>

--- a/lib/compat.c
+++ b/lib/compat.c
@@ -15,7 +15,7 @@
     support version symboling
 */
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_i.h"
 #include "fuse_misc.h"
 #include "fuse_opt.h"

--- a/lib/cuse_lowlevel.c
+++ b/lib/cuse_lowlevel.c
@@ -7,7 +7,7 @@
   See the file COPYING.LIB.
 */
 
-#include "config.h"
+#include "fuse_config.h"
 #include "cuse_lowlevel.h"
 #include "fuse_kernel.h"
 #include "fuse_i.h"

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -13,7 +13,7 @@
 /* For pthread_rwlock_t */
 #define _GNU_SOURCE
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_i.h"
 #include "fuse_lowlevel.h"
 #include "fuse_opt.h"

--- a/lib/fuse_loop.c
+++ b/lib/fuse_loop.c
@@ -8,7 +8,7 @@
   See the file COPYING.LIB
 */
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_lowlevel.h"
 #include "fuse_i.h"
 

--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -8,7 +8,7 @@
   See the file COPYING.LIB.
 */
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_lowlevel.h"
 #include "fuse_misc.h"
 #include "fuse_kernel.h"

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -11,7 +11,7 @@
 
 #define _GNU_SOURCE
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_i.h"
 #include "fuse_kernel.h"
 #include "fuse_opt.h"

--- a/lib/fuse_opt.c
+++ b/lib/fuse_opt.c
@@ -9,7 +9,7 @@
   See the file COPYING.LIB
 */
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_i.h"
 #include "fuse_opt.h"
 #include "fuse_misc.h"

--- a/lib/fuse_signals.c
+++ b/lib/fuse_signals.c
@@ -8,7 +8,7 @@
   See the file COPYING.LIB
 */
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_lowlevel.h"
 #include "fuse_i.h"
 

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -10,7 +10,7 @@
   See the file COPYING.LIB.
 */
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_i.h"
 #include "fuse_misc.h"
 #include "fuse_opt.h"

--- a/lib/modules/iconv.c
+++ b/lib/modules/iconv.c
@@ -6,7 +6,7 @@
   See the file COPYING.LIB
 */
 
-#include <config.h>
+#include <fuse_config.h>
 
 #include <fuse.h>
 #include <stdio.h>

--- a/lib/modules/subdir.c
+++ b/lib/modules/subdir.c
@@ -6,7 +6,7 @@
   See the file COPYING.LIB
 */
 
-#include <config.h>
+#include <fuse_config.h>
 
 #include <fuse.h>
 #include <stdio.h>

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -8,7 +8,7 @@
   See the file COPYING.LIB.
 */
 
-#include "config.h"
+#include "fuse_config.h"
 #include "fuse_i.h"
 #include "fuse_misc.h"
 #include "fuse_opt.h"

--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -8,7 +8,7 @@
   See the file COPYING.LIB.
 */
 
-#include "config.h"
+#include "fuse_config.h"
 #include "mount_util.h"
 #include <stdio.h>
 #include <unistd.h>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libfuse3', ['c'], version: '3.13.0',
-        meson_version: '>= 0.42',
+        meson_version: '>= 0.50',
         default_options: [
             'buildtype=debugoptimized',
             'cpp_std=c++11',
@@ -141,8 +141,8 @@ else
 endif
 
 # Write the test results into config.h (stored in build directory)
-configure_file(output: 'config.h',
-               configuration : cfg)
+configure_file(output: 'fuse_config.h',
+               configuration : cfg, install: true, install_dir: 'include/fuse3')
 
 # '.' will refer to current build directory, which contains config.h
 include_dirs = include_directories('include', 'lib', '.')
@@ -169,3 +169,4 @@ endif
 foreach n : subdirs
     subdir(n)
 endforeach
+

--- a/test/test_setattr.c
+++ b/test/test_setattr.c
@@ -9,7 +9,7 @@
 
 #define FUSE_USE_VERSION 30
 
-#include <config.h>
+#include <fuse_config.h>
 #include <fuse_lowlevel.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -1,5 +1,5 @@
 #define _GNU_SOURCE
-#include "config.h"
+#include "fuse_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/test_write_cache.c
+++ b/test/test_write_cache.c
@@ -9,7 +9,7 @@
 
 #define FUSE_USE_VERSION 30
 
-#include <config.h>
+#include <fuse_config.h>
 #include <fuse_lowlevel.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/travis-build.sh
+++ b/test/travis-build.sh
@@ -24,7 +24,7 @@ export ASAN_OPTIONS="detect_leaks=1"
 export CC
 
 # Standard build
-for CC in gcc gcc-7 gcc-10 clang; do
+for CC in gcc gcc-9 gcc-10 clang; do
     echo "=== Building with ${CC} ==="
     mkdir build-${CC}; cd build-${CC}
     if [ "${CC}" == "clang" ]; then

--- a/test/travis-install.sh
+++ b/test/travis-install.sh
@@ -4,7 +4,7 @@ set -e
 
 sudo python3 -m pip install --upgrade pip
 # Meson 0.45 requires Python 3.5 or newer
-sudo python3 -m pip install pytest meson==0.44
+sudo python3 -m pip install pytest meson==0.50
 valgrind --version
 ninja --version
 meson --version

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -8,7 +8,7 @@
 /* This program does the mounting and unmounting of FUSE filesystems */
 
 #define _GNU_SOURCE /* for clone */
-#include "config.h"
+#include "fuse_config.h"
 #include "mount_util.h"
 
 #include <stdio.h>

--- a/util/mount.fuse.c
+++ b/util/mount.fuse.c
@@ -6,7 +6,7 @@
   See the file COPYING.
 */
 
-#include "config.h"
+#include "fuse_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This addresses: https://github.com/libfuse/libfuse/issues/724

HAVE_LIBC_VERSIONED_SYMBOLS configures the library if to use versioned symbols and is set at meson configuration time. External filesystems (the main target, actually)
include fuse headers and the preprocessor
then acts on HAVE_LIBC_VERSIONED_SYMBOLS. Problem was now that 'config.h' was not distributed with libfuse and so HAVE_LIBC_VERSIONED_SYMBOLS was never defined with external tools and the preprocessor did the wrong decision.

This commit also increases the the minimal meson version, as this depends on meson feature only available in 0.50

<quote 'meson' >
WARNING: Project specifies a minimum meson_
version '>= 0.42' but uses features which were added
 in newer versions:
 * 0.50.0: {'install arg in configure_file'} </quote>

Additionally the config file has been renamed to "fuse_config.h" to avoid clashes - 'config.h' is not very specific.