### PR TITLE
Make fuse_custom_io support multi-threaded event loop

### DIFF
--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -136,6 +136,7 @@ struct fuse_custom_io {
 	ssize_t (*splice_send)(int fdin, off_t *offin, int fdout,
 				     off_t *offout, size_t len,
 			           unsigned int flags, void *userdata);
+	int (*clone_fd)(int master_fd);
 };
 
 /**


### PR DESCRIPTION
Define a new clone_fd() helper for fuse_custom_io, users can implement their own clone fd logic.