### PR TITLE
Implement access in passthrough_ll example

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -1154,6 +1154,17 @@ static void lo_lseek(fuse_req_t req, fuse_ino_t ino, off_t off, int whence,
 		fuse_reply_err(req, errno);
 }
 
+static void lo_access(fuse_req_t req, fuse_ino_t ino, int mask) {
+	int res;
+
+	if (lo_debug(req))
+		fuse_log(FUSE_LOG_DEBUG, "lo_access(ino=%" PRIu64 ", mask=0x%x)\n", ino, mask);
+
+	res = faccessat(lo_fd(req, ino), ".", mask, 0);
+
+	fuse_reply_err(req, res == -1 ? errno : 0);
+}
+
 static const struct fuse_lowlevel_ops lo_oper = {
 	.init		= lo_init,
 	.destroy	= lo_destroy,
@@ -1193,6 +1204,7 @@ static const struct fuse_lowlevel_ops lo_oper = {
 	.copy_file_range = lo_copy_file_range,
 #endif
 	.lseek		= lo_lseek,
+	.access = lo_access,
 };
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Locally made sure that the access request is received and handled by
simply creating a FUSE mount within a FUSE mount:
```
* Terminal 1
$ gcc -Wall passthrough_ll.c `pkg-config fuse3 --cflags --libs` -o passthrough_ll
$ ./passthrough_ll -d -o allow_other -o source=SOURCE_DIR1 MOUNT_POINT

* Terminal 2
$ ./passthrough_ll -d -o allow_other -o source=SOURCE_DIR2 MOUNT_POINT/../inner_mount

* Terminal 1 (output)
unique: 330, opcode: ACCESS (34), nodeid: 140104920207584, insize: 48, pid: 864202
lo_access(ino=140104920207584, mask=0x1)
   unique: 330, success, outsize: 16
unique: 332, opcode: ACCESS (34), nodeid: 140104920207584, insize: 48, pid: 864202
lo_access(ino=140104920207584, mask=0x2)
   unique: 332, success, outsize: 16
```