### PR TITLE
Add support for kernel flag FUSE_HAS_EXPIRE_ONLY

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2021,7 +2021,7 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		}
 		if (inargflags & FUSE_DIRECT_IO_ALLOW_MMAP)
 			se->conn.capable |= FUSE_CAP_DIRECT_IO_ALLOW_MMAP;
-		if (arg->minor >= 38)
+		if (arg->minor >= 38 || (inargflags & FUSE_HAS_EXPIRE_ONLY))
 			se->conn.capable |= FUSE_CAP_EXPIRE_ONLY;
 	} else {
 		se->conn.max_readahead = 0;

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -23,7 +23,7 @@ from tempfile import NamedTemporaryFile
 from contextlib import contextmanager
 from util import (wait_for_mount, umount, cleanup, base_cmdline,
                   safe_sleep, basename, fuse_test_marker, test_printcap,
-                  fuse_proto, powerset)
+                  fuse_proto, fuse_caps, powerset)
 from os.path import join as pjoin
 
 pytestmark = fuse_test_marker()
@@ -349,7 +349,7 @@ def test_notify_inval_entry(tmpdir, only_expire, notify, output_checker):
         cmdline.append('--no-notify')
     if only_expire == "expire_entries":
         cmdline.append('--only-expire')
-        if fuse_proto < (7,38):
+        if "FUSE_CAP_EXPIRE_ONLY" not in fuse_caps:
             pytest.skip('only-expire not supported by running kernel')
     mount_process = subprocess.Popen(cmdline, stdout=output_checker.fd,
                                      stderr=output_checker.fd)


### PR DESCRIPTION
Adding the check for flag `FUSE_HAS_EXPIRE_ONLY` introduced in commit: https://github.com/torvalds/linux/commit/5cadfbd5a11e5495cac217534c5f788168b1afd7

This allows to use the feature with kernels that have backported the feature.