### PR TITLE
Fix notify_inval_entry --only-expire

### DIFF
--- a/example/notify_inval_entry.c
+++ b/example/notify_inval_entry.c
@@ -229,13 +229,10 @@ static void tfs_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
 }
 
 static void tfs_init(void *userdata, struct fuse_conn_info *conn) {
-    (void) userdata;
     if(options.only_expire && !(conn->capable & FUSE_CAP_EXPIRE_ONLY)) {
         fprintf(stderr, "FUSE_CAP_EXPIRE_ONLY not supported by kernel\n");
-        exit(1);
+        fuse_session_exit(*(struct fuse_session **) userdata);
     }
-    if(options.only_expire)
-        conn->want |= FUSE_CAP_EXPIRE_ONLY;
 }
 
 static const struct fuse_lowlevel_ops tfs_oper = {
@@ -327,7 +324,7 @@ int main(int argc, char *argv[]) {
     update_fs();
 
     se = fuse_session_new(&args, &tfs_oper,
-                          sizeof(tfs_oper), NULL);
+                          sizeof(tfs_oper), &se);
     if (se == NULL)
         goto err_out1;
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -347,6 +347,8 @@ def test_notify_inval_entry(tmpdir, only_expire, notify, output_checker):
         cmdline.append('--no-notify')
     if only_expire == "expire_entries":
         cmdline.append('--only-expire')
+        if fuse_proto < (7,38):
+            pytest.skip('only-expire not supported by running kernel')
     mount_process = subprocess.Popen(cmdline, stdout=output_checker.fd,
                                      stderr=output_checker.fd)
     try:


### PR DESCRIPTION
On Linux 5.15.49 `example/notify_inval_entry --only-expire` works just fine, but on 6.2.9 it fails as follows:

```
$ ./example/notify_inval_entry --only-expire -s -d -f example/mountpoint
[.. snip ..]
notify_inval_entry: ../example/notify_inval_entry.c:261: update_fs_loop: Assertion `fuse_lowlevel_notify_expire_entry (se, FUSE_ROOT_ID, old_name, strlen(old_name), FUSE_LL_EXPIRE_ONLY) == 0' failed.
Aborted (core dumped)
```

I strongly suspect https://github.com/torvalds/linux/commit/4f8d37020e1fd0bf6ee9381ba918135ef3712efd is the responsible kernel commit.

(The two kernel versions in question are what I'm getting from running Docker on a MacOSX laptop for the old kernel, and my Archlinux desktop for the new kernel.)

I noticed the problem, because `test/test_examples.py::test_notify_inval_entry[True-expire_entries] ` fails on the newer kernel.

Fixes https://github.com/libfuse/libfuse/issues/769