### PR TITLE
ci-build.sh: Fix checking for function arguments

### DIFF
--- a/test/ci-build.sh
+++ b/test/ci-build.sh
@@ -89,7 +89,7 @@ sanitized_build()
     meson configure -D b_lundef=false
 
     # additional options
-    if [ -n "$@" ]; then
+    if [[ $# -gt 0 ]]; then
         meson configure "$@"
     fi
 


### PR DESCRIPTION
Checking for an emtpy string actually doesn't work for $@, so just check for number of arguments.