### PR TITLE
Make expire only function fail if no kernel support

### DIFF
--- a/example/notify_inval_entry.c
+++ b/example/notify_inval_entry.c
@@ -371,8 +371,6 @@ int main(int argc, char *argv[]) {
         ret = fuse_session_loop_mt(se, &config);
     }
 
-    pthread_join(updater, NULL);
-
     // fuse session was cancelled within update_fs_loop()
     if (ret == -FUSE_DESTROY) {
         goto err_out3;

--- a/example/notify_inval_entry.c
+++ b/example/notify_inval_entry.c
@@ -270,20 +270,20 @@ static void* update_fs_loop(void *data) {
             if(options.only_expire) {
                 int ret = fuse_lowlevel_notify_expire_entry
                    (se, FUSE_ROOT_ID, old_name, strlen(old_name));
-               // forget is not being called
-               // the dentry is running just into a timeout
-	       if (ret == -ENOSYS) {
-		 printf("fuse_lowlevel_notify_expire_entry not supported by kernel\n");
-		 printf("Stopping mountpoint...\n");
-		 raise(SIGINT);
-		 return NULL;
-	       }
-               if (old_lookup_cnt == lookup_cnt) {
-                 assert(ret == -ENOENT);
-               } else {
-                 assert(ret == 0);
-                 old_lookup_cnt = lookup_cnt;
-               }
+                if (ret == -ENOSYS) {
+                    printf("fuse_lowlevel_notify_expire_entry not supported by kernel\n");
+                    printf("Next call to mountpoint will kill it...\n");
+                    raise(SIGINT);
+                    return NULL;
+                }
+                // forget is not being called
+                // the dentry is running just into a timeout
+                if (old_lookup_cnt == lookup_cnt) {
+                    assert(ret == -ENOENT);
+                } else {
+                    assert(ret == 0);
+                    old_lookup_cnt = lookup_cnt;
+                }
             } else {
                 assert(fuse_lowlevel_notify_inval_entry
                       (se, FUSE_ROOT_ID, old_name, strlen(old_name)) == 0);

--- a/example/notify_inval_entry.c
+++ b/example/notify_inval_entry.c
@@ -78,7 +78,6 @@
 
 #define FUSE_USE_VERSION 34
 
-#include <fuse_kernel.h>
 #include <fuse_lowlevel.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -418,7 +418,7 @@ struct fuse_loop_config_v1 {
 #define FUSE_CAP_EXPLICIT_INVAL_DATA    (1 << 25)
 
 /**
- * Indicates support that dentries can be expired or invalidated.
+ * Indicates support that dentries can be expired.
  * 
  * Expiring dentries, instead of invalidating them, makes a difference for 
  * overmounted dentries, where plain invalidation would detach all submounts 

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1683,30 +1683,7 @@ int fuse_lowlevel_notify_inval_inode(struct fuse_session *se, fuse_ino_t ino,
 				     off_t off, off_t len);
 
 /**
- * Notify parent attributes and the dentry matching parent/name
- * 
- * Underlying function for fuse_lowlevel_notify_inval_entry() and
- * fuse_lowlevel_notify_expire_entry().
- * 
- * @warning
- * Only checks if fuse_lowlevel_notify_inval_entry() is supported by
- * the kernel. All other flags will fall back to 
- * fuse_lowlevel_notify_inval_entry() if not supported! 
- *
- * @param se the session object
- * @param parent inode number
- * @param name file name
- * @param namelen strlen() of file name
- * @param flags flags to control if the entry should be expired or invalidated
- * @return zero for success, -errno for failure
-*/
-int fuse_lowlevel_notify_entry(struct fuse_session *se, fuse_ino_t parent,
-                                      const char *name, size_t namelen,
-                                      enum fuse_notify_entry_flags flags);
-
-/**
- * Notify to invalidate parent attributes and the dentry matching
- * parent/name
+ * Notify to invalidate parent attributes and the dentry matching parent/name
  *
  * To avoid a deadlock this function must not be called in the
  * execution path of a related filesystem operation or within any code
@@ -1733,12 +1710,13 @@ int fuse_lowlevel_notify_inval_entry(struct fuse_session *se, fuse_ino_t parent,
 				     const char *name, size_t namelen);
 
 /**
- * Notify to expire parent attributes and the dentry 
- * matching parent/name
+ * Notify to expire parent attributes and the dentry matching parent/name
  * 
- * Compared to invalidating an entry, expiring the entry results not
- * in a forceful removal of that entry from kernel cache 
- * but instead the next access to it forces a lookup from the filesystem.
+ * Same restrictions apply as for fuse_lowlevel_notify_inval_entry()
+ * 
+ * Compared to invalidating an entry, expiring the entry results not in a
+ * forceful removal of that entry from kernel cache but instead the next access
+ * to it forces a lookup from the filesystem.
  * 
  * This makes a difference for overmounted dentries, where plain invalidation
  * would detach all submounts before dropping the dentry from the cache. 
@@ -1751,14 +1729,13 @@ int fuse_lowlevel_notify_inval_entry(struct fuse_session *se, fuse_ino_t parent,
  * any submounts will still be detached.
  * 
  * Added in FUSE protocol version 7.38. If the kernel does not support
- * this (or a newer) version, the function will return -ENOSYS and do
- * nothing.
+ * this (or a newer) version, the function will return -ENOSYS and do nothing.
  *
  * @param se the session object
  * @param parent inode number
  * @param name file name
  * @param namelen strlen() of file name
- * @return zero for success, -errno for failure, -enosys if kernel does not support
+ * @return zero for success, -errno for failure, -enosys if no kernel support
 */
 int fuse_lowlevel_notify_expire_entry(struct fuse_session *se, fuse_ino_t parent,
                                       const char *name, size_t namelen);

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1688,6 +1688,10 @@ int fuse_lowlevel_notify_inval_inode(struct fuse_session *se, fuse_ino_t ino,
  * Underlying function for fuse_lowlevel_notify_inval_entry() and
  * fuse_lowlevel_notify_expire_entry().
  * 
+ * @warning
+ * Only checks if fuse_lowlevel_notify_inval_entry() is supported by
+ * the kernel. All other flags will fall back to 
+ * fuse_lowlevel_notify_inval_entry() if not supported! 
  *
  * @param se the session object
  * @param parent inode number
@@ -1745,12 +1749,16 @@ int fuse_lowlevel_notify_inval_entry(struct fuse_session *se, fuse_ino_t parent,
  * so invalidation will only be triggered for the non-overmounted case.
  * The dentry could also be mounted in a different mount instance, in which case
  * any submounts will still be detached.
+ * 
+ * Added in FUSE protocol version 7.38. If the kernel does not support
+ * this (or a newer) version, the function will return -ENOSYS and do
+ * nothing.
  *
  * @param se the session object
  * @param parent inode number
  * @param name file name
  * @param namelen strlen() of file name
- * @return zero for success, -errno for failure
+ * @return zero for success, -errno for failure, -enosys if kernel does not support
 */
 int fuse_lowlevel_notify_expire_entry(struct fuse_session *se, fuse_ino_t parent,
                                       const char *name, size_t namelen);

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -139,11 +139,12 @@ struct fuse_custom_io {
 };
 
 /**
- * Flags for fuse_lowlevel_notify_expire_entry()
+ * Flags for fuse_lowlevel_notify_entry()
  * 0 = invalidate entry
  * FUSE_LL_EXPIRE_ONLY = expire entry
 */
-enum fuse_expire_flags {
+enum fuse_notify_entry_flags {
+	FUSE_LL_INVALIDATE = 0,
 	FUSE_LL_EXPIRE_ONLY	= (1 << 0),
 };
 
@@ -1682,6 +1683,24 @@ int fuse_lowlevel_notify_inval_inode(struct fuse_session *se, fuse_ino_t ino,
 				     off_t off, off_t len);
 
 /**
+ * Notify parent attributes and the dentry matching parent/name
+ * 
+ * Underlying function for fuse_lowlevel_notify_inval_entry() and
+ * fuse_lowlevel_notify_expire_entry().
+ * 
+ *
+ * @param se the session object
+ * @param parent inode number
+ * @param name file name
+ * @param namelen strlen() of file name
+ * @param flags flags to control if the entry should be expired or invalidated
+ * @return zero for success, -errno for failure
+*/
+int fuse_lowlevel_notify_entry(struct fuse_session *se, fuse_ino_t parent,
+                                      const char *name, size_t namelen,
+                                      enum fuse_notify_entry_flags flags);
+
+/**
  * Notify to invalidate parent attributes and the dentry matching
  * parent/name
  *
@@ -1710,13 +1729,11 @@ int fuse_lowlevel_notify_inval_entry(struct fuse_session *se, fuse_ino_t parent,
 				     const char *name, size_t namelen);
 
 /**
- * Notify to expire or invalidate parent attributes and the dentry 
+ * Notify to expire parent attributes and the dentry 
  * matching parent/name
  * 
- * Underlying function for fuse_lowlevel_notify_inval_entry().
- * 
- * In addition to invalidating an entry, it also allows to expire an entry.
- * In that case, the entry is not forcefully removed from kernel cache 
+ * Compared to invalidating an entry, expiring the entry results not
+ * in a forceful removal of that entry from kernel cache 
  * but instead the next access to it forces a lookup from the filesystem.
  * 
  * This makes a difference for overmounted dentries, where plain invalidation
@@ -1733,12 +1750,10 @@ int fuse_lowlevel_notify_inval_entry(struct fuse_session *se, fuse_ino_t parent,
  * @param parent inode number
  * @param name file name
  * @param namelen strlen() of file name
- * @param flags flags to control if the entry should be expired or invalidated
  * @return zero for success, -errno for failure
 */
 int fuse_lowlevel_notify_expire_entry(struct fuse_session *se, fuse_ino_t parent,
-                                      const char *name, size_t namelen,
-                                      enum fuse_expire_flags flags);
+                                      const char *name, size_t namelen);
 
 /**
  * This function behaves like fuse_lowlevel_notify_inval_entry() with

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2305,7 +2305,26 @@ int fuse_lowlevel_notify_inval_inode(struct fuse_session *se, fuse_ino_t ino,
 	return send_notify_iov(se, FUSE_NOTIFY_INVAL_INODE, iov, 2);
 }
 
-int fuse_lowlevel_notify_entry(struct fuse_session *se, fuse_ino_t parent,
+/**
+ * Notify parent attributes and the dentry matching parent/name
+ * 
+ * Underlying base function for fuse_lowlevel_notify_inval_entry() and
+ * fuse_lowlevel_notify_expire_entry().
+ * 
+ * @warning
+ * Only checks if fuse_lowlevel_notify_inval_entry() is supported by
+ * the kernel. All other flags will fall back to 
+ * fuse_lowlevel_notify_inval_entry() if not supported!
+ * DO THE PROPER CHECKS IN THE DERIVED FUNCTION!
+ *
+ * @param se the session object
+ * @param parent inode number
+ * @param name file name
+ * @param namelen strlen() of file name
+ * @param flags flags to control if the entry should be expired or invalidated
+ * @return zero for success, -errno for failure
+*/
+static int fuse_lowlevel_notify_entry(struct fuse_session *se, fuse_ino_t parent,
 							const char *name, size_t namelen,
 							enum fuse_notify_entry_flags flags)
 {

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2305,9 +2305,9 @@ int fuse_lowlevel_notify_inval_inode(struct fuse_session *se, fuse_ino_t ino,
 	return send_notify_iov(se, FUSE_NOTIFY_INVAL_INODE, iov, 2);
 }
 
-int fuse_lowlevel_notify_expire_entry(struct fuse_session *se, fuse_ino_t parent,
-				      const char *name, size_t namelen,
-				      enum fuse_expire_flags flags)
+int fuse_lowlevel_notify_entry(struct fuse_session *se, fuse_ino_t parent,
+							const char *name, size_t namelen,
+							enum fuse_notify_entry_flags flags)
 {
 	struct fuse_notify_inval_entry_out outarg;
 	struct iovec iov[3];
@@ -2333,9 +2333,21 @@ int fuse_lowlevel_notify_expire_entry(struct fuse_session *se, fuse_ino_t parent
 }
 
 int fuse_lowlevel_notify_inval_entry(struct fuse_session *se, fuse_ino_t parent,
-				     const char *name, size_t namelen)
+						 const char *name, size_t namelen)
 {
-	return fuse_lowlevel_notify_expire_entry(se, parent, name, namelen, 0);
+	return fuse_lowlevel_notify_entry(se, parent, name, namelen, FUSE_LL_INVALIDATE);
+}
+
+int fuse_lowlevel_notify_expire_entry(struct fuse_session *se, fuse_ino_t parent,
+							const char *name, size_t namelen)
+{
+	if (!se)
+		return -EINVAL;
+
+	if (!(se->conn.capable & FUSE_CAP_EXPIRE_ONLY))
+		return -ENOSYS;
+
+	return fuse_lowlevel_notify_entry(se, parent, name, namelen, FUSE_LL_EXPIRE_ONLY);
 }
 
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -347,6 +347,8 @@ def test_notify_inval_entry(tmpdir, only_expire, notify, output_checker):
         cmdline.append('--no-notify')
     if only_expire == "expire_entries":
         cmdline.append('--only-expire')
+        if fuse_proto < (7,38):
+            pytest.skip('only-expire not supported by running kernel')
     mount_process = subprocess.Popen(cmdline, stdout=output_checker.fd,
                                      stderr=output_checker.fd)
     try:


### PR DESCRIPTION
Hi @Nikratio 

I finally managed to take care of this PR concering expire_only ( Issue #707 ) 

Integrates fix from PR #771  for the example. However changes a biy by removing `tfs_init` (just commented out) (currently not a proper cherry pick of that branch.. hope that is ok?)

I renamned the old function that does not check for the kenrel support of expire and just falls back to invalidate to ` fuse_lowlevel_notify_entry`. It us now designed to be a base function used both by `expire` and `invalidate`. The new `expire` then does the checking for the kernel support.

For the example i added a `raise(SIGINT)` in case the kernel support is not given. ( i am not sure how backporting functionality works but i now there is red hat ticket open to backport the kernel. as such i thought this example better fails because the function return `-ENOSYS` then check before the major/minor fuse version.

Open to discussion if that is how you want it 
Maybe @bsbernd  and @matthiasgoergens are also interested in the discussion  