### PR TITLE
Add minimal token permissions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: Check for spelling errors

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - master
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: '${{ matrix.os }}'


### PR DESCRIPTION
Closes #792.

As mentioned in the issue above, this PR ensures the workflows run with read-only permissions. This protects the project from supply-chain attacks.