### PR TITLE
Remove unnecessary write_header_size check

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2658,9 +2658,6 @@ void fuse_session_process_buf_int(struct fuse_session *se,
 	int res;
 
 	if (buf->flags & FUSE_BUF_IS_FD) {
-		if (buf->size < tmpbuf.buf[0].size)
-			tmpbuf.buf[0].size = buf->size;
-
 		mbuf = malloc(tmpbuf.buf[0].size);
 		if (mbuf == NULL) {
 			fuse_log(FUSE_LOG_ERR, "fuse: failed to allocate header\n");
@@ -2740,7 +2737,7 @@ void fuse_session_process_buf_int(struct fuse_session *se,
 			fuse_reply_err(intr, EAGAIN);
 	}
 
-	if ((buf->flags & FUSE_BUF_IS_FD) && write_header_size < buf->size &&
+	if ((buf->flags & FUSE_BUF_IS_FD) &&
 	    (in->opcode != FUSE_WRITE || !se->op.write_buf) &&
 	    in->opcode != FUSE_NOTIFY_REPLY) {
 		void *newmbuf;


### PR DESCRIPTION
IIUC, in fuse_session_receive_buf_int(), if fuse_buf is set with FUSE_BUF_IS_FD, fuse_buf's size would be greater than "sizeof(struct fuse_in_header) + sizeof(struct fuse_write_in) + pagesize)", then write_header_size must be less than fuse_buf's size, so we can remove write_header_size check safely.