### PR TITLE
Add in the libfuse version a program was compiled with

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -831,6 +831,18 @@ struct fuse_bufvec {
 	struct fuse_buf buf[1];
 };
 
+/**
+ * libfuse version a file system was compiled with. Should be filled in from
+ * defines in 'libfuse_config.h'
+ */
+struct libfuse_version
+{
+	int major;
+	int minor;
+	int hotfix;
+	int padding;
+};
+
 /* Initialize bufvec with a single buffer of given size */
 #define FUSE_BUFVEC_INIT(size__)				\
 	((struct fuse_bufvec) {					\

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1991,6 +1991,36 @@ int fuse_parse_cmdline_312(struct fuse_args *args,
 #endif
 #endif
 
+/*
+ * This should mostly not be called directly, but instead the fuse_session_new()
+ * macro should be used, which fills in the libfuse version compilation
+ * is done against automatically.
+ */
+struct fuse_session *_fuse_session_new_317(struct fuse_args *args,
+					  const struct fuse_lowlevel_ops *op,
+					  size_t op_size,
+					  struct libfuse_version *version,
+					  void *userdata);
+
+/* Do not call this directly, but only through fuse_session_new() */
+#if (defined(LIBFUSE_BUILT_WITH_VERSIONED_SYMBOLS))
+struct fuse_session *
+_fuse_session_new(struct fuse_args *args,
+		 const struct fuse_lowlevel_ops *op,
+		 size_t op_size,
+		 struct libfuse_version *version,
+		 void *userdata);
+#else
+struct fuse_session *
+_fuse_session_new_317(struct fuse_args *args,
+		      const struct fuse_lowlevel_ops *op,
+		      size_t op_size,
+		      struct libfuse_version *version,
+		      void *userdata);
+#define _fuse_session_new(args, op, op_size, version, userdata)	\
+	_fuse_session_new_317(args, op, op_size, version, userdata)
+#endif
+
 /**
  * Create a low level session.
  *
@@ -2015,13 +2045,25 @@ int fuse_parse_cmdline_312(struct fuse_args *args,
  * @param args argument vector
  * @param op the (low-level) filesystem operations
  * @param op_size sizeof(struct fuse_lowlevel_ops)
+ * @param version the libfuse version a file system server was compiled against
  * @param userdata user data
- *
  * @return the fuse session on success, NULL on failure
  **/
-struct fuse_session *fuse_session_new(struct fuse_args *args,
-				      const struct fuse_lowlevel_ops *op,
-				      size_t op_size, void *userdata);
+static inline struct fuse_session *
+fuse_session_new(struct fuse_args *args,
+		 const struct fuse_lowlevel_ops *op,
+		 size_t op_size,
+		 void *userdata)
+{
+	struct libfuse_version version = {
+		.major = FUSE_MAJOR_VERSION,
+		.minor = FUSE_MINOR_VERSION,
+		.hotfix = FUSE_HOTFIX_VERSION,
+		.padding = 0
+	};
+
+	return _fuse_session_new(args, op, op_size, &version, userdata);
+}
 
 /**
  * Set a file descriptor for the session.

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -65,6 +65,11 @@ struct fuse_session {
 	struct fuse_notify_req notify_list;
 	size_t bufsize;
 	int error;
+
+	/* This is useful if any kind of ABI incompatibility is found at
+	 * a later version, to 'fix' it at run time.
+	 */
+	struct libfuse_version version;
 };
 
 struct fuse_chan {

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3020,9 +3020,12 @@ restart:
 	return res;
 }
 
-struct fuse_session *fuse_session_new(struct fuse_args *args,
-				      const struct fuse_lowlevel_ops *op,
-				      size_t op_size, void *userdata)
+FUSE_SYMVER("_fuse_session_new_317", "_fuse_session_new@@FUSE_3.17")
+struct fuse_session *_fuse_session_new_317(struct fuse_args *args,
+					  const struct fuse_lowlevel_ops *op,
+					  size_t op_size,
+					  struct libfuse_version *version,
+					  void *userdata)
 {
 	int err;
 	struct fuse_session *se;
@@ -3101,6 +3104,14 @@ struct fuse_session *fuse_session_new(struct fuse_args *args,
 	se->userdata = userdata;
 
 	se->mo = mo;
+
+	/* Fuse server application should pass the version it was compiled
+	 * against and pass it. If a libfuse version accidentally introduces an
+	 * ABI incompatibility, it might be possible to 'fix' that at run time,
+	 * by checking the version numbers.
+	 */
+	se->version = *version;
+
 	return se;
 
 out5:
@@ -3114,6 +3125,22 @@ out2:
 	free(se);
 out1:
 	return NULL;
+}
+
+struct fuse_session *fuse_session_new_30(struct fuse_args *args,
+					  const struct fuse_lowlevel_ops *op,
+					  size_t op_size,
+					  void *userdata);
+FUSE_SYMVER("fuse_session_new_30", "fuse_session_new@FUSE_3.0")
+struct fuse_session *fuse_session_new_30(struct fuse_args *args,
+					  const struct fuse_lowlevel_ops *op,
+					  size_t op_size,
+					  void *userdata)
+{
+	/* unknown version */
+	struct libfuse_version version = { 0 };
+
+	return _fuse_session_new_317(args, op, op_size, &version, userdata);
 }
 
 int fuse_session_custom_io(struct fuse_session *se, const struct fuse_custom_io *io,

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -187,6 +187,15 @@ FUSE_3.12 {
 		fuse_lowlevel_notify_expire_entry;
 } FUSE_3.4;
 
+FUSE_3.17 {
+	global:
+		_fuse_session_new_317;
+		_fuse_new;
+		_fuse_new_30;
+		_fuse_new_317;
+		fuse_main_real_317;
+} FUSE_3.12;
+
 # Local Variables:
 # indent-tabs-mode: t
 # End:

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -304,8 +304,11 @@ int fuse_daemonize(int foreground)
 	return 0;
 }
 
-int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
-		   size_t op_size, void *user_data)
+int fuse_main_real_317(int argc, char *argv[], const struct fuse_operations *op,
+		   size_t op_size, struct libfuse_version *version, void *user_data);
+FUSE_SYMVER("fuse_main_real_317", "fuse_main_real@@FUSE_3.17")
+int fuse_main_real_317(int argc, char *argv[], const struct fuse_operations *op,
+		   size_t op_size, struct libfuse_version *version, void *user_data)
 {
 	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
 	struct fuse *fuse;
@@ -341,8 +344,7 @@ int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
 		goto out1;
 	}
 
-
-	fuse = fuse_new_31(&args, op, op_size, user_data);
+	fuse = _fuse_new(&args, op, op_size, version, user_data);
 	if (fuse == NULL) {
 		res = 3;
 		goto out1;
@@ -394,6 +396,16 @@ out1:
 	return res;
 }
 
+int fuse_main_real_30(int argc, char *argv[], const struct fuse_operations *op,
+		      size_t op_size, void *user_data);
+FUSE_SYMVER("fuse_main_real_30", "fuse_main_real@FUSE_3.0")
+int fuse_main_real_30(int argc, char *argv[], const struct fuse_operations *op,
+		      size_t op_size, void *user_data)
+{
+	struct libfuse_version version = { 0 };
+
+	return fuse_main_real_317(argc, argv, op, op_size, &version, user_data);
+}
 
 void fuse_apply_conn_info_opts(struct fuse_conn_info_opts *opts,
 			       struct fuse_conn_info *conn)


### PR DESCRIPTION
The API stays the same, the libfuse version comes from inlined functions, which are defined fuse_lowlevel.h and fuse.h.

fuse_session_new() -> static inlinei, in the application _fuse_session_new -> inside of libfuse

fuse_new() -> static inline, in the application
_fuse_new() -> inside of libfuse