### PR TITLE
Use a single bit for "no_interrupt"

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -642,7 +642,7 @@ struct fuse_conn_info {
 	 * 2) Return ENOSYS for the reply of FUSE_INTERRUPT request to
 	 * inform the kernel not to send the FUSE_INTERRUPT request.
 	 */
-	unsigned no_interrupt;
+	unsigned no_interrupt : 1;
 
 	/**
 	 * For future use.


### PR DESCRIPTION
This is an addition to commit cef8c8b24
"Add support for no_interrupt"
and uses a single bit - the variable is used as boolean.

This should allow us to add more booleans into the "unsigned" in the future. Though I'm not sure yet how to handle "$arch" that does not have unsigned as 32bit value.