### PR TITLE
add custom mem bufv support

### DIFF
--- a/example/custom_mem_bufv_ll.cc
+++ b/example/custom_mem_bufv_ll.cc
@@ -1,0 +1,273 @@
+/*
+  FUSE: Filesystem in Userspace
+  Copyright (C) 2001-2007  Miklos Szeredi <miklos@szeredi.hu>
+  Copyright (C) 2023-2025  Xiaoguang Wang <lege.wang@jaguarmicro.com>
+
+  This program can be distributed under the terms of the GNU GPLv2.
+  See the file COPYING.
+*/
+
+/**
+ * minimal example filesystem using low-level API and a custom io. This custom
+ * io is implemented using memory-mapped buffer. Currently for simplicity, this
+ * test uses global variable's address as memory-mapped buffer address. In
+ * practical scenarios, memory-mapped buffer may come from guest vm by
+ * vhost-user protocol.
+ */
+
+#define FUSE_USE_VERSION 34
+
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <fuse_lowlevel.h>
+#include <fuse_kernel.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <assert.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include <iostream>
+#include <unordered_map>
+
+using namespace std;
+
+struct request {
+	struct fuse_bufvec *in_bufv;
+	struct fuse_bufvec *out_bufv;
+
+	request(struct fuse_bufvec *in, struct fuse_bufvec *out) : in_bufv(in), out_bufv(out) {}
+};
+
+unordered_map<int, struct request> req_map;
+
+static struct fuse_in_header in_header;
+static struct fuse_init_in  init_in;
+static struct fuse_out_header out_header;
+static struct fuse_init_out init_out;
+
+static const struct fuse_lowlevel_ops fuse_ll_oper = {};
+
+static int create_socket(const char *socket_path) {
+	struct sockaddr_un addr;
+
+	if (strnlen(socket_path, sizeof(addr.sun_path)) >=
+		sizeof(addr.sun_path)) {
+		printf("Socket path may not be longer than %lu characters\n",
+			 sizeof(addr.sun_path) - 1);
+		return -1;
+	}
+
+	if (remove(socket_path) == -1 && errno != ENOENT) {
+		printf("Could not delete previous socket file entry at %s. Error: "
+			 "%s\n", socket_path, strerror(errno));
+		return -1;
+	}
+
+	memset(&addr, 0, sizeof(struct sockaddr_un));
+	strcpy(addr.sun_path, socket_path);
+
+	int sfd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (sfd == -1) {
+		printf("Could not create socket. Error: %s\n", strerror(errno));
+		return -1;
+	}
+
+	addr.sun_family = AF_UNIX;
+	if (bind(sfd, (struct sockaddr *) &addr,
+		   sizeof(struct sockaddr_un)) == -1) {
+		printf("Could not bind socket. Error: %s\n", strerror(errno));
+		return -1;
+	}
+
+	if (listen(sfd, 1) == -1)
+		return -1;
+
+	printf("Awaiting connection on socket at %s...\n", socket_path);
+	int cfd = accept(sfd, NULL, NULL);
+	if (cfd == -1) {
+		printf("Could not accept connection. Error: %s\n",
+			 strerror(errno));
+		return -1;
+	} else {
+		printf("Accepted connection!\n");
+	}
+	return cfd;
+}
+
+static ssize_t readall(int fd, void *buf, size_t len)
+{
+	int i;
+	size_t count = 0;
+
+	(void)buf;
+	while (count < len) {
+		i = read(fd, (char *)buf + count, len - count);
+		if (!i)
+			break;
+		if (i < 0)
+			return i;
+		count += i;
+	}
+	return count;
+}
+
+static ssize_t get_mem_buf(int fd, struct fuse_bufvec **bufv, void *userdata)
+{
+	struct fuse_bufvec *in = *bufv, *out = NULL;
+	ssize_t res;
+
+	(void)userdata;
+
+	if (!in || in->count < 2) {
+		free(in);
+		*bufv = NULL;
+		in = (struct fuse_bufvec *)malloc(sizeof(struct fuse_bufvec) +
+						  sizeof(struct fuse_buf));
+	} else {
+		in = *bufv;
+	}
+
+	out = (struct fuse_bufvec *)malloc(sizeof(struct fuse_bufvec) +
+					   sizeof(struct fuse_buf));
+
+	res = readall(fd, &in_header, sizeof(in_header));
+	if (res != sizeof(in_header))
+		exit(-1);
+	res = readall(fd, &init_in, sizeof(init_in));
+	if (res != sizeof(init_in))
+		exit(-1);
+
+	in->buf[0].size = sizeof(in_header);
+	in->buf[0].mem = &in_header;
+	in->buf[0].flags = FUSE_BUF_IS_CUSTOM_BUF;
+	in->buf[1].size = sizeof(init_in);
+	in->buf[1].mem = &init_in;
+	in->buf[1].flags = FUSE_BUF_IS_CUSTOM_BUF;
+	in->count = 2;
+	in->idx = 0;
+	in->off = 0;
+
+	out->buf[0].size = sizeof(out_header);
+	out->buf[0].mem = &out_header;
+	out->buf[1].size = sizeof(init_out);
+	out->buf[1].mem = &init_out;
+	out->count = 2;
+	out->idx = 0;
+	out->off = 0;
+
+	*bufv = in;
+	req_map.insert(make_pair(in_header.unique, request(in, out)));
+	return sizeof(in_header) + sizeof(init_in);
+}
+
+static ssize_t get_reply_mem_bufv(int fd, uint64_t unique,
+			   struct fuse_bufvec **bufv, void *userdata)
+{
+	(void)fd;
+	(void)unique;
+	(void)bufv;
+	(void)userdata;
+
+	auto it = req_map.find(unique);
+	if (it == req_map.end())
+		return -1;
+
+	*bufv = it->second.out_bufv;
+	return 1;
+}
+
+static ssize_t commit_req(int fd, uint64_t unique, void *userdata)
+{
+	ssize_t ret;
+
+	(void)fd;
+	(void)unique;
+	(void)userdata;
+
+	auto it = req_map.find(unique);
+	if (it != req_map.end()) {
+		ret = write(fd, &out_header, sizeof(out_header));
+		if (ret != sizeof(out_header))
+			exit(-1);
+		ret = write(fd, &init_out, sizeof(init_out));
+		if (ret != sizeof(init_out))
+			exit(-1);
+		return 1;
+	}
+	return 0;
+}
+
+static void fuse_cmdline_help_uds(void)
+{
+	printf("    -h   --help            print help\n"
+	       "    -V   --version         print version\n"
+	       "    -d   -o debug          enable debug output (implies -f)\n");
+}
+
+int main(int argc, char *argv[])
+{
+	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
+	struct fuse_session *se;
+	struct fuse_cmdline_opts opts;
+	const struct fuse_custom_io io = {
+		.writev = NULL,
+		.read = NULL,
+		.splice_receive = NULL,
+		.splice_send = NULL,
+		.get_mem_bufv = get_mem_buf,
+		.get_reply_mem_bufv = get_reply_mem_bufv,
+		.commit_req = commit_req,
+	};
+	int cfd = -1;
+	int ret = -1;
+
+	if (fuse_parse_cmdline(&args, &opts) != 0)
+		return 1;
+	if (opts.show_help) {
+		printf("usage: %s [options]\n\n", argv[0]);
+		fuse_cmdline_help_uds();
+		fuse_lowlevel_help();
+		ret = 0;
+		goto err_out1;
+	} else if (opts.show_version) {
+		printf("FUSE library version %s\n", fuse_pkgversion());
+		fuse_lowlevel_version();
+		ret = 0;
+		goto err_out1;
+	}
+
+	se = fuse_session_new(&args, &fuse_ll_oper,
+			      sizeof(fuse_ll_oper), NULL);
+	if (se == NULL)
+	    goto err_out1;
+
+	if (fuse_set_signal_handlers(se) != 0)
+	    goto err_out2;
+
+	cfd = create_socket("/tmp/libfuse-custom-mem-ll.sock");
+	if (cfd == -1)
+		goto err_out3;
+
+	if (fuse_session_custom_io(se, &io, cfd) != 0)
+		goto err_out3;
+
+	/* Block until ctrl+c */
+	ret = fuse_session_loop(se);
+err_out3:
+	fuse_remove_signal_handlers(se);
+err_out2:
+	fuse_session_destroy(se);
+err_out1:
+	free(opts.mountpoint);
+	fuse_opt_free_args(&args);
+
+	return ret ? 1 : 0;
+}

--- a/example/meson.build
+++ b/example/meson.build
@@ -35,6 +35,10 @@ if not platform.endswith('bsd') and platform != 'dragonfly' and add_languages('c
     executable('passthrough_hp', 'passthrough_hp.cc',
                dependencies: [ thread_dep, libfuse_dep ],
                install: false)
+
+    executable('custom_mem_bufv_ll', 'custom_mem_bufv_ll.cc',
+               dependencies: [ thread_dep, libfuse_dep ],
+               install: false)
 endif
 
 # TODO: Link passthrough_fh with ulockmgr if available

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -694,7 +694,16 @@ enum fuse_buf_flags {
 	 * until .size bytes have been copied or an error or EOF is
 	 * detected.
 	 */
-	FUSE_BUF_FD_RETRY	= (1 << 3)
+	FUSE_BUF_FD_RETRY	= (1 << 3),
+
+	/**
+	 * Buffer contains a custom mem buf, see struct fuse_custom_io definition.
+	 *
+	 * Normally if this flag is set, buffer is a memory-mapped buffer and you
+	 * don't need to call free(3) on it. It depends on how fuse_custom_io's
+	 * implementation to drop this buf.
+	 */
+	FUSE_BUF_IS_CUSTOM_BUF	= (1 << 4)
 };
 
 /**

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -173,10 +173,10 @@ void cuse_lowlevel_init(fuse_req_t req, fuse_ino_t nodeide, const void *inarg);
 
 int fuse_start_thread(pthread_t *thread_id, void *(*func)(void *), void *arg);
 
-int fuse_session_receive_buf_int(struct fuse_session *se, struct fuse_buf *buf,
-				 struct fuse_chan *ch);
-void fuse_session_process_buf_int(struct fuse_session *se,
-				  const struct fuse_buf *buf, struct fuse_chan *ch);
+int fuse_session_receive_bufvec_int(struct fuse_session *se,
+		struct fuse_bufvec **bufv, struct fuse_chan *ch);
+void fuse_session_process_bufvec_int(struct fuse_session *se,
+		struct fuse_bufvec *bufv, struct fuse_chan *ch);
 
 struct fuse *fuse_new_31(struct fuse_args *args, const struct fuse_operations *op,
 		      size_t op_size, void *private_data);
@@ -190,6 +190,9 @@ int fuse_session_loop_mt_312(struct fuse_session *se, struct fuse_loop_config *c
  */
 int fuse_loop_cfg_verify(struct fuse_loop_config *config);
 
+void fuse_free_buf(struct fuse_bufvec *bufv);
+ssize_t fuse_buf_copy_from_iov(struct fuse_bufvec *dstv,
+			       struct iovec *iov, int count);
 
 #define FUSE_MAX_MAX_PAGES 256
 #define FUSE_DEFAULT_MAX_PAGES_PER_REQ 32

--- a/lib/fuse_loop.c
+++ b/lib/fuse_loop.c
@@ -19,22 +19,20 @@
 int fuse_session_loop(struct fuse_session *se)
 {
 	int res = 0;
-	struct fuse_buf fbuf = {
-		.mem = NULL,
-	};
+	struct fuse_bufvec *bufv = NULL;
 
 	while (!fuse_session_exited(se)) {
-		res = fuse_session_receive_buf_int(se, &fbuf, NULL);
+		res = fuse_session_receive_bufvec_int(se, &bufv, NULL);
 
 		if (res == -EINTR)
 			continue;
 		if (res <= 0)
 			break;
 
-		fuse_session_process_buf_int(se, &fbuf, NULL);
+		fuse_session_process_bufvec_int(se, bufv, NULL);
 	}
 
-	free(fbuf.mem);
+	fuse_free_buf(bufv);
 	if(res > 0)
 		/* No error, just the length of the most recently read
 		   request */

--- a/test/test_custom_mem_bufv.py
+++ b/test/test_custom_mem_bufv.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+if __name__ == '__main__':
+    import sys
+
+    import pytest
+    sys.exit(pytest.main([__file__] + sys.argv[1:]))
+
+import os
+import socket
+import struct
+import subprocess
+import sys
+import time
+from os.path import join as pjoin
+
+import pytest
+
+from util import base_cmdline, basename
+
+FUSE_OP_INIT = 26
+
+FUSE_MAJOR_VERSION = 7
+FUSE_MINOR_VERSION = 38
+
+fuse_in_header_fmt = '<IIQQIIII'
+fuse_out_header_fmt = '<IiQ'
+
+fuse_init_in_fmt = '<IIIII44x'
+fuse_init_out_fmt = '<IIIIHHIIHHI28x'
+
+
+def sock_recvall(sock: socket.socket, bufsize: int) -> bytes:
+    buf = bytes()
+    while len(buf) < bufsize:
+        buf += sock.recv(bufsize - len(buf))
+    return buf
+
+
+def tst_init(sock: socket.socket):
+    unique_req = 10
+    dummy_init_req_header = struct.pack(
+        fuse_in_header_fmt, struct.calcsize(fuse_in_header_fmt) +
+        struct.calcsize(fuse_init_in_fmt), FUSE_OP_INIT, unique_req, 0, 0, 0,
+        0, 0)
+    dummy_init_req_payload = struct.pack(
+        fuse_init_in_fmt, FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION, 0, 0, 0)
+    dummy_init_req = dummy_init_req_header + dummy_init_req_payload
+
+    sock.sendall(dummy_init_req)
+
+    response_header = sock_recvall(sock, struct.calcsize(fuse_out_header_fmt))
+    packet_len, _, unique_res = struct.unpack(
+        fuse_out_header_fmt, response_header)
+    assert unique_res == unique_req
+
+    response_payload = sock_recvall(sock, packet_len - len(response_header))
+    response_payload = struct.unpack(fuse_init_out_fmt, response_payload)
+    assert response_payload[0] == FUSE_MAJOR_VERSION
+
+
+def test_custom_mem_bufv(output_checker):
+    cmdline = base_cmdline + [pjoin(basename, 'example', 'custom_mem_bufv_ll')]
+    print(cmdline)
+    custom_mem_bufv_process = subprocess.Popen(cmdline, stdout=output_checker.fd,
+                                   stderr=output_checker.fd)
+    time.sleep(1)
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(1)
+    sock.connect("/tmp/libfuse-custom-mem-ll.sock")
+
+    tst_init(sock)
+
+    sock.close()
+    custom_mem_bufv_process.terminate()
+    try:
+        custom_mem_bufv_process.wait(1)
+    except subprocess.TimeoutExpired:
+        custom_mem_bufv_process.kill()
+    os.remove("/tmp/libfuse-custom-mem-ll.sock")


### PR DESCRIPTION
DPU(Data Processing Unit) is becoming more popular, currently DPU can accelerate block io or net by implementing virtio blk or net logic with hardware, now more advanced DPUs start to support virtio filesystem protocol:
  https://docs.oasis-open.org/virtio/virtio/v1.3/csd01/virtio-v1.3-csd01.html#x1-49600011

With DPU that supports virtio filesystem protocol, user can deploy userspace filesystems(based on fuse) on the DPU side, but these filesystems need to get raw fuse request and reply request data by handling virtio details, virtiofsd is one such example of doing so:
  https://gitlab.com/virtio-fs/virtiofsd
virtiofsd is written with rust, and used vhost-user library to fetch and reply fuse request.

AFAIK, there're many userspace filesystems based on fuse and are written with c language, they read and reply fuse request by reading and writing /dev/fuse, so these filesystems can't be deployed on the DPU side quickly and will require substantial adaptation work.

To ease adaptation effort, extend fuse_custom_io, add 3 new interfaces:
  ssize_t (*get_mem_bufv)(int fd, struct fuse_bufvec **bufv, void *userdata);
  ssize_t (*get_reply_mem_bufv)(int fd, uint64_t unique,
		struct fuse_bufvec **bufv, void *userdata);
  ssize_t (*commit_req)(int fd, uint64_t unique, void *userdata);

In virtio filesystem protocol, one fuse request consists of multiple non-contiguous memory segments, so choose fuse_bufvec as the main unit to hold fuse request and reply data.
  get_mem_bufv() will return one fuse_bufvec, which describes one fuse
request and may contain multiple fuse_buf.
  get_reply_mem_bufv() will return one fuse_bufvec, which will be used
to hold request's reply data.
  commit_req() is used to notify the request completion event.

Thanks to Tofik Sonono's previous fuse_custom_io work, we also could use read or splice_receive interface to handle virtio detailes, but it's not efficent.

Yet, there are still some adaptation work to do, userspace filesystem based on fuse need to implement above 3 interfaces, which may use vhost-user library to fetch and reply fuse request. As long as above 3 interfaces are implemented, userspace filesystem based on /dev/fuse could be easily deployed on the DPU side.

I must admit this patch is not  mature enough, currently I just send it out to see whether I'm in the right direction, and whether fuse_custom_io's new interfaces are well designed, or whether modifications to core libfuse codes are acceptable, etc.

Thanks.