### PR TITLE
Improve wording of user_allow_other usage instructions

### DIFF
--- a/util/fuse.conf
+++ b/util/fuse.conf
@@ -11,7 +11,7 @@
 
 
 # mount_max = n - this option sets the maximum number of mounts.
-# Currently (2014) it must be typed exactly as shown
-# (with a single space before and after the equals sign).
+# It must be typed exactly as shown (with a single space before and after the
+# equals sign).
 
 #mount_max = 1000

--- a/util/fuse.conf
+++ b/util/fuse.conf
@@ -1,11 +1,11 @@
 # The file /etc/fuse.conf allows for the following parameters:
 #
-# user_allow_other - Using the allow_other mount option works fine as root, in
-# order to have it work as user you need user_allow_other in /etc/fuse.conf as
-# well. (This option allows users to use the allow_other option.) You need
-# allow_other if you want users other than the owner to access a mounted fuse.
-# This option must appear on a line by itself. There is no value, just the
-# presence of the option.
+# user_allow_other - Using the allow_other mount option works fine as root, but
+# in order to have it work as a regular user, you need to set user_allow_other
+# in /etc/fuse.conf as well. This option allows non-root users to use the
+# allow_other option. You need allow_other if you want users other than the
+# owner of a mounted fuse to access it. This option must appear on a line by
+# itself. There is no value; just the presence of the option activates it.
 
 #user_allow_other
 


### PR DESCRIPTION
While I appreciate the detailed instructions for `user_allow_other`, IMO these small grammatical, punctuation and wording adjustments improve the clarity of the content.

In addition, I took the opportunity to remove a dated comment from the `mount_max` usage instructions immediately below.
