### PR TITLE
Fix max_threads command line parameter propagation

### DIFF
--- a/lib/helper.c
+++ b/lib/helper.c
@@ -376,6 +376,7 @@ int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
 		fuse_loop_cfg_set_clone_fd(loop_config, opts.clone_fd);
 
 		fuse_loop_cfg_set_idle_threads(loop_config, opts.max_idle_threads);
+		fuse_loop_cfg_set_max_threads(loop_config, opts.max_threads);
 		res = fuse_loop_mt(fuse, loop_config);
 	}
 	if (res)


### PR DESCRIPTION
The fuse_main_real() method doesn't apply the max_threads parameter parsed through the commandline arguments. This commit fixes the wiring of max_threads argument.