### PR TITLE
libfuse: use --direct-io for passthrough_hp with fstests

### DIFF
--- a/xfstests/mount.fuse.passthrough
+++ b/xfstests/mount.fuse.passthrough
@@ -35,4 +35,4 @@ fi
 
 [ -n "$PASSTHROUGH_PATH" ] || PASSTHROUGH_PATH=${0#*mount.fuse.}
 
-exec "$PASSTHROUGH_PATH" -o fsname=$dev,allow_other $source "$mnt" -o "$mntopts" "$@"
+exec "$PASSTHROUGH_PATH" --direct-io -o fsname=$dev,allow_other $source "$mnt" -o "$mntopts" "$@"


### PR DESCRIPTION
generic/095 uses a fio job that does directio, however we constantly return -EIO if we're using the passthrough functionality and don't have --direct-io set.  This causes odd problems with the test because of a bug in fio, so update the helper to use --direct-io because we do in fact want to test direct io properly.