### PR TITLE
Allow linking with mold / fix the version script

### DIFF
--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -83,7 +83,6 @@ FUSE_3.0 {
 		fuse_fs_unlink;
 		fuse_fs_utimens;
 		fuse_fs_write;
-		fuse_register_module;
 		fuse_reply_iov;
 		fuse_version;
 		fuse_pkgversion;
@@ -161,7 +160,6 @@ FUSE_3.3 {
 FUSE_3.4 {
 	global:
 		fuse_fs_copy_file_range;
-		fuse_reply_copy_file_range;
 } FUSE_3.3;
 
 FUSE_3.7 {


### PR DESCRIPTION
This fixes issue https://github.com/libfuse/libfuse/issues/810 and should avoid mold linking errors.
Commit d4e294b removed made fuse_register_module() a static function, but forgot to remove it from the version script.

Commit fe4f942 introduced copy_file_range to libfuse and added the non-exiting (neither declared nor defined) function fuse_reply_copy_file_range() to the version script. Kernel side just exects an integer reply how much was copied, using fuse_reply_write() as in fuse_lib_copy_file_range() is sufficient and no extra function is needed.