### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives me time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to Nikolaus@rath.org; and/or
+- send me a [private vulnerability report](https://github.com/libarchive/libarchive/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by a single volunteer on a reasonable-effort basis. As such,
+I ask that you give me 90 days to work on a fix before public exposure.
+
+Note we are aware of a long-standing security issue when using `allow_others` (see
+[#15](https://github.com/libfuse/libfuse/issues/15)).


### PR DESCRIPTION
Fixes https://github.com/libfuse/libfuse/issues/796.

As mentioned in the linked issue, this PR adds a security policy to the project.

I added an email I found in https://github.com/libfuse/libfuse/issues/639, let me know if there's another you'd rather use. Likewise, if you'd rather use just the email or just GitHub's feature, let me know and I'll change accordingly.