### PR TITLE
Make the changes to custom_io backwards compabible.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,11 @@
+libfuse 3.17.x (tbd)
+====================
+
+When using -DFUSE_USE_VERSION=317 then
+* Added new fuse_session_custom_io_317 function to allow extra callbacks.
+
+* Use clone_fd callback in struct fuse_custom_io
+
 libfuse 3.16.2 (2023-10-10)
 ===========================
 

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -136,7 +136,10 @@ struct fuse_custom_io {
 	ssize_t (*splice_send)(int fdin, off_t *offin, int fdout,
 				     off_t *offout, size_t len,
 			           unsigned int flags, void *userdata);
+
+#if FUSE_USE_VERSION >= FUSE_MAKE_VERSION(3, 17)
 	int (*clone_fd)(int master_fd);
+#endif
 };
 
 /**
@@ -2042,6 +2045,7 @@ struct fuse_session *fuse_session_new(struct fuse_args *args,
  *
  * @param se session object
  * @param io Custom io to use when retrieving/sending requests/responses
+ * @param io_size sizeof(struct fuse_custom_io)
  * @param fd file descriptor for the session
  *
  * @return 0  on success
@@ -2050,8 +2054,14 @@ struct fuse_session *fuse_session_new(struct fuse_args *args,
  * @return -errno  if failed to allocate memory to store `io`
  *
  **/
+#if FUSE_USE_VERSION < FUSE_MAKE_VERSION(3, 17)
 int fuse_session_custom_io(struct fuse_session *se,
-				   const struct fuse_custom_io *io, int fd);
+			   const struct fuse_custom_io *io, int fd);
+#else
+int fuse_session_custom_io_317(struct fuse_session *se,
+			       const struct fuse_custom_io *io, size_t io_size, int fd);
+#define fuse_session_custom_io(_SE, _IO, _FD) fuse_session_custom_io_317(_SE, _IO, (sizeof(_IO)), _FD)
+#endif
 
 /**
  * Mount a FUSE file system.

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -37,7 +37,7 @@ libfuse = library('fuse3', libfuse_sources, version: meson.project_version(),
                   soversion: '3', include_directories: include_dirs,
                   dependencies: deps, install: true,
                   link_depends: 'fuse_versionscript',
-                  c_args: [ '-DFUSE_USE_VERSION=312',
+                  c_args: [ '-DFUSE_USE_VERSION=317',
                             '-DFUSERMOUNT_DIR="@0@"'.format(fusermount_path) ],
                   link_args: ['-Wl,--version-script,' + meson.current_source_dir()
                               + '/fuse_versionscript' ])

--- a/util/meson.build
+++ b/util/meson.build
@@ -11,7 +11,7 @@ executable('mount.fuse3', ['mount.fuse.c'],
            link_with: [ libfuse ],
            install: true,
            install_dir: get_option('sbindir'),
-           c_args: '-DFUSE_USE_VERSION=312')
+           c_args: '-DFUSE_USE_VERSION=317')
 
 
 udevrulesdir = get_option('udevrulesdir')


### PR DESCRIPTION
Pass in a size field to session_custom_io so that new entries
can be added without breaking the ABI.

Make the function prototype backwards compatible.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
