### PR TITLE
fusermount: provide suid,dev for privileged users

### DIFF
--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -736,7 +736,11 @@ static int do_mount(const char *mnt, const char **typep, mode_t rootmode,
 		    char **mnt_optsp)
 {
 	int res;
+	#ifdef NO_PRIVS
+	int flags = 0;
+	#else
 	int flags = MS_NOSUID | MS_NODEV;
+	#endif
 	char *optbuf;
 	char *mnt_opts = NULL;
 	const char *s;

--- a/util/meson.build
+++ b/util/meson.build
@@ -6,6 +6,12 @@ executable('fusermount3', ['fusermount.c', '../lib/mount_util.c'],
            install_dir: get_option('bindir'),
            c_args: '-DFUSE_CONF="@0@"'.format(fuseconf_path))
 
+executable('fusermount3_no_privs', ['fusermount.c', '../lib/mount_util.c'],
+           include_directories: include_dirs,
+           install: true,
+           install_dir: get_option('bindir'),
+           c_args: ['-DFUSE_CONF="@0@"'.format(fuseconf_path), '-DNO_PRIVS'])
+
 executable('mount.fuse3', ['mount.fuse.c'],
            include_directories: include_dirs,
            link_with: [ libfuse ],


### PR DESCRIPTION
Fixes https://github.com/libfuse/libfuse/issues/148

This is a simple attempt to provide access to options like suid and dev for privileged users, without opening security holes in a suid binary.

I'm not sure this is a good idea, it's mostly for discussion.