### PR TITLE
Fix meson deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ must use [Meson](http://mesonbuild.com/) and
 tarball, create a (temporary) build directory and run Meson:
 
     $ mkdir build; cd build
-    $ meson ..
+    $ meson setup ..
 
 Normally, the default build options will work fine. If you
 nevertheless want to adjust them, you can do so with the


### PR DESCRIPTION
When running `meson ..` I get:

```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```

So let's fix this in the docs.