### PR TITLE
Fix doxygen warning about parameter name

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -968,7 +968,7 @@ struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op,
 #else /* LIBFUSE_BUILT_WITH_VERSIONED_SYMBOLS */
 struct fuse *fuse_new_31(struct fuse_args *args,
 		      const struct fuse_operations *op,
-		      size_t op_size, void *user_data);
+		      size_t op_size, void *private_data);
 #define fuse_new(args, op, size, data) fuse_new_31(args, op, size, data)
 #endif /* LIBFUSE_BUILT_WITH_VERSIONED_SYMBOLS */
 #endif


### PR DESCRIPTION
Before:

```
$ doxygen doc/Doxyfile
/Users/matthias/prog/fuser/libfuse/include/fuse.h:934: warning: argument 'private_data' of command @param is not found in the argument list of fuse_new_31(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *user_data)
/Users/matthias/prog/fuser/libfuse/include/fuse.h:934: warning: The following parameter of fuse_new_31(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *user_data) is not documented:
  parameter 'user_data'
```

As an aside: now the name in the prototype of `fuse_new_31` doesn't fit with its definition.  But that's fine in C, and I don't want to change all the code and risk breaking anything.