### PR TITLE
Allow to have page aligned writes

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,6 +5,7 @@ libfuse 3.17 (unreleased)
   New public function: fuse_set_fail_signal_handlers()
 * Allows fuse_log() messages to be send to syslog instead of stderr
   New public functions: fuse_log_enable_syslog() and fuse_log_close_syslog()
+* Handle buffer misalignment for FUSE_WRITE
 
 libfuse 3.16.2 (2023-10-10)
 ===========================

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4550,13 +4550,14 @@ static int fuse_session_loop_remember(struct fuse *f)
 			else
 				break;
 		} else if (res > 0) {
-			res = fuse_session_receive_buf_int(se, &fbuf, NULL);
+			res = fuse_session_receive_buf_internal(se, &fbuf,
+								NULL);
 			if (res == -EINTR)
 				continue;
 			if (res <= 0)
 				break;
 
-			fuse_session_process_buf_int(se, &fbuf, NULL);
+			fuse_session_process_buf_internal(se, &fbuf, NULL);
 		} else {
 			timeout = fuse_clean_cache(f);
 			curr_time(&now);
@@ -4774,7 +4775,7 @@ void fuse_lib_help(struct fuse_args *args)
 			   fuse_lib_opt_proc) == -1
 	    || !conf.modules)
 		return;
-	
+
 	char *module;
 	char *next;
 	struct fuse_module *m;
@@ -4791,8 +4792,6 @@ void fuse_lib_help(struct fuse_args *args)
 			print_module_help(module, &m->factory);
 	}
 }
-
-				      
 
 static int fuse_init_intr_signal(int signum, int *installed)
 {

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4550,14 +4550,13 @@ static int fuse_session_loop_remember(struct fuse *f)
 			else
 				break;
 		} else if (res > 0) {
-			res = fuse_session_receive_buf(se, &fbuf);
-
+			res = fuse_session_receive_buf_int(se, &fbuf, NULL);
 			if (res == -EINTR)
 				continue;
 			if (res <= 0)
 				break;
 
-			fuse_session_process_buf(se, &fbuf);
+			fuse_session_process_buf_int(se, &fbuf, NULL);
 		} else {
 			timeout = fuse_clean_cache(f);
 			curr_time(&now);

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -188,6 +188,8 @@ void cuse_lowlevel_init(fuse_req_t req, fuse_ino_t nodeide, const void *inarg);
 
 int fuse_start_thread(pthread_t *thread_id, void *(*func)(void *), void *arg);
 
+void fuse_buf_free(struct fuse_buf *buf);
+
 int fuse_session_receive_buf_int(struct fuse_session *se, struct fuse_buf *buf,
 				 struct fuse_chan *ch);
 void fuse_session_process_buf_int(struct fuse_session *se,

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -190,10 +190,12 @@ int fuse_start_thread(pthread_t *thread_id, void *(*func)(void *), void *arg);
 
 void fuse_buf_free(struct fuse_buf *buf);
 
-int fuse_session_receive_buf_int(struct fuse_session *se, struct fuse_buf *buf,
-				 struct fuse_chan *ch);
-void fuse_session_process_buf_int(struct fuse_session *se,
-				  const struct fuse_buf *buf, struct fuse_chan *ch);
+int fuse_session_receive_buf_internal(struct fuse_session *se,
+				      struct fuse_buf *buf,
+				      struct fuse_chan *ch);
+void fuse_session_process_buf_internal(struct fuse_session *se,
+				       const struct fuse_buf *buf,
+				       struct fuse_chan *ch);
 
 struct fuse *fuse_new_31(struct fuse_args *args, const struct fuse_operations *op,
 		      size_t op_size, void *private_data);

--- a/lib/fuse_loop.c
+++ b/lib/fuse_loop.c
@@ -24,7 +24,7 @@ int fuse_session_loop(struct fuse_session *se)
 	};
 
 	while (!fuse_session_exited(se)) {
-		res = fuse_session_receive_buf_int(se, &fbuf, NULL);
+		res = fuse_session_receive_buf_internal(se, &fbuf, NULL);
 
 		if (res == -EINTR)
 			continue;

--- a/lib/fuse_loop.c
+++ b/lib/fuse_loop.c
@@ -24,7 +24,7 @@ int fuse_session_loop(struct fuse_session *se)
 	};
 
 	while (!fuse_session_exited(se)) {
-		res = fuse_session_receive_buf(se, &fbuf);
+		res = fuse_session_receive_buf_int(se, &fbuf, NULL);
 
 		if (res == -EINTR)
 			continue;
@@ -34,7 +34,7 @@ int fuse_session_loop(struct fuse_session *se)
 		fuse_session_process_buf(se, &fbuf);
 	}
 
-	free(fbuf.mem);
+	fuse_buf_free(&fbuf);
 	if(res > 0)
 		/* No error, just the length of the most recently read
 		   request */

--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -135,7 +135,8 @@ static void *fuse_do_work(void *data)
 		int res;
 
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-		res = fuse_session_receive_buf_int(mt->se, &w->fbuf, w->ch);
+		res = fuse_session_receive_buf_internal(mt->se, &w->fbuf,
+							w->ch);
 		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 		if (res == -EINTR)
 			continue;
@@ -171,7 +172,7 @@ static void *fuse_do_work(void *data)
 			fuse_loop_start_thread(mt);
 		pthread_mutex_unlock(&mt->lock);
 
-		fuse_session_process_buf_int(mt->se, &w->fbuf, w->ch);
+		fuse_session_process_buf_internal(mt->se, &w->fbuf, w->ch);
 
 		pthread_mutex_lock(&mt->lock);
 		if (!isforget)

--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -194,7 +194,7 @@ static void *fuse_do_work(void *data)
 			pthread_mutex_unlock(&mt->lock);
 
 			pthread_detach(w->thread_id);
-			free(w->fbuf.mem);
+			fuse_buf_free(&w->fbuf);
 			fuse_chan_put(w->ch);
 			free(w);
 			return NULL;
@@ -350,7 +350,7 @@ static void fuse_join_worker(struct fuse_mt *mt, struct fuse_worker *w)
 	pthread_mutex_lock(&mt->lock);
 	list_del_worker(w);
 	pthread_mutex_unlock(&mt->lock);
-	free(w->fbuf.mem);
+	fuse_buf_free(&w->fbuf);
 	fuse_chan_put(w->ch);
 	free(w);
 }

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2740,10 +2740,11 @@ static int fuse_ll_copy_from_pipe(struct fuse_bufvec *dst,
 void fuse_session_process_buf(struct fuse_session *se,
 			      const struct fuse_buf *buf)
 {
-	fuse_session_process_buf_int(se, buf, NULL);
+	fuse_session_process_buf_internal(se, buf, NULL);
 }
 
-void fuse_session_process_buf_int(struct fuse_session *se,
+/* libfuse internal handler */
+void fuse_session_process_buf_internal(struct fuse_session *se,
 				  const struct fuse_buf *buf, struct fuse_chan *ch)
 {
 	const size_t write_header_size = sizeof(struct fuse_in_header) +
@@ -3189,8 +3190,9 @@ int fuse_session_receive_buf(struct fuse_session *se, struct fuse_buf *buf)
 }
 
 /* libfuse internal handler */
-int fuse_session_receive_buf_int(struct fuse_session *se, struct fuse_buf *buf,
-				 struct fuse_chan *ch)
+int fuse_session_receive_buf_internal(struct fuse_session *se,
+				      struct fuse_buf *buf,
+				      struct fuse_chan *ch)
 {
 	return _fuse_session_receive_buf(se, buf, ch, true);
 }

--- a/lib/util.h
+++ b/lib/util.h
@@ -1,1 +1,3 @@
+#define ROUND_UP(val, round_to) (((val) + (round_to - 1)) & ~(round_to - 1))
+
 int libfuse_strtol(const char *str, long *res);


### PR DESCRIPTION
Read/writes IOs should be page aligned as fuse server
might need to copy data to another buffer otherwise in
order to fulfill network or device storage requirements.

Simple reproducer is example/passthrough*
and opening a file with O_DIRECT - without this change
writing to that file failed with -EINVAL if the underlying
file system was using ext4 (for passthrough_hp the
'passthrough' feature has to be disabled).

