### PR TITLE
Update fuse_file_info::flags comment to include create()

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -48,7 +48,7 @@ extern "C" {
  * descriptors can share a single file handle.
  */
 struct fuse_file_info {
-	/** Open flags.	 Available in open() and release() */
+	/** Open flags.	 Available in open(), release() and create() */
 	int flags;
 
 	/** In case of a write operation indicates if this was caused


### PR DESCRIPTION
This is a minor comment / documentation change to state that fuse_file_info::flags field is also used by the create() function.