### PR TITLE
 Use single place to define the version and increase version to 3.17.0

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -25,12 +25,6 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-/** Major version of FUSE library interface */
-#define FUSE_MAJOR_VERSION 3
-
-/** Minor version of FUSE library interface */
-#define FUSE_MINOR_VERSION 16
-
 #define FUSE_MAKE_VERSION(maj, min)  ((maj) * 100 + (min))
 #define FUSE_VERSION FUSE_MAKE_VERSION(FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION)
 

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,14 @@ project('libfuse3', ['c'], version: '3.16.2',
             'warning_level=2',
         ])
 
+# Would be better to create the version string
+# from integers, i.e. concatenating strings instead
+# of splitting a string, but 'project' needs to be
+# the first meson.build keyword...
+version_list = meson.project_version().split('.')
+FUSE_MAJOR_VERSION = version_list[0]
+FUSE_MINOR_VERSION = version_list[1]
+FUSE_HOTFIX_VERSION = version_list[2]
 
 platform = host_machine.system()
 if platform == 'darwin'
@@ -33,6 +41,10 @@ private_cfg = configuration_data()
 #       this config.
 #
 public_cfg = configuration_data()
+
+public_cfg.set('FUSE_MAJOR_VERSION', FUSE_MAJOR_VERSION)
+public_cfg.set('FUSE_MINOR_VERSION', FUSE_MINOR_VERSION)
+public_cfg.set('FUSE_HOTFIX_VERSION', FUSE_HOTFIX_VERSION)
 
 # Default includes when checking for presence of functions and
 # struct members

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libfuse3', ['c'], version: '3.16.2',
+project('libfuse3', ['c'], version: '3.17.0',
         meson_version: '>= 0.51',
         default_options: [
             'buildtype=debugoptimized',


### PR DESCRIPTION
Defining the version in fuse_common.h, is removed, it is defined
through meson and provided by "libfuse_config.h". I.e. it avoids
to define the version twice - once in meson and once in
fuse_common.h.

Ideal would be to set integers in the meson file and create the version
string from these integers. However, meson requires that "project"
is the first meson.build keyword - with that it requires to
set the version from a string and then major/minor/hotfix integers
are created from string split.