### PR TITLE
Add more documentation for FUSE_CAP_EXPORT_SUPPORT

### DIFF
--- a/doc/README.NFS
+++ b/doc/README.NFS
@@ -21,12 +21,16 @@ be requested on any inode, including non-directories, while the latter
 is only requested for directories.  Otherwise these special lookups
 should behave identically to ordinary lookups.
 
-Note: Setting FUSE_CAP_EXPORT_SUPPORT requires the file system
-to handle node-ids (fuse_ino_t) the file system does not know
-about - i.e. a fuse FORGET request might have been received 
-or the node-id was used in a previous instance of the file system daemon.
-The node-id might not be valid at all when an invalid handle is passed
-to open_by_handle_at(). 
+Furthermore, setting FUSE_CAP_EXPORT_SUPPORT requires the file system
+to handle node-ids (fuse_ino_t) that the file system may does not know
+about - e.g. a fuse FORGET request might have been received or the node-id
+was used in a previous instance of the file system daemon. The node-id might
+not be valid at all when an invalid handle is passed to open_by_handle_at(). 
+This implies that the filesystem *must not* reuse node-ids even if
+generation numbers are set correctly. This is because generation numbers
+are not provided by the kernel to e.g. the getattr() handler, so the
+handler would be unable to tell if the provided node-id refers to the
+"known" current one, or a previous one that has been forgotten and re-used.
 
 2) high-level interface
 

--- a/doc/README.NFS
+++ b/doc/README.NFS
@@ -21,6 +21,13 @@ be requested on any inode, including non-directories, while the latter
 is only requested for directories.  Otherwise these special lookups
 should behave identically to ordinary lookups.
 
+Note: Setting FUSE_CAP_EXPORT_SUPPORT requires the file system
+to handle node-ids (fuse_ino_t) the file system does not know
+about - i.e. a fuse FORGET request might have been received 
+or the node-id was used in a previous instance of the file system daemon.
+The node-id might not be valid at all when an invalid handle is passed
+to open_by_handle_at(). 
+
 2) high-level interface
 
 Because the high-level interface is path based, it is not possible to

--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -190,9 +190,6 @@ static int get_fs_fd(fuse_ino_t ino) {
 
 static void sfs_init(void *userdata, fuse_conn_info *conn) {
     (void)userdata;
-    if (conn->capable & FUSE_CAP_EXPORT_SUPPORT)
-        conn->want |= FUSE_CAP_EXPORT_SUPPORT;
-
     if (fs.timeout && conn->capable & FUSE_CAP_WRITEBACK_CACHE)
         conn->want |= FUSE_CAP_WRITEBACK_CACHE;
 

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -170,9 +170,6 @@ static void lo_init(void *userdata,
 {
 	struct lo_data *lo = (struct lo_data*) userdata;
 
-	if(conn->capable & FUSE_CAP_EXPORT_SUPPORT)
-		conn->want |= FUSE_CAP_EXPORT_SUPPORT;
-
 	if (lo->writeback &&
 	    conn->capable & FUSE_CAP_WRITEBACK_CACHE) {
 		if (lo->debug)

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -185,7 +185,8 @@ struct fuse_loop_config_v1 {
  *
  * When this flag is set, the filesystem must be prepared to receive requests
  * for invalid inodes (i.e., for which a FORGET request was received or
- * which have been used in a previous instance of the filesystem daemon).
+ * which have been used in a previous instance of the filesystem daemon) and
+ * must not re-use node-ids (even when setting generation numbers).
  *
  * This feature is disabled by default.
  */

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -186,7 +186,7 @@ struct fuse_loop_config_v1 {
  * When this flag is set, the filesystem must be prepared to receive requests
  * for invalid inodes (i.e., for which a FORGET request was received or
  * which have been used in a previous instance of the filesystem daemon) and
- * must not re-use node-ids (even when setting generation numbers).
+ * must not reuse node-ids (even when setting generation numbers).
  *
  * This feature is disabled by default.
  */

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -183,6 +183,10 @@ struct fuse_loop_config_v1 {
 /**
  * Indicates that the filesystem supports lookups of "." and "..".
  *
+ * When this flag is set, the filesystem must be prepared to receive requests
+ * for invalid inodes (i.e., for which a FORGET request was received or
+ * which have been used in a previous instance of the filesystem daemon).
+ *
  * This feature is disabled by default.
  */
 #define FUSE_CAP_EXPORT_SUPPORT		(1 << 4)


### PR DESCRIPTION
Also remove the flag from passthrough_ll.c and passthrough_hp.cc as these implementations do _not_ handle that flag. They just cast fuse_ino_t to an inode and cause a heap buffer overflow for unknown objects (simplest reproducer are the examples in "man 2 open_by_handle_at", but to unmount/mount the file system after name_to_handle_at and before open_by_handle_at).

Fixes https://github.com/libfuse/libfuse/issues/838