### PR TITLE
fuse_common.h: fix warning on _Static_assert()

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -957,7 +957,7 @@ void fuse_loop_cfg_convert(struct fuse_loop_config *config,
  * On 32bit systems please add -D_FILE_OFFSET_BITS=64 to your compile flags!
  */
 
-#if defined(__GNUC__) && (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ >= 6) && !defined __cplusplus
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 _Static_assert(sizeof(off_t) == 8, "fuse: off_t must be 64bit");
 #else
 struct _fuse_off_t_must_be_64bit_dummy_struct \


### PR DESCRIPTION
When building a project that uses libfuse with musl libc, gcc gives the following warning if provided with the `-std=c99 -Wpedantic` options:

```
/usr/include/fuse3/fuse_common.h:938:1: warning: ISO C99 does not support '_Static_assert' [-Wpedantic]
  938 | _Static_assert(sizeof(off_t) == 8, "fuse: off_t must be 64bit");
      | ^~~~~~~~~~~~~~
```

Note: not reproducible with glibc, since glibc's `sys/cdefs.h` (which is included by `features.h`, and the latter is included by some system headers, e.g. `sys/types.h`, used by libfuse) defines `_Static_assert` when it's not available:

```C
#if (!defined _Static_assert && !defined __cplusplus \
     && (defined __STDC_VERSION__ ? __STDC_VERSION__ : 0) < 201112 \
     && (!(__GNUC_PREREQ (4, 6) || __clang_major__ >= 4) \
         || defined __STRICT_ANSI__))
# define _Static_assert(expr, diagnostic) \
    extern int (*__Static_assert_function (void)) \
      [!!sizeof (struct { int __error_if_negative: (expr) ? 2 : -1; })]
#endif
```

Since `_Static_assert` is introduced in C11, it would be better to use a more standard-conformant way to check for its availability.