### PR TITLE
Pass cache_readdir and keep_cache from high level API

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,8 @@
+libfuse next.release.version (xxxx-xx-xx)
+===========================
+
+* Readdir kernel cache can be enabled from high-level API.
+
 libfuse 3.15.1 (2023-07-05)
 ===========================
 

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -3374,6 +3374,8 @@ static void fuse_lib_opendir(fuse_req_t req, fuse_ino_t ino,
 		err = fuse_fs_opendir(f->fs, path, &fi);
 		fuse_finish_interrupt(f, req, &d);
 		dh->fh = fi.fh;
+		llfi->cache_readdir = fi.cache_readdir;
+		llfi->keep_cache = fi.keep_cache;
 	}
 	if (!err) {
 		if (fuse_reply_open(req, llfi) == -ENOENT) {


### PR DESCRIPTION
Currently `cache_readdir` and `keep_cache` flags are not passed from high-level api to low-level. This means that high-level API users can not use readdir kernel caching.

This commit simply passes the above mentioned flags to low-level.

Fixes #821

