### PR TITLE
Add processing for FUSE_CAP_HANDLE_KILLPRIV and disable it by default

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -363,7 +363,7 @@ struct fuse_loop_config_v1 {
  * setuid and setgid bits when a file is written, truncated, or
  * its owner is changed.
  *
- * This feature is enabled by default when supported by the kernel.
+ * This feature is disabled by default.
  */
 #define FUSE_CAP_HANDLE_KILLPRIV         (1 << 20)
 

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2054,7 +2054,6 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		se->conn.want |= (cap)
 	LL_SET_DEFAULT(1, FUSE_CAP_ASYNC_READ);
 	LL_SET_DEFAULT(1, FUSE_CAP_AUTO_INVAL_DATA);
-	LL_SET_DEFAULT(1, FUSE_CAP_HANDLE_KILLPRIV);
 	LL_SET_DEFAULT(1, FUSE_CAP_ASYNC_DIO);
 	LL_SET_DEFAULT(1, FUSE_CAP_IOCTL_DIR);
 	LL_SET_DEFAULT(1, FUSE_CAP_ATOMIC_O_TRUNC);
@@ -2146,6 +2145,8 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		outargflags |= FUSE_PARALLEL_DIROPS;
 	if (se->conn.want & FUSE_CAP_POSIX_ACL)
 		outargflags |= FUSE_POSIX_ACL;
+	if (se->conn.want & FUSE_CAP_HANDLE_KILLPRIV)
+		outargflags |= FUSE_HANDLE_KILLPRIV;
 	if (se->conn.want & FUSE_CAP_CACHE_SYMLINKS)
 		outargflags |= FUSE_CACHE_SYMLINKS;
 	if (se->conn.want & FUSE_CAP_EXPLICIT_INVAL_DATA)


### PR DESCRIPTION
https://github.com/libfuse/libfuse/issues/884

1.add processing for flag FUSE_CAP_HANDLE_KILLPRIV when init.
2.disable FUSE_CAP_HANDLE_KILLPRIV by default