### PR TITLE
xfstests example: Use export in local.config and remove comment

### DIFF
--- a/xfstests/local.config
+++ b/xfstests/local.config
@@ -7,6 +7,13 @@ export FUSE_SUBTYP=.passthrough
 export MOUNT_OPTIONS=""
 export TEST_FS_MOUNT_OPTS=""
 
-export PASSTHROUGH_PATH=<path-to-libfuse-build>/example/passthrough_hp
+# If PASSTHROUGH_PATH is unset, the mount helper is going to look
+# for the binary '${FUSE_SUBTYP}', though omitting the leading dot '.'.
+# Example:
+#       with FUSE_SUBTYP=".passthrough", the mount helper is called
+#       'mount.fuse.passthrough' and that would try to run
+#       'passthrough'.
+# export PASSTHROUGH_PATH=<path-to-libfuse-build>/example/passthrough_hp
+
 export SCRATCH_SOURCE=/mnt/src/scratch
 export TEST_SOURCE=/mnt/src/test

--- a/xfstests/local.config
+++ b/xfstests/local.config
@@ -7,6 +7,6 @@ export FUSE_SUBTYP=.passthrough
 export MOUNT_OPTIONS=""
 export TEST_FS_MOUNT_OPTS=""
 
-PASSTHROUGH_PATH=/home/nikratio/libfuse/build/example/passthrough_hp
-SCRATCH_SOURCE=/mnt/src/scratch
-TEST_SOURCE=/mnt/src/test
+export PASSTHROUGH_PATH=<path-to-libfuse-build>/example/passthrough_hp
+export SCRATCH_SOURCE=/mnt/src/scratch
+export TEST_SOURCE=/mnt/src/test

--- a/xfstests/local.config
+++ b/xfstests/local.config
@@ -1,7 +1,9 @@
-export TEST_DEV=non1
+export TEST_DEV=source:/mnt/src/test
 export TEST_DIR=/mnt/test
-export SCRATCH_DEV=non2
+
+export SCRATCH_DEV=source:/mnt/src/scratch
 export SCRATCH_MNT=/mnt/scratch
+
 export FSTYP=fuse
 export FUSE_SUBTYP=.passthrough
 export MOUNT_OPTIONS=""
@@ -14,6 +16,3 @@ export TEST_FS_MOUNT_OPTS=""
 #       'mount.fuse.passthrough' and that would try to run
 #       'passthrough'.
 # export PASSTHROUGH_PATH=<path-to-libfuse-build>/example/passthrough_hp
-
-export SCRATCH_SOURCE=/mnt/src/scratch
-export TEST_SOURCE=/mnt/src/test

--- a/xfstests/mount.fuse.passthrough
+++ b/xfstests/mount.fuse.passthrough
@@ -12,17 +12,14 @@ mntopts="$1"
 shift
 
 # source can be provided as NFS style device (e.g. TEST_DEV=source:/${TEST_SOURCE})
-# or by exporting the {TEST,SCRATCH}_SOURCE env vars
 # and/or it can already be inside mount options (passthrough_ll style)
 if ( echo "$mntopts" | grep -q "source=" ) ; then
 	# Don't pass source as position argument
 	source=
 elif [[ "$dev" == "source:"* ]]; then
 	source="${dev#"source:"}"
-elif [ "$dev" = "${SCRATCH_DEV}" ]; then
-	source="${SCRATCH_SOURCE}"
-elif [ "$dev" = "${TEST_DEV}" ]; then
-	source="${TEST_SOURCE}"
+else
+    >&2 echo "passthrough source is undefined, aborting!"
 fi
 
 if ( echo "$mntopts" | grep -q remount ) ; then

--- a/xfstests/mount.fuse.passthrough
+++ b/xfstests/mount.fuse.passthrough
@@ -2,16 +2,40 @@
 
 ulimit -n 1048576
 
-# It would be easier if we could just set SCRATCH_DEV and TEST_DEV to the source directory
-# path in local.options. Unfortunately, setting these variables to a path seems get
-# xfstests all worked up (even though it should treat these as opaque values), and it
-# refuses to even start running any tests).
 dev="$1"
 shift
-if [ "$dev" = "${SCRATCH_DEV}" ]; then
-  source="${SCRATCH_SOURCE}"
-else
-  source="${TEST_SOURCE}"
+mnt="$1"
+shift
+# -o
+shift
+mntopts="$1"
+shift
+
+# source can be provided as NFS style device (e.g. TEST_DEV=source:/${TEST_SOURCE})
+# or by exporting the {TEST,SCRATCH}_SOURCE env vars
+# and/or it can already be inside mount options (passthrough_ll style)
+if ( echo "$mntopts" | grep -q "source=" ) ; then
+	# Don't pass source as position argument
+	source=
+elif [[ "$dev" == "source:"* ]]; then
+	source="${dev#"source:"}"
+elif [ "$dev" = "${SCRATCH_DEV}" ]; then
+	source="${SCRATCH_SOURCE}"
+elif [ "$dev" = "${TEST_DEV}" ]; then
+	source="${TEST_SOURCE}"
 fi
 
-exec "$PASSTHROUGH_PATH" -o fsname=$dev,allow_other "${source}" "$@"
+if ( echo "$mntopts" | grep -q remount ) ; then
+	exec mount -i "$dev" "$mnt" -o "$mntopts"
+fi
+
+# set default to SUBTYPE (extracted from this script name)
+# example:
+#   Copy or link this script to /sbin/mount.fuse.passthrough_hp
+#   If xfstests local.config does not set PASSTHROUGH_PATH,
+#   PASSTHROUGH_PATH will be set to 'passthrough_hp' and exec below
+#   will look that up from $PATH
+
+[ -n "$PASSTHROUGH_PATH" ] || PASSTHROUGH_PATH=${0#*mount.fuse.}
+
+exec "$PASSTHROUGH_PATH" -o fsname=$dev,allow_other $source "$mnt" -o "$mntopts" "$@"


### PR DESCRIPTION
mount.fuse.passthrough had a comment explaining that these variables
do not work if specified in local.config. Actually the variables
just had to be exported - remove the comment and export the example
variables.
