### PR TITLE
libfuse: null-terminate buffer in fuse_req_getgroups()

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3353,6 +3353,7 @@ retry:
 		goto retry;
 	}
 
+	buf[ret] = '\0';
 	ret = -EIO;
 	s = strstr(buf, "\nGroups:");
 	if (s == NULL)


### PR DESCRIPTION
After reading the file /proc/$PID/task/$PID/status the buffer wasn't terminated with a null character.  This could theoretically lead to buffer overrun by the subsequent strstr() call.

Since the contents of the proc file are guaranteed to contain the pattern that strstr is looking for, this doesn't happen in normal situations.

Add null termination for robustness.