### PR TITLE
xfstests: Add the possibility for extra daemon options

### DIFF
--- a/xfstests/local.config
+++ b/xfstests/local.config
@@ -9,6 +9,9 @@ export FUSE_SUBTYP=.passthrough
 export MOUNT_OPTIONS=""
 export TEST_FS_MOUNT_OPTS=""
 
+# extra binary options, such as '--direct-io' or '--nopassthrough', etc
+export EXTRA_BIN_OPTIONS=""
+
 # If PASSTHROUGH_PATH is unset, the mount helper is going to look
 # for the binary '${FUSE_SUBTYP}', though omitting the leading dot '.'.
 # Example:

--- a/xfstests/mount.fuse.passthrough
+++ b/xfstests/mount.fuse.passthrough
@@ -35,4 +35,6 @@ fi
 
 [ -n "$PASSTHROUGH_PATH" ] || PASSTHROUGH_PATH=${0#*mount.fuse.}
 
-exec "$PASSTHROUGH_PATH" -o fsname=$dev,allow_other $source "$mnt" -o "$mntopts" "$@"
+#echo "EXTRA_BIN_OPTIONS='${EXTRA_BIN_OPTIONS}'"
+
+exec "$PASSTHROUGH_PATH" ${EXTRA_BIN_OPTIONS} -o fsname=$dev,allow_other $source "$mnt" -o "$mntopts" "$@"


### PR DESCRIPTION
We need to test w/o page cache, w/o passthrough and other options. I.e. we need to have the possibility to add these options via local.config