### PR TITLE
add fmask and dmask options

### DIFF
--- a/doc/mount.fuse3.8
+++ b/doc/mount.fuse3.8
@@ -181,8 +181,8 @@ This option is an alternative to
 cached data is invalidated on \fBopen\fP(2) if the modification
 time or the size of the file has changed since it was last opened.
 .TP
-\fBumask=M\fP
-Override the permission bits in \fIst_mode\fP set by the filesystem. The resulting permission bits are the ones missing from the given umask value.  The value is given in octal representation.
+\fBumask=M fmask=M dmask=M\fP
+Override the permission bits set by the filesystem in \fIst_mode\fP. The resulting permission bits are the ones missing from the mask value, which is given in octal representation. \fBfmask\fP and \fBdmask\fP (respectively) may be used to control the permission bits of files and directories separately. umask is overridden by the individual fmask and dmask options.
 .TP
 \fBuid=N\fP
 Override the \fIst_uid\fP field set by the filesystem (N is numeric).

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -298,6 +298,14 @@ struct fuse_config {
 	int show_help;
 	char *modules;
 	int debug;
+
+	/**
+	 * `fmask` and `dmask` function the same way as `umask`, but apply
+	 * to files and directories separately. If non-zero, `fmask` and
+	 * `dmask` take precedence over the `umask` setting.
+	 */
+	unsigned int fmask;
+	unsigned int dmask;
 };
 
 


### PR DESCRIPTION
dmask: umask applied to directories
fmask: umask applied to non-directories
see https://github.com/libfuse/libfuse/issues/975

to get "typical" permission bits for regular files (0644) and directories (0755), a single umask option is not sufficient (or well, it isn't the way fuse implements it)

there is precident for separate umask and dmask options in other filesystems (see for example fat: https://github.com/torvalds/linux/tree/master/fs/fat)

this addition should not affect backward-compatibility; the original umask option retains the same meaning, but non-zero fmask or dmask will override it.