### PR TITLE
Passthrough "x-*" options to mtab

### DIFF
--- a/lib/mount.c
+++ b/lib/mount.c
@@ -209,6 +209,12 @@ static int fuse_mount_opt_proc(void *data, const char *arg, int key,
 
 	case KEY_MTAB_OPT:
 		return fuse_opt_add_opt(&mo->mtab_opts, arg);
+
+	/* Third party options like 'x-gvfs-notrash' */
+	case FUSE_OPT_KEY_OPT:
+		return (strncmp("x-", arg, 2) == 0) ?
+			fuse_opt_add_opt(&mo->mtab_opts, arg) :
+			1;
 	}
 
 	/* Pass through unknown options */

--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -54,7 +54,6 @@ static int mtab_needs_update(const char *mnt)
 	 * Skip mtab update if /etc/mtab:
 	 *
 	 *  - doesn't exist,
-	 *  - is a symlink,
 	 *  - is on a read-only filesystem.
 	 */
 	res = lstat(_PATH_MOUNTED, &stbuf);
@@ -64,9 +63,6 @@ static int mtab_needs_update(const char *mnt)
 	} else {
 		uid_t ruid;
 		int err;
-
-		if (S_ISLNK(stbuf.st_mode))
-			return 0;
 
 		ruid = getuid();
 		if (ruid != 0)


### PR DESCRIPTION
This implements #651, tested with bindfs.

There are 3 main changes to get this to work:

- Unknown options will be added to `mtab_opts` if they start with "x-"
- Options starting with "x-" are not provided to `do_mount()`
- Options starting with "x-" are added back for the call to `add_mount()`

On my system, `/etc/mtab` is a symlink to `/proc/self/mounts`. This causes fuse to skip updating the mtab entry because of the symlink check. I removed the check in this patch, but there is likely a reason it was there in the first place, maybe the check could be narrowed to links that are pointing to `/proc/self/mounts`?

Also, another set of eyes to make sure my string manipulation logic is correct would be appreciated.