### PR TITLE
util/mount.fuse.c: compile with linux headers < 3.5

### DIFF
--- a/util/mount.fuse.c
+++ b/util/mount.fuse.c
@@ -43,6 +43,10 @@
 #define SECBIT_NOROOT_LOCKED (issecure_mask(SECURE_NOROOT_LOCKED))
 #endif
 #endif
+/* linux < 3.5 */
+#ifndef PR_SET_NO_NEW_PRIVS
+#define PR_SET_NO_NEW_PRIVS 38
+#endif
 
 #include "fuse.h"
 


### PR DESCRIPTION
PR_SET_NO_NEW_PRIVS was added in linux 3.5 according to prtcl(2) man page

https://elixir.bootlin.com/linux/v4.3/source/include/uapi/linux/prctl.h#L174