### PR TITLE
passthrough_hp benchmark mode

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -1348,6 +1348,8 @@ int main(int argc, char *argv[]) {
     if (fs.num_threads != -1)
         fuse_loop_cfg_set_idle_threads(loop_config, fs.num_threads);
 
+    fuse_loop_cfg_set_clone_fd(loop_config, fs.clone_fd);
+
     if (fuse_session_mount(se, argv[2]) != 0)
         goto err_out3;
 

--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -835,6 +835,7 @@ static void sfs_create(fuse_req_t req, fuse_ino_t parent, const char *name,
     }
 
     fi->fh = fd;
+    fi->parallel_direct_writes = 1;
     fuse_entry_param e;
     auto err = do_lookup(parent, name, &e);
     if (err) {
@@ -901,6 +902,7 @@ static void sfs_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi) {
     fi->keep_cache = (fs.timeout != 0);
     fi->noflush = (fs.timeout == 0 && (fi->flags & O_ACCMODE) == O_RDONLY);
     fi->fh = fd;
+    fi->parallel_direct_writes = 1;
     fuse_reply_open(req, fi);
 }
 


### PR DESCRIPTION
This adds a read/write benchmark mode for passthrough_hp. Minor commits are the forgotten handler for clone_fd and adding in parallel dio writes.