### PR TITLE
Add FUSE_CAP_HANDLE_KILLPRIV_V2 handling

### DIFF
--- a/example/printcap.c
+++ b/example/printcap.c
@@ -81,6 +81,14 @@ static void pc_init(void *userdata,
 			printf("\tFUSE_CAP_EXPLICIT_INVAL_DATA\n");
 	if(conn->capable & FUSE_CAP_EXPIRE_ONLY)
 			printf("\tFUSE_CAP_EXPIRE_ONLY\n");
+	if(conn->capable & FUSE_CAP_SETXATTR_EXT)
+			printf("\tFUSE_CAP_SETXATTR_EXT\n");
+	if(conn->capable & FUSE_CAP_HANDLE_KILLPRIV)
+			printf("\tFUSE_CAP_HANDLE_KILLPRIV\n");
+	if(conn->capable & FUSE_CAP_HANDLE_KILLPRIV_V2)
+			printf("\tFUSE_CAP_HANDLE_KILLPRIV_V2\n");
+	if(conn->capable & FUSE_CAP_DIRECT_IO_ALLOW_MMAP)
+			printf("\tFUSE_CAP_DIRECT_IO_ALLOW_MMAP\n");
 	fuse_session_exit(se);
 }
 

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -368,6 +368,23 @@ struct fuse_loop_config_v1 {
 #define FUSE_CAP_HANDLE_KILLPRIV         (1 << 20)
 
 /**
+ * Indicates that the filesystem is responsible for unsetting
+ * setuid and setgid bit and additionally cap (stored as xattr) when a
+ * file is written, truncated, or its owner is changed.
+ * Upon write/truncate suid/sgid is only killed if caller
+ * does not have CAP_FSETID. Additionally upon
+ * write/truncate sgid is killed only if file has group
+ * execute permission. (Same as Linux VFS behavior).
+ * KILLPRIV_V2 requires handling of
+ *   - FUSE_OPEN_KILL_SUIDGID (set in struct fuse_create_in::open_flags)
+ *   - FATTR_KILL_SUIDGID (set in struct fuse_setattr_in::valid)
+ *   - FUSE_WRITE_KILL_SUIDGID (set in struct fuse_write_in::write_flags)
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_HANDLE_KILLPRIV_V2         (1 << 21)
+
+/**
  * Indicates that the kernel supports caching symlinks in its page cache.
  *
  * When this feature is enabled, symlink targets are saved in the page cache.

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2001,6 +2001,8 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 			se->conn.capable |= FUSE_CAP_POSIX_ACL;
 		if (inargflags & FUSE_HANDLE_KILLPRIV)
 			se->conn.capable |= FUSE_CAP_HANDLE_KILLPRIV;
+		if (inargflags & FUSE_HANDLE_KILLPRIV_V2)
+			se->conn.capable |= FUSE_CAP_HANDLE_KILLPRIV_V2;
 		if (inargflags & FUSE_CACHE_SYMLINKS)
 			se->conn.capable |= FUSE_CAP_CACHE_SYMLINKS;
 		if (inargflags & FUSE_NO_OPENDIR_SUPPORT)
@@ -2145,6 +2147,8 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		outargflags |= FUSE_POSIX_ACL;
 	if (se->conn.want & FUSE_CAP_HANDLE_KILLPRIV)
 		outargflags |= FUSE_HANDLE_KILLPRIV;
+	if (se->conn.want & FUSE_CAP_HANDLE_KILLPRIV_V2)
+		outargflags |= FUSE_HANDLE_KILLPRIV_V2;
 	if (se->conn.want & FUSE_CAP_CACHE_SYMLINKS)
 		outargflags |= FUSE_CACHE_SYMLINKS;
 	if (se->conn.want & FUSE_CAP_EXPLICIT_INVAL_DATA)


### PR DESCRIPTION
Passthrough file systems actually do not need special privilege handling as the underlying file system is responsible for that. FUSE_HANDLE_KILLPRIV / KILLPRIV_v2 may reduce getattr calls on setattr() and KILLPRIV_V2 additionally sets the fuse superblock flag "SB_NOSEC", which helps to reduce GETXATTR calls on write as KILLPRIV_V2 moves responsibility of capability removal on write to server (userspace) side.

Non-passthrough file systems need to carefully handle KILLRPIV_V2 requirements, as documented as part of the
FUSE_CAP_HANDLE_KILLPRIV_V2 definition, to avoid security issues.

Example with `passthrough_hp --debug-fuse --direct-io`:

dd if=/dev/zero of=/scratch/dest/testfile bs=1M count=5

Unpatched
=========
unique: 42, opcode: OPEN (14), nodeid: 106377750012376, insize: 48, pid: 117185
   unique: 42, success, outsize: 32
unique: 44, opcode: GETXATTR (22), nodeid: 106377750012376, insize: 68, pid: 117185
   unique: 44, error: -95 (Operation not supported), outsize: 16
unique: 46, opcode: SETATTR (4), nodeid: 106377750012376, insize: 128, pid: 117185
   unique: 46, success, outsize: 120
unique: 48, opcode: FLUSH (25), nodeid: 106377750012376, insize: 64, pid: 117185
   unique: 48, success, outsize: 16
unique: 50, opcode: GETXATTR (22), nodeid: 106377750012376, insize: 68, pid: 117185
   unique: 50, error: -95 (Operation not supported), outsize: 16
unique: 52, opcode: WRITE (16), nodeid: 106377750012376, insize: 1048656, pid: 117185
   unique: 52, success, outsize: 24
unique: 54, opcode: GETXATTR (22), nodeid: 106377750012376, insize: 68, pid: 117185
   unique: 54, error: -95 (Operation not supported), outsize: 16
unique: 56, opcode: WRITE (16), nodeid: 106377750012376, insize: 1048656, pid: 117185
   unique: 56, success, outsize: 24
unique: 58, opcode: GETXATTR (22), nodeid: 106377750012376, insize: 68, pid: 117185
   unique: 58, error: -95 (Operation not supported), outsize: 16
unique: 60, opcode: WRITE (16), nodeid: 106377750012376, insize: 1048656, pid: 117185
   unique: 60, success, outsize: 24
unique: 62, opcode: GETXATTR (22), nodeid: 106377750012376, insize: 68, pid: 117185
   unique: 62, error: -95 (Operation not supported), outsize: 16
unique: 64, opcode: WRITE (16), nodeid: 106377750012376, insize: 1048656, pid: 117185
   unique: 64, success, outsize: 24
unique: 66, opcode: GETXATTR (22), nodeid: 106377750012376, insize: 68, pid: 117185
   unique: 66, error: -95 (Operation not supported), outsize: 16
unique: 68, opcode: WRITE (16), nodeid: 106377750012376, insize: 1048656, pid: 117185
   unique: 68, success, outsize: 24
unique: 70, opcode: SETATTR (4), nodeid: 106377750012376, insize: 128, pid: 117185
   unique: 70, success, outsize: 120
unique: 72, opcode: FLUSH (25), nodeid: 106377750012376, insize: 64, pid: 117185
   unique: 72, success, outsize: 16
unique: 74, opcode: RELEASE (18), nodeid: 106377750012376, insize: 64, pid: 0
   unique: 74, success, outsize: 16

Patched
=======
unique: 98, opcode: OPEN (14), nodeid: 106377750012376, insize: 48, pid: 117128
   unique: 98, success, outsize: 32
unique: 100, opcode: SETATTR (4), nodeid: 106377750012376, insize: 128, pid: 117128
   unique: 100, success, outsize: 120
unique: 102, opcode: FLUSH (25), nodeid: 106377750012376, insize: 64, pid: 117128
   unique: 102, success, outsize: 16
unique: 104, opcode: WRITE (16), nodeid: 106377750012376, insize: 1048656, pid: 117128
   unique: 104, success, outsize: 24
unique: 106, opcode: WRITE (16), nodeid: 106377750012376, insize: 1048656, pid: 117128
   unique: 106, success, outsize: 24
unique: 108, opcode: WRITE (16), nodeid: 106377750012376, insize: 1048656, pid: 117128
   unique: 108, success, outsize: 24
unique: 110, opcode: WRITE (16), nodeid: 106377750012376, insize: 1048656, pid: 117128
   unique: 110, success, outsize: 24
unique: 112, opcode: WRITE (16), nodeid: 106377750012376, insize: 1048656, pid: 117128
   unique: 112, success, outsize: 24
unique: 114, opcode: SETATTR (4), nodeid: 106377750012376, insize: 128, pid: 117128
   unique: 114, success, outsize: 120
unique: 116, opcode: FLUSH (25), nodeid: 106377750012376, insize: 64, pid: 117128
   unique: 116, success, outsize: 16
unique: 118, opcode: RELEASE (18), nodeid: 106377750012376, insize: 64, pid: 0
   unique: 118, success, outsize: 16