### PR TITLE
Fix use-after-free warning

### DIFF
--- a/lib/modules/iconv.c
+++ b/lib/modules/iconv.c
@@ -77,12 +77,13 @@ static int iconv_convpath(struct iconv *ic, const char *path, char **newpathp,
 
 			inc = (pathlen + 1) * 4;
 			newpathlen += inc;
+			int dp = p - newpath;
 			tmp = realloc(newpath, newpathlen + 1);
 			err = -ENOMEM;
 			if (!tmp)
 				goto err;
 
-			p = tmp + (p - newpath);
+			p = tmp + dp;
 			plen += inc;
 			newpath = tmp;
 		}


### PR DESCRIPTION
When building, I get the following warning:

```bash
$ ninja
[18/71] Compiling C object lib/libfuse3.so.3.14.1.p/modules_iconv.c.o
../lib/modules/iconv.c: In function ‘iconv_convpath’:
../lib/modules/iconv.c:85:38: warning: pointer ‘newpath’ may be used after ‘realloc’ [-Wuse-after-free]
   85 |                         p = tmp + (p - newpath);
      |                                   ~~~^~~~~~~~~~
../lib/modules/iconv.c:80:31: note: call to ‘realloc’ here
   80 |                         tmp = realloc(newpath, newpathlen + 1);
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[71/71] Linking target example/passthrough_hp
```

It's a false positive,  I thinks.  But it's also easy to silence this warning with a small refactor.