### PR TITLE
Don't set FUSE_CAP_PARALLEL_DIROPS by default

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -336,8 +336,6 @@ struct fuse_loop_config_v1 {
  * is unset, the FUSE kernel module will ensure that lookup() and
  * readdir() requests are never issued concurrently for the same
  * directory.
- *
- * This feature is enabled by default when supported by the kernel.
  */
 #define FUSE_CAP_PARALLEL_DIROPS        (1 << 18)
 

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2053,7 +2053,6 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 	if ((cond) && (se->conn.capable & (cap))) \
 		se->conn.want |= (cap)
 	LL_SET_DEFAULT(1, FUSE_CAP_ASYNC_READ);
-	LL_SET_DEFAULT(1, FUSE_CAP_PARALLEL_DIROPS);
 	LL_SET_DEFAULT(1, FUSE_CAP_AUTO_INVAL_DATA);
 	LL_SET_DEFAULT(1, FUSE_CAP_HANDLE_KILLPRIV);
 	LL_SET_DEFAULT(1, FUSE_CAP_ASYNC_DIO);


### PR DESCRIPTION
Allowing parallel dir operations could result in a crash in a filesystem
implementation that is not prepared for this.

To be safe keep this flag off by default (this is not a regression, since
there was no public release where this flag wasn't ignored).

If the filesystem wants better perforance, then it should set this flag
explicitly.

Fixes: c9905341ea34 ("Pass FUSE_PARALLEL_DIROPS to kernel (#861)")
Signed-off-by: Miklos Szeredi <mszeredi@redhat.com>
