### PR TITLE
Stop suppressing memory leak detection

### DIFF
--- a/test/lsan_suppress.txt
+++ b/test/lsan_suppress.txt
@@ -1,11 +1,1 @@
 # Suppression file for address sanitizer.
-
-# There are some leaks in command line option parsing. They should be
-# fixed at some point, but are harmless since they consume just a small,
-# constant amount of memory and do not grow.
-leak:fuse_opt_parse
-
-
-# Leaks in fusermount3 are harmless as well (it's a short-lived
-# process) - but patches are welcome!
-leak:fusermount.c


### PR DESCRIPTION
In order to fix the memory leaks, I tried to just disable leak suppression, and see what breaks.  But from https://github.com/libfuse/libfuse/pull/762 it looks like our suppression didn't actually work; and we didn't actually see any memory leaks in the tests anyway.