### PR TITLE
libfuse: have passthrough_hp return an error with invalid mount options

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -1421,6 +1421,7 @@ int main(int argc, char *argv[]) {
         (fs.debug_fuse && fuse_opt_add_arg(&args, "-odebug")))
         errx(3, "ERROR: Out of memory");
 
+    ret = -1;
     fuse_lowlevel_ops sfs_oper {};
     assign_operations(sfs_oper);
     auto se = fuse_session_new(&args, &sfs_oper, sizeof(sfs_oper), &fs);


### PR DESCRIPTION
generic/003 fails currently because if you specify -o relatime we will fail to mount, but not return an error, so the test thinks that we support relatime and then hilarity ensues.  Set ret so that if we get any failures while trying to mount we will properly error out.