### PR TITLE
meson.build: pass -D_FILE_OFFSET_BITS=64 to C/C++ compiler

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -74,10 +74,10 @@ private_cfg.set('HAVE_STRUCT_STAT_ST_ATIMESPEC',
 #
 # Compiler configuration
 #
-add_project_arguments('-D_REENTRANT', '-DHAVE_LIBFUSE_PRIVATE_CONFIG_H', '-Wno-sign-compare',
+add_project_arguments('-D_REENTRANT', '-DHAVE_LIBFUSE_PRIVATE_CONFIG_H', '-Wno-sign-compare', '-D_FILE_OFFSET_BITS=64',
                       '-Wstrict-prototypes', '-Wmissing-declarations', '-Wwrite-strings',
                       '-fno-strict-aliasing', language: 'c')
-add_project_arguments('-D_REENTRANT', '-DHAVE_LIBFUSE_PRIVATE_CONFIG_H', '-D_GNU_SOURCE',
+add_project_arguments('-D_REENTRANT', '-DHAVE_LIBFUSE_PRIVATE_CONFIG_H', '-D_GNU_SOURCE', '-D_FILE_OFFSET_BITS=64',
                      '-Wno-sign-compare', '-Wmissing-declarations',
                      '-Wwrite-strings', '-fno-strict-aliasing', language: 'cpp')
 


### PR DESCRIPTION
libfuse requires a 64bit off_t, it's not optional
../include/fuse_common.h:938:1: error: Kstatic assertion failed: "fuse: off_t must be 64bit"

so this only takes effect if compiling for a 32bit glibc system, it's ignored everywhere else

meson by default adds -D_FILE_OFFSET_BITS=64 to C/C++ compilers, and removes duplicate declarations There are several opened issues in meson's git repo requesting to remove that behavior, so this makes sense even more now

this fixes compilation with muon (a C99 (mostly) meson compatible build app) in a 32bit glibc system ...