### PR TITLE
Make errnum-verification more flexible

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -213,7 +213,12 @@ int fuse_send_reply_iov_nofree(fuse_req_t req, int error, struct iovec *iov,
 {
 	struct fuse_out_header out;
 
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 32
+	const char *str = strerrordesc_np(error * -1);
+	if ((str == NULL && error != 0) || error > 0) {
+#else
 	if (error <= -1000 || error > 0) {
+#endif
 		fuse_log(FUSE_LOG_ERR, "fuse: bad error value: %i\n",	error);
 		error = -ERANGE;
 	}


### PR DESCRIPTION
This change aims to make the checking of errnum values passed to the kernel in reply headers more flexible while maintaining correctness. This is achieved by, instead of hardcoding a value, checking the return value of a function which is defined to return NULL if the errnum value is not a valid errnum.

Since this function is non-standard, it's usage is gated behind glibc version-test macros. While from my understanding gnulib also provides this function, I felt it was better to not introduce a dependency for this purpose.