### PR TITLE
example/: Convert all fuse_session_loop_mt users to 3.12 API

### DIFF
--- a/example/hello_ll.c
+++ b/example/hello_ll.c
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
 	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
 	struct fuse_session *se;
 	struct fuse_cmdline_opts opts;
-	struct fuse_loop_config config;
+	struct fuse_loop_config *config;
 	int ret = -1;
 
 	if (fuse_parse_cmdline(&args, &opts) != 0)
@@ -259,9 +259,12 @@ int main(int argc, char *argv[])
 	if (opts.singlethread)
 		ret = fuse_session_loop(se);
 	else {
-		config.clone_fd = opts.clone_fd;
-		config.max_idle_threads = opts.max_idle_threads;
-		ret = fuse_session_loop_mt(se, &config);
+		config = fuse_loop_cfg_create();
+		fuse_loop_cfg_set_clone_fd(config, opts.clone_fd);
+		fuse_loop_cfg_set_max_threads(config, opts.max_threads);
+		ret = fuse_session_loop_mt(se, config);
+		fuse_loop_cfg_destroy(config);
+		config = NULL;
 	}
 
 	fuse_session_unmount(se);

--- a/example/notify_inval_entry.c
+++ b/example/notify_inval_entry.c
@@ -307,7 +307,7 @@ int main(int argc, char *argv[]) {
     struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
     struct fuse_session *se;
     struct fuse_cmdline_opts opts;
-    struct fuse_loop_config config;
+    struct fuse_loop_config *config;
     pthread_t updater;
     int ret = -1;
 
@@ -362,9 +362,12 @@ int main(int argc, char *argv[]) {
     if (opts.singlethread) {
         ret = fuse_session_loop(se);
     } else {
-        config.clone_fd = opts.clone_fd;
-        config.max_idle_threads = opts.max_idle_threads;
-        ret = fuse_session_loop_mt(se, &config);
+		config = fuse_loop_cfg_create();
+		fuse_loop_cfg_set_clone_fd(config, opts.clone_fd);
+		fuse_loop_cfg_set_max_threads(config, opts.max_threads);
+		ret = fuse_session_loop_mt(se, config);
+		fuse_loop_cfg_destroy(config);
+		config = NULL;
     }
 
     fuse_session_unmount(se);

--- a/example/notify_inval_inode.c
+++ b/example/notify_inval_inode.c
@@ -311,7 +311,7 @@ int main(int argc, char *argv[]) {
     struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
     struct fuse_session *se;
     struct fuse_cmdline_opts opts;
-    struct fuse_loop_config config;
+    struct fuse_loop_config *config;
     pthread_t updater;
     int ret = -1;
 
@@ -364,9 +364,12 @@ int main(int argc, char *argv[]) {
     if (opts.singlethread)
         ret = fuse_session_loop(se);
     else {
-        config.clone_fd = opts.clone_fd;
-        config.max_idle_threads = opts.max_idle_threads;
-        ret = fuse_session_loop_mt(se, &config);
+	config = fuse_loop_cfg_create();
+	fuse_loop_cfg_set_clone_fd(config, opts.clone_fd);
+	fuse_loop_cfg_set_max_threads(config, opts.max_threads);
+	ret = fuse_session_loop_mt(se, config);
+	fuse_loop_cfg_destroy(config);
+	config = NULL;
     }
 
     fuse_session_unmount(se);

--- a/example/notify_store_retrieve.c
+++ b/example/notify_store_retrieve.c
@@ -387,7 +387,7 @@ int main(int argc, char *argv[]) {
     struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
     struct fuse_session *se;
     struct fuse_cmdline_opts opts;
-    struct fuse_loop_config config;
+    struct fuse_loop_config *config;
     int ret = -1;
 
     if (fuse_opt_parse(&args, &options, option_spec, NULL) == -1)
@@ -436,9 +436,12 @@ int main(int argc, char *argv[]) {
     if (opts.singlethread)
         ret = fuse_session_loop(se);
     else {
-        config.clone_fd = opts.clone_fd;
-        config.max_idle_threads = opts.max_idle_threads;
-        ret = fuse_session_loop_mt(se, &config);
+	config = fuse_loop_cfg_create();
+	fuse_loop_cfg_set_clone_fd(config, opts.clone_fd);
+	fuse_loop_cfg_set_max_threads(config, opts.max_threads);
+	ret = fuse_session_loop_mt(se, config);
+	fuse_loop_cfg_destroy(config);
+	config = NULL;
     }
 
     assert(retrieve_status != 1);

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -35,7 +35,7 @@
  */
 
 #define _GNU_SOURCE
-#define FUSE_USE_VERSION 34
+#define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 12)
 
 #include <fuse_lowlevel.h>
 #include <unistd.h>
@@ -1198,7 +1198,7 @@ int main(int argc, char *argv[])
 	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
 	struct fuse_session *se;
 	struct fuse_cmdline_opts opts;
-	struct fuse_loop_config config;
+	struct fuse_loop_config *config;
 	struct lo_data lo = { .debug = 0,
 	                      .writeback = 0 };
 	int ret = -1;
@@ -1304,9 +1304,12 @@ int main(int argc, char *argv[])
 	if (opts.singlethread)
 		ret = fuse_session_loop(se);
 	else {
-		config.clone_fd = opts.clone_fd;
-		config.max_idle_threads = opts.max_idle_threads;
-		ret = fuse_session_loop_mt(se, &config);
+		config = fuse_loop_cfg_create();
+		fuse_loop_cfg_set_clone_fd(config, opts.clone_fd);
+		fuse_loop_cfg_set_max_threads(config, opts.max_threads);
+		ret = fuse_session_loop_mt(se, config);
+		fuse_loop_cfg_destroy(config);
+		config = NULL;
 	}
 
 	fuse_session_unmount(se);


### PR DESCRIPTION
Convert all the remaining users of fuse_session_loop_mt() to the new 3.12 config api.