### PR TITLE
fuse_lowlevel.h: add more setattr flags

### DIFF
--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -156,7 +156,15 @@ enum fuse_expire_flags {
 #define FUSE_SET_ATTR_MTIME	(1 << 5)
 #define FUSE_SET_ATTR_ATIME_NOW	(1 << 7)
 #define FUSE_SET_ATTR_MTIME_NOW	(1 << 8)
+#define FUSE_SET_ATTR_FORCE	(1 << 9)
 #define FUSE_SET_ATTR_CTIME	(1 << 10)
+#define FUSE_SET_ATTR_KILL_SUID	(1 << 11)
+#define FUSE_SET_ATTR_KILL_SGID	(1 << 12)
+#define FUSE_SET_ATTR_FILE	(1 << 13)
+#define FUSE_SET_ATTR_KILL_PRIV	(1 << 14)
+#define FUSE_SET_ATTR_OPEN	(1 << 15)
+#define FUSE_SET_ATTR_TIMES_SET	(1 << 16)
+#define FUSE_SET_ATTR_TOUCH	(1 << 17)
 
 /* ----------------------------------------------------------- *
  * Request methods and replies				       *

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1186,6 +1186,8 @@ static void do_setattr(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 			FUSE_SET_ATTR_SIZE	|
 			FUSE_SET_ATTR_ATIME	|
 			FUSE_SET_ATTR_MTIME	|
+			FUSE_SET_ATTR_KILL_SUID |
+			FUSE_SET_ATTR_KILL_SGID |
 			FUSE_SET_ATTR_ATIME_NOW	|
 			FUSE_SET_ATTR_MTIME_NOW |
 			FUSE_SET_ATTR_CTIME;


### PR DESCRIPTION
Such as for the xfstest-dev's generic/684 test case it will clear suid and sgid if the fallocate request is commited by an unprivileged user.

The kernel fuse passed the ATTR_KILL_SUID/ATTR_KILL_SGID flags to userspace but it will be dropped.

Signed-off-by: Xiubo Li <xiubli@redhat.com>