### PR TITLE
FUSE loop: fix a race condition when free memory

### DIFF
--- a/lib/fuse_loop.c
+++ b/lib/fuse_loop.c
@@ -34,7 +34,8 @@ int fuse_session_loop(struct fuse_session *se)
 		fuse_session_process_buf_int(se, &fbuf, NULL);
 	}
 
-	free(fbuf.mem);
+	if (fbuf.mem)
+		free(fbuf.mem);
 	if(res > 0)
 		/* No error, just the length of the most recently read
 		   request */


### PR DESCRIPTION
When I call the fuse_main_real, I met the following error: free(): invalid pointer

The problem here is that I received a signal between fuse_set_signal_handlers and fuse_loop.

So when free takes effect, fbuf.mem is still null.