### PR TITLE
passthrough_ll: fix fd leaks in lo_destroy()

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -190,6 +190,7 @@ static void lo_destroy(void *userdata)
 	while (lo->root.next != &lo->root) {
 		struct lo_inode* next = lo->root.next;
 		lo->root.next = next->next;
+		close(next->fd);
 		free(next);
 	}
 }


### PR DESCRIPTION
By virtio-fs and libfuse fuse_custom_io, passthrough_ll could be a virtio filesystem device backend, this bug was found when doing mount, fsstress and umount repeatedly.