### PR TITLE
Handle NO_OPEN/NO_OPENDIR support automatically

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -325,8 +325,10 @@ struct fuse_loop_config_v1 {
  * kernel. (If this flag is not set, returning ENOSYS will be treated
  * as an error and signaled to the caller).
  *
- * Setting (or unsetting) this flag in the `want` field has *no
- * effect*.
+ * Setting this flag in the `want` field enables this behavior automatically
+ * within libfuse for low level API users. If non-low level users wish to have
+ * this behavior you must return `ENOSYS` from the open() handler on supporting
+ * kernels.
  */
 #define FUSE_CAP_NO_OPEN_SUPPORT	(1 << 17)
 
@@ -404,7 +406,10 @@ struct fuse_loop_config_v1 {
  * flag is not set, returning ENOSYS will be treated as an error and signalled
  * to the caller.)
  *
- * Setting (or unsetting) this flag in the `want` field has *no effect*.
+ * Setting this flag in the `want` field enables this behavior automatically
+ * within libfuse for low level API users.  If non-low level users with to have
+ * this behavior you must return `ENOSYS` from the opendir() handler on
+ * supporting kernels.
  */
 #define FUSE_CAP_NO_OPENDIR_SUPPORT    (1 << 24)
 

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -532,6 +532,13 @@ struct fuse_lowlevel_ops {
 	 * future calls to open and release will also succeed without being
 	 * sent to the filesystem process.
 	 *
+	 * To get this behavior without providing an opendir handler, you may
+	 * set FUSE_CAP_NO_OPEN_SUPPORT in `fuse_conn_info.want` on supported
+	 * kernels to automatically get the zero message open().
+	 *
+	 * If this callback is not provided and FUSE_CAP_NO_OPEN_SUPPORT is not
+	 * set in `fuse_conn_info.want` then an empty reply will be sent.
+	 *
 	 * Valid replies:
 	 *   fuse_reply_open
 	 *   fuse_reply_err
@@ -704,6 +711,13 @@ struct fuse_lowlevel_ops {
 	 * releasedir will also succeed without being sent to the filesystem
 	 * process. In addition, the kernel will cache readdir results
 	 * as if opendir returned FOPEN_KEEP_CACHE | FOPEN_CACHE_DIR.
+	 *
+	 * To get this behavior without providing an opendir handler, you may
+	 * set FUSE_CAP_NO_OPENDIR_SUPPORT in `fuse_conn_info.want` on supported
+	 * kernels to automatically get the zero message opendir().
+	 *
+	 * If this callback is not provided and FUSE_CAP_NO_OPENDIR_SUPPORT is
+	 * not set in `fuse_conn_info.want` then an empty reply will be sent.
 	 *
 	 * Valid replies:
 	 *   fuse_reply_open

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1351,6 +1351,8 @@ static void do_open(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 
 	if (req->se->op.open)
 		req->se->op.open(req, nodeid, &fi);
+	else if (req->se->conn.want & FUSE_CAP_NO_OPEN_SUPPORT)
+		fuse_reply_err(req, ENOSYS);
 	else
 		fuse_reply_open(req, &fi);
 }
@@ -1507,6 +1509,8 @@ static void do_opendir(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 
 	if (req->se->op.opendir)
 		req->se->op.opendir(req, nodeid, &fi);
+	else if (req->se->conn.want & FUSE_CAP_NO_OPENDIR_SUPPORT)
+		fuse_reply_err(req, ENOSYS);
 	else
 		fuse_reply_open(req, &fi);
 }


### PR DESCRIPTION
If the file system doesn't provide a ->open or an ->opendir, and the kernel supports FUSE_CAP_NO_OPEN_SUPPORT or FUSE_CAP_NO_OPENDIR_SUPPORT, return ENOSYS so that the kernel no longer sends OPEN or OPENDIR requests, and properly caches the directories.