### PR TITLE
Fix FUSE_CAP_DIRECT_IO_ALLOW_MMAP - use new numerical value

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -445,7 +445,7 @@ struct fuse_loop_config_v1 {
  * ensure coherency between mount points (or network clients) and with kernel page
  * cache as enforced by mmap that cannot be guaranteed anymore.
  */
-#define FUSE_CAP_DIRECT_IO_ALLOW_MMAP  (1 << 27)
+#define FUSE_CAP_DIRECT_IO_ALLOW_MMAP  (1 << 28)
 
 /**
  * Ioctl flags


### PR DESCRIPTION
Commit 22741f5582ea003c3518aff76e8df6561403f88b accidentally re-used (1 << 27), which is already taken for
FUSE_CAP_SETXATTR_EXT.

Fortunately not part of any release yet.