### PR TITLE
Workaround musl bug when mountdir has whitespace

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -151,6 +151,38 @@ else
      message('Disabling versioned libc symbols')
 endif
 
+# Older versions of musl libc don't unescape entries in /etc/mtab
+# Try to detect this behaviour, and work around, if necessary.
+detect_getmntent_needs_unescape = '''
+#define _GNU_SOURCE
+#include <mntent.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define dir_space_tab "dir\\040space\\011tab"
+
+int main()
+{
+    const char *fake_mtab = "name " dir_space_tab " type opts 0 0\n";
+    FILE *f = fmemopen((void *)fake_mtab, strlen(fake_mtab) + 1, "r");
+    struct mntent *entp = getmntent(f);
+    fclose(f);
+    if(NULL == entp)
+        exit(EXIT_FAILURE);
+    if (0 == strcmp(entp->mnt_dir, dir_space_tab))
+        printf("needs escaping\n");
+    else
+        printf("no need to escape\n");
+}
+'''
+
+result = cc.run(detect_getmntent_needs_unescape)
+if result.compiled() and result.returncode() == 0 and result.stdout().strip() == 'needs escaping'
+  message('getmntent does not unescape')
+  add_project_arguments('-DGETMNTENT_NEEDS_UNESCAPING', language: 'c')
+endif
+
 # Write private test results into fuse_config.h (stored in build directory)
 configure_file(output: 'fuse_config.h', configuration : private_cfg)
 


### PR DESCRIPTION
Fixes https://github.com/libfuse/libfuse/issues/634 and https://github.com/mpartel/bindfs/issues/106

It'll be a while before my upstream fix makes it into musl.