### PR TITLE
Fuse mount: make auto_unmount compatible with suid/dev mount options

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -1241,6 +1241,10 @@ int main(int argc, char *argv[])
 
 	} else {
 		lo.source = strdup("/");
+		if(!lo.source) {
+			fuse_log(FUSE_LOG_ERR, "fuse: memory allocation failed\n");
+			exit(1);
+		}
 	}
 	if (!lo.timeout_set) {
 		switch (lo.cache) {

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -89,7 +89,7 @@ struct lo_data {
 	int writeback;
 	int flock;
 	int xattr;
-	const char *source;
+	char *source;
 	double timeout;
 	int cache;
 	int timeout_set;
@@ -1240,7 +1240,7 @@ int main(int argc, char *argv[])
 		}
 
 	} else {
-		lo.source = "/";
+		lo.source = strdup("/");
 	}
 	if (!lo.timeout_set) {
 		switch (lo.cache) {
@@ -1302,5 +1302,6 @@ err_out1:
 	if (lo.root.fd >= 0)
 		close(lo.root.fd);
 
+	free(lo.source);
 	return ret ? 1 : 0;
 }

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -322,6 +322,65 @@ void fuse_kern_unmount(const char *mountpoint, int fd)
 	waitpid(pid, NULL, 0);
 }
 
+static int fuse_mount_fusermount_setup_auto_unmount_only(const char *mountpoint, int quiet)
+{
+	int fds[2], pid;
+	int res;
+
+	if (!mountpoint) {
+		fuse_log(FUSE_LOG_ERR, "fuse: missing mountpoint parameter\n");
+		return -1;
+	}
+
+	res = socketpair(PF_UNIX, SOCK_STREAM, 0, fds);
+	if(res == -1) {
+		perror("fuse: socketpair() failed");
+		return -1;
+	}
+
+	pid = fork();
+	if(pid == -1) {
+		perror("fuse: fork() failed");
+		close(fds[0]);
+		close(fds[1]);
+		return -1;
+	}
+
+	if(pid == 0) {
+		char env[10];
+		const char *argv[32];
+		int a = 0;
+
+		if (quiet) {
+			int fd = open("/dev/null", O_RDONLY);
+			if (fd != -1) {
+				dup2(fd, 1);
+				dup2(fd, 2);
+			}
+		}
+
+		argv[a++] = FUSERMOUNT_PROG;
+		argv[a++] = "--setup-auto-unmount-only";
+		argv[a++] = "--";
+		argv[a++] = mountpoint;
+		argv[a++] = NULL;
+
+		close(fds[1]);
+		fcntl(fds[0], F_SETFD, 0);
+		snprintf(env, sizeof(env), "%i", fds[0]);
+		setenv(FUSE_COMMFD_ENV, env, 1);
+		exec_fusermount(argv);
+		perror("fuse: failed to exec fusermount3");
+		_exit(1);
+	}
+
+	close(fds[0]);
+
+	// Now fusermount3 will only exit when fds[1] closes automatically when our
+	// process exits.
+	return 0;
+}
+
 static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
 		const char *opts, int quiet)
 {
@@ -420,12 +479,6 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
 		fuse_log(FUSE_LOG_ERR, "fuse: failed to access mountpoint %s: %s\n",
 			mnt, strerror(errno));
 		return -1;
-	}
-
-	if (mo->auto_unmount) {
-		/* Tell the caller to fallback to fusermount3 because
-		   auto-unmount does not work otherwise. */
-		return -2;
 	}
 
 	fd = open(devname, O_RDWR | O_CLOEXEC);
@@ -590,7 +643,13 @@ int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo)
 		goto out;
 
 	res = fuse_mount_sys(mountpoint, mo, mnt_opts);
-	if (res == -2) {
+	if (res >= 0 && mo->auto_unmount) {
+		if(0 > fuse_mount_fusermount_setup_auto_unmount_only(mountpoint, 0)) {
+			// Something went wrong, let's umount like in fuse_mount_sys.
+			umount2(mountpoint, 2); /* lazy umount */
+			res = -1;
+		}
+	} else if (res == -2) {
 		if (mo->fusermount_opts &&
 		    fuse_opt_add_opt(&mnt_opts, mo->fusermount_opts) == -1)
 			goto out;

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -646,7 +646,7 @@ int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo)
 	if (res >= 0 && mo->auto_unmount) {
 		if(0 > setup_auto_unmount(mountpoint, 0)) {
 			// Something went wrong, let's umount like in fuse_mount_sys.
-			umount2(mountpoint, 2); /* lazy umount */
+			umount2(mountpoint, MNT_DETACH); /* lazy umount */
 			res = -1;
 		}
 	} else if (res == -2) {

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -322,7 +322,7 @@ void fuse_kern_unmount(const char *mountpoint, int fd)
 	waitpid(pid, NULL, 0);
 }
 
-static int fuse_mount_fusermount_setup_auto_unmount_only(const char *mountpoint, int quiet)
+static int setup_auto_unmount(const char *mountpoint, int quiet)
 {
 	int fds[2], pid;
 	int res;
@@ -360,7 +360,7 @@ static int fuse_mount_fusermount_setup_auto_unmount_only(const char *mountpoint,
 		}
 
 		argv[a++] = FUSERMOUNT_PROG;
-		argv[a++] = "--setup-auto-unmount-only";
+		argv[a++] = "--auto-unmount";
 		argv[a++] = "--";
 		argv[a++] = mountpoint;
 		argv[a++] = NULL;
@@ -644,7 +644,7 @@ int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo)
 
 	res = fuse_mount_sys(mountpoint, mo, mnt_opts);
 	if (res >= 0 && mo->auto_unmount) {
-		if(0 > fuse_mount_fusermount_setup_auto_unmount_only(mountpoint, 0)) {
+		if(0 > setup_auto_unmount(mountpoint, 0)) {
 			// Something went wrong, let's umount like in fuse_mount_sys.
 			umount2(mountpoint, 2); /* lazy umount */
 			res = -1;

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -372,9 +372,16 @@ def test_notify_inval_entry(tmpdir, only_expire, notify, output_checker):
     else:
         umount(mount_process, mnt_dir)
 
-def test_dev_auto_unmount(short_tmpdir, output_checker):
+@pytest.mark.parametrize("intended_user", ('root', 'non_root'))
+def test_dev_auto_unmount(short_tmpdir, output_checker, intended_user):
     """Check that root can mount with dev and auto_unmount
-    (but non-root cannot)."""
+    (but non-root cannot).
+    Split into root vs non-root, so that the output of pytest
+    makes clear what functionality is being tested."""
+    if os.getuid() == 0 and intended_user == 'non_root':
+        pytest.skip('needs to run as non-root')
+    if os.getuid() != 0 and intended_user == 'root':
+        pytest.skip('needs to run as root')
     mnt_dir = str(short_tmpdir.mkdir('mnt'))
     src_dir = str('/dev')
     cmdline = base_cmdline + \

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -386,10 +386,10 @@ def test_dev_auto_unmount(short_tmpdir, output_checker):
     try:
         wait_for_mount(mount_process, mnt_dir)
         if os.getuid() == 0:
-            open(pjoin(mnt_dir, 'null'))
+            open(pjoin(mnt_dir, 'null')).close()
         else:
             with pytest.raises(PermissionError):
-                open(pjoin(mnt_dir, 'null'))
+                open(pjoin(mnt_dir, 'null')).close()
     except:
         cleanup(mount_process, mnt_dir)
         raise

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1329,7 +1329,6 @@ static void usage(void)
 	       " -V		    print version\n"
 	       " -o opt[,opt...]    mount options\n"
 	       " -u		    unmount\n"
-	       " -U 		    setup auto-unmount only\n"
 	       " -q		    quiet\n"
 	       " -z		    lazy unmount\n",
 	       progname);
@@ -1361,7 +1360,9 @@ int main(int argc, char *argv[])
 
 	static const struct option long_opts[] = {
 		{"unmount", no_argument, NULL, 'u'},
-		{"setup-auto-unmount-only", no_argument, NULL, 'U'},
+		// Note: auto-unmount deliberately does not have a short version.
+		// It's meant for internal use by mount.c's setup_auto_unmount.
+		{"auto-unmount", no_argument, NULL, 'U'},
 		{"lazy",    no_argument, NULL, 'z'},
 		{"quiet",   no_argument, NULL, 'q'},
 		{"help",    no_argument, NULL, 'h'},


### PR DESCRIPTION
> When you run as root, fuse normally does not call fusermount but uses
> the mount system call directly. When you specify auto_unmount, it goes
> through fusermount instead. However, fusermount is a setuid binary that
> is normally called by regular users, so it cannot in general accept suid
> or dev options.

In this patch, we split up how fuse mounts as root when `auto_unmount` is specified.

First, we mount using system calls directly, then we reach out to fusermount to set up auto_unmount only (with no actual mounting done in fusermount).

Fixes https://github.com/libfuse/libfuse/issues/148