### PR TITLE
Avoid max-idle threads warning

### DIFF
--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -464,9 +464,11 @@ void fuse_loop_cfg_set_idle_threads(struct fuse_loop_config *config,
 				    unsigned int value)
 {
 	if (value > FUSE_LOOP_MT_MAX_THREADS) {
-		fuse_log(FUSE_LOG_ERR,
-			 "Ignoring invalid max threads value "
-			 "%u > max (%u).\n", value, FUSE_LOOP_MT_MAX_THREADS);
+		if (value != UINT_MAX)
+			fuse_log(FUSE_LOG_ERR,
+				 "Ignoring invalid max threads value "
+				 "%u > max (%u).\n", value,
+				 FUSE_LOOP_MT_MAX_THREADS);
 		return;
 	}
 	config->max_idle_threads = value;

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -210,7 +210,7 @@ int fuse_parse_cmdline_312(struct fuse_args *args,
 {
 	memset(opts, 0, sizeof(struct fuse_cmdline_opts));
 
-	opts->max_idle_threads = -1; /* new default in fuse version 3.12 */
+	opts->max_idle_threads = UINT_MAX; /* new default in fuse version 3.12 */
 	opts->max_threads = 10;
 
 	if (fuse_opt_parse(args, opts, fuse_helper_opts,
@@ -238,7 +238,6 @@ int fuse_parse_cmdline_30(struct fuse_args *args,
 			  struct fuse_cmdline_opts *out_opts)
 {
 	struct fuse_cmdline_opts opts;
-
 
 	int rc = fuse_parse_cmdline_312(args, &opts);
 	if (rc == 0) {


### PR DESCRIPTION
If a program with API before 312 did not set
max_idle_threads the new default from
fuse_parse_cmdline_312() is applied, which sets
UINT_MAX (-1).

Later in compat fuse_session_loop_mt_32 the old
config v1 struct is converted and that conversion
prints a warning if the default unset value was used.

This could have also happened to programs using the current API, which just apply values struct fuse_cmdline_opts, without checking if the defaults are set.