### PR TITLE
passthrough examples: enable direct io when open has flag: O_DIRECT

### DIFF
--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -59,6 +59,13 @@ static void *xmp_init(struct fuse_conn_info *conn,
 	(void) conn;
 	cfg->use_ino = 1;
 
+	/* parallel_direct_writes feature depends on direct_io features.
+	   To make parallel_direct_writes valid, need either set cfg->direct_io
+	   in current function (recommended in high level API) or set fi->direct_io
+	   in xmp_create() or xmp_open(). */
+	// cfg->direct_io = 1;
+	   cfg->parallel_direct_writes = 1;
+
 	/* Pick up changes from lower filesystem right away. This is
 	   also necessary for better hardlink support. When the kernel
 	   calls the unlink() handler, it does not know the inode of
@@ -285,7 +292,6 @@ static int xmp_create(const char *path, mode_t mode,
 		return -errno;
 
 	fi->fh = res;
-	fi->parallel_direct_writes = 1;
 	return 0;
 }
 
@@ -298,7 +304,6 @@ static int xmp_open(const char *path, struct fuse_file_info *fi)
 		return -errno;
 
 	fi->fh = res;
-	fi->parallel_direct_writes = 1;
 	return 0;
 }
 

--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -303,6 +303,14 @@ static int xmp_open(const char *path, struct fuse_file_info *fi)
 	if (res == -1)
 		return -errno;
 
+        /* Enable direct_io when open has flags O_DIRECT to enjoy the feature
+        parallel_direct_writes (i.e., to get a shared lock, not exclusive lock,
+        for writes to the same file). */
+	if (fi->flags & O_DIRECT) {
+		fi->direct_io = 1;
+		fi->parallel_direct_writes = 1;
+	}
+
 	fi->fh = res;
 	return 0;
 }

--- a/example/passthrough_fh.c
+++ b/example/passthrough_fh.c
@@ -54,6 +54,13 @@ static void *xmp_init(struct fuse_conn_info *conn,
 	cfg->use_ino = 1;
 	cfg->nullpath_ok = 1;
 
+	/* parallel_direct_writes feature depends on direct_io features.
+	   To make parallel_direct_writes valid, need either set cfg->direct_io
+	   in current function (recommended in high level API) or set fi->direct_io
+	   in xmp_create() or xmp_open(). */
+	// cfg->direct_io = 1;
+	cfg->parallel_direct_writes = 1;
+
 	/* Pick up changes from lower filesystem right away. This is
 	   also necessary for better hardlink support. When the kernel
 	   calls the unlink() handler, it does not know the inode of
@@ -366,7 +373,6 @@ static int xmp_create(const char *path, mode_t mode, struct fuse_file_info *fi)
 		return -errno;
 
 	fi->fh = fd;
-	fi->parallel_direct_writes = 1;
 	return 0;
 }
 
@@ -379,7 +385,6 @@ static int xmp_open(const char *path, struct fuse_file_info *fi)
 		return -errno;
 
 	fi->fh = fd;
-	fi->parallel_direct_writes = 1;
 	return 0;
 }
 

--- a/example/passthrough_fh.c
+++ b/example/passthrough_fh.c
@@ -384,6 +384,14 @@ static int xmp_open(const char *path, struct fuse_file_info *fi)
 	if (fd == -1)
 		return -errno;
 
+        /* Enable direct_io when open has flags O_DIRECT to enjoy the feature
+           parallel_direct_writes (i.e., to get a shared lock, not exclusive lock,
+           for writes to the same file). */
+        if (fi->flags & O_DIRECT) {
+		fi->direct_io = 1;
+		fi->parallel_direct_writes = 1;
+	}
+
 	fi->fh = fd;
 	return 0;
 }

--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -840,6 +840,9 @@ static void sfs_create(fuse_req_t req, fuse_ino_t parent, const char *name,
     if (fs.direct_io)
 	    fi->direct_io = 1;
 
+    /* parallel_direct_writes feature depends on direct_io features.
+       To make parallel_direct_writes valid, need set fi->direct_io
+       in current function. */
     fi->parallel_direct_writes = 1;
 
     Inode& inode = get_inode(e.ino);
@@ -902,6 +905,9 @@ static void sfs_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi) {
     if (fs.direct_io)
 	    fi->direct_io = 1;
 
+    /* parallel_direct_writes feature depends on direct_io features.
+       To make parallel_direct_writes valid, need set fi->direct_io
+       in current function. */
     fi->parallel_direct_writes = 1;
 
     fi->fh = fd;

--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -905,6 +905,12 @@ static void sfs_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi) {
     if (fs.direct_io)
 	    fi->direct_io = 1;
 
+    /* Enable direct_io when open has flags O_DIRECT to enjoy the feature
+       parallel_direct_writes (i.e., to get a shared lock, not exclusive lock,
+       for writes to the same file). */
+    if (fi->flags & O_DIRECT)
+	    fi->direct_io = 1;
+
     /* parallel_direct_writes feature depends on direct_io features.
        To make parallel_direct_writes valid, need set fi->direct_io
        in current function. */

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -775,6 +775,9 @@ static void lo_create(fuse_req_t req, fuse_ino_t parent, const char *name,
 	else if (lo->cache == CACHE_ALWAYS)
 		fi->keep_cache = 1;
 
+	/* parallel_direct_writes feature depends on direct_io features.
+	   To make parallel_direct_writes valid, need set fi->direct_io
+	   in current function. */
 	fi->parallel_direct_writes = 1;
 
 	err = lo_do_lookup(req, parent, name, &e);
@@ -834,6 +837,9 @@ static void lo_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	else if (lo->cache == CACHE_ALWAYS)
 		fi->keep_cache = 1;
 
+	/* parallel_direct_writes feature depends on direct_io features.
+	   To make parallel_direct_writes valid, need set fi->direct_io
+	   in current function. */
 	fi->parallel_direct_writes = 1;
 
 	fuse_reply_open(req, fi);

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -837,6 +837,12 @@ static void lo_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 	else if (lo->cache == CACHE_ALWAYS)
 		fi->keep_cache = 1;
 
+        /* Enable direct_io when open has flags O_DIRECT to enjoy the feature
+        parallel_direct_writes (i.e., to get a shared lock, not exclusive lock,
+	for writes to the same file in the kernel). */
+	if (fi->flags & O_DIRECT)
+		fi->direct_io = 1;
+
 	/* parallel_direct_writes feature depends on direct_io features.
 	   To make parallel_direct_writes valid, need set fi->direct_io
 	   in current function. */


### PR DESCRIPTION
I use the passthrough  example (i.e., passthrough_hp) as the fuse daemon. In the application, when I open a file with flag O_DIRECT and read some data from the file, it doesn't go through into the `fuse_direct_read_iter `in the fuse kernel. The reason is that the fuse daemon dosen't check the O_DIRECT flag and enable it. 
So enable it when flag O_DIRECT is set.