### PR TITLE
Upgrade meson version in CI and bump minimum meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libfuse3', ['c'], version: '3.14.1',
-        meson_version: '>= 0.50',
+        meson_version: '>= 0.51',
         default_options: [
             'buildtype=debugoptimized',
             'cpp_std=c++11',

--- a/test/ci-install.sh
+++ b/test/ci-install.sh
@@ -3,8 +3,7 @@
 set -e
 
 sudo python3 -m pip install --upgrade pip
-# Meson 0.45 requires Python 3.5 or newer
-sudo python3 -m pip install pytest meson==0.50
+sudo python3 -m pip install pytest meson==1.0.1
 valgrind --version
 ninja --version
 meson --version

--- a/util/meson.build
+++ b/util/meson.build
@@ -17,7 +17,7 @@ executable('mount.fuse3', ['mount.fuse.c'],
 udevrulesdir = get_option('udevrulesdir')
 if udevrulesdir == ''
   udev = dependency('udev')
-  udevrulesdir = join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
+  udevrulesdir = join_paths(udev.get_variable(pkgconfig: 'udevdir'), 'rules.d')
 endif
 
 meson.add_install_script('install_helper.sh',


### PR DESCRIPTION
The previous version we used was almost half a decade old by now.

Fix deprecated udev.get_pkgconfig_variable in meson and slightly bump minimum meson version.