### PR TITLE
util/meson.build: don't install udev.rules if udevdir cannot be determined

### DIFF
--- a/util/install_helper.sh
+++ b/util/install_helper.sh
@@ -37,8 +37,10 @@ if $useroot; then
     fi
 fi
 
-install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
+if [ "${udevrulesdir}" != "" ]; then
+    install -D -m 644 "${MESON_SOURCE_ROOT}/util/udev.rules" \
         "${DESTDIR}${udevrulesdir}/99-fuse3.rules"
+fi
 
 if [ "$initscriptdir" != "" ]; then
     install -D -m 755 "${MESON_SOURCE_ROOT}/util/init_script" \

--- a/util/meson.build
+++ b/util/meson.build
@@ -16,8 +16,14 @@ executable('mount.fuse3', ['mount.fuse.c'],
 
 udevrulesdir = get_option('udevrulesdir')
 if udevrulesdir == ''
-  udev = dependency('udev')
-  udevrulesdir = join_paths(udev.get_variable(pkgconfig: 'udevdir'), 'rules.d')
+  udev = dependency('udev', required: false)
+  if udev.found()
+     udevrulesdir = join_paths(udev.get_variable(pkgconfig: 'udevdir'), 'rules.d')
+  endif
+endif
+
+if udevrulesdir == ''
+  warning('could not determine udevdir, udev.rules will not be installed')
 endif
 
 meson.add_install_script('install_helper.sh',


### PR DESCRIPTION
make the udev dependency optional

just show a big warning if `udevrulesdir` is empty