### PR TITLE
remove duplicated fuse_chan_put() 

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1740,8 +1740,6 @@ static int find_interrupted(struct fuse_session *se, struct fuse_req *req)
 			pthread_mutex_lock(&se->lock);
 			curr->ctr--;
 			if (!curr->ctr) {
-				fuse_chan_put(req->ch);
-				req->ch = NULL;
 				destroy_req(curr);
 			}
 


### PR DESCRIPTION
remove duplicated fuse_chan_put() in do_interrupt().
In the pull request [#649 ](https://github.com/libfuse/libfuse/pull/649), it invokes fuse_chan_put(req->ch) twice if curr->ctr is zero, one is in the find_interrupted()(line 1717), another is in the do_interrupt()(line 1747). The fuse_chan_put() in the find_interrupted() is not needed.