### PR TITLE
Atomic struct fuse_req::ref_cnt

### DIFF
--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -14,7 +14,7 @@ struct mount_opts;
 struct fuse_req {
 	struct fuse_session *se;
 	uint64_t unique;
-	_Atomic int ctr;
+	_Atomic int ref_cnt;
 	pthread_mutex_t lock;
 	struct fuse_ctx ctx;
 	struct fuse_chan *ch;

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -14,7 +14,7 @@ struct mount_opts;
 struct fuse_req {
 	struct fuse_session *se;
 	uint64_t unique;
-	int ctr;
+	_Atomic int ctr;
 	pthread_mutex_t lock;
 	struct fuse_ctx ctx;
 	struct fuse_chan *ch;


### PR DESCRIPTION
Make  `struct fuse_req::ctr` an atomic type and rename to ::ref_cnt`