### PR TITLE
reset got_init after handling FUSE_DESTROY message

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2204,6 +2204,7 @@ static void do_destroy(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 	(void) inarg;
 
 	se->got_destroy = 1;
+	se->got_init = 0;
 	if (se->op.destroy)
 		se->op.destroy(se->userdata);
 


### PR DESCRIPTION
User may still need to mount same fuse filesystem after umounting it(In this case, the userspace filesystem server needs to keep live), and after handling FUSE_DESTROY message, new FUSE_INIT message may come, so need to reset got_init to be zero.
This change is necessary when exporting existing fuse filesystems as virtiofs devices, users may mount or umount as they wish.