### PR TITLE
Enabled parallel direct IO writes for passthrough examples

### DIFF
--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -285,6 +285,7 @@ static int xmp_create(const char *path, mode_t mode,
 		return -errno;
 
 	fi->fh = res;
+	fi->parallel_direct_writes = 1;
 	return 0;
 }
 
@@ -297,6 +298,7 @@ static int xmp_open(const char *path, struct fuse_file_info *fi)
 		return -errno;
 
 	fi->fh = res;
+	fi->parallel_direct_writes = 1;
 	return 0;
 }
 

--- a/example/passthrough_fh.c
+++ b/example/passthrough_fh.c
@@ -366,6 +366,7 @@ static int xmp_create(const char *path, mode_t mode, struct fuse_file_info *fi)
 		return -errno;
 
 	fi->fh = fd;
+	fi->parallel_direct_writes = 1;
 	return 0;
 }
 
@@ -378,6 +379,7 @@ static int xmp_open(const char *path, struct fuse_file_info *fi)
 		return -errno;
 
 	fi->fh = fd;
+	fi->parallel_direct_writes = 1;
 	return 0;
 }
 

--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -836,6 +836,8 @@ static void sfs_create(fuse_req_t req, fuse_ino_t parent, const char *name,
     if (fs.direct_io)
 	    fi->direct_io = 1;
 
+    fi->parallel_direct_writes = 1;
+
     Inode& inode = get_inode(e.ino);
     lock_guard<mutex> g {inode.m};
     inode.nopen++;
@@ -895,6 +897,8 @@ static void sfs_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi) {
 
     if (fs.direct_io)
 	    fi->direct_io = 1;
+
+    fi->parallel_direct_writes = 1;
 
     fi->fh = fd;
     fuse_reply_open(req, fi);

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -775,6 +775,8 @@ static void lo_create(fuse_req_t req, fuse_ino_t parent, const char *name,
 	else if (lo->cache == CACHE_ALWAYS)
 		fi->keep_cache = 1;
 
+	fi->parallel_direct_writes = 1;
+
 	err = lo_do_lookup(req, parent, name, &e);
 	if (err)
 		fuse_reply_err(req, err);
@@ -831,6 +833,9 @@ static void lo_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		fi->direct_io = 1;
 	else if (lo->cache == CACHE_ALWAYS)
 		fi->keep_cache = 1;
+
+	fi->parallel_direct_writes = 1;
+
 	fuse_reply_open(req, fi);
 }
 


### PR DESCRIPTION
All these passthrough examples don't need writes to be serialized.

Actually, most file systems probably handle non serialized parallel direct writes - the FOPEN_PARALLEL_DIRECT_WRITES flag is just to avoid a regression for those file system that rely on serialized DIO writes in fuse kernel. Passthrough file system forward the IO to another file system, which actually handles that internally - serialized in fuser kernel is not needed.