### PR TITLE
Support max writes larger than the default limit

### DIFF
--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -70,6 +70,11 @@ struct fuse_session {
 	 * a later version, to 'fix' it at run time.
 	 */
 	struct libfuse_version version;
+
+	/* Used for max writes larger than the default limit of
+	 * FUSE_MAX_MAX_PAGES * PAGE_SIZE.
+	 */
+	unsigned int extended_max_write;
 };
 
 struct fuse_chan {

--- a/test/test_write_cache.c
+++ b/test/test_write_cache.c
@@ -37,10 +37,12 @@ struct options {
     int writeback;
     int data_size;
     int delay_ms;
+    unsigned int extended_max_write;
 } options = {
     .writeback = 0,
     .data_size = 2048,
     .delay_ms = 0,
+    .extended_max_write = 0,
 };
 
 #define WRITE_SYSCALLS 64
@@ -51,6 +53,7 @@ static const struct fuse_opt option_spec[] = {
     OPTION("writeback_cache", writeback),
     OPTION("--data-size=%d", data_size),
     OPTION("--delay_ms=%d", delay_ms),
+    OPTION("--extended_max_write=%u", extended_max_write),
     FUSE_OPT_END
 };
 static int got_write;
@@ -261,6 +264,12 @@ int main(int argc, char *argv[]) {
 #ifndef __FreeBSD__    
     assert(fuse_opt_add_arg(&args, "-oauto_unmount") == 0);
 #endif
+    if (options.extended_max_write) {
+	char max_write[32] = {};
+	assert(snprintf(max_write, sizeof(max_write), "-oextended_max_write=%u",
+		options.extended_max_write) > 0);
+	assert(fuse_opt_add_arg(&args, max_write) == 0);
+    }
     se = fuse_session_new(&args, &tfs_oper,
                           sizeof(tfs_oper), NULL);
     fuse_opt_free_args(&args);


### PR DESCRIPTION
Currently, the max write size for a request is limited in the kernel by FUSE_MAX_MAX_PAGES. There is a patch upstream [1] for enabling this limit to be dynamically configured through a sysctl. The motivating factor behind this is for improving performance for large workloads (some benchmarks can be found in the discussion in [2]).

In libfuse, users can request the max write size through setting "conn->max_write" in their init callback. However, this will fail for sizes larger than the default max write size (FUSE_MAX_MAX_PAGES * PAGESIZE) because the buffer allocated for receiving requests (in fuse_session_receive_buf_int) is allocated with size se->bufsize which is set to the default max write size (since at the time of buffer allocation, the init callback has not been called, so we do not know what max write size the user requests).

To support max write sizes larger than the default size, this commit adds an option -o "extended_max_write=" which allocates the request buffer at the requested max write size. This option can only be used for writes exceeding the default max write size (for writes less than the default max write size, users should set "conn->max_write" in their init callback). If for some reason the user sets both conn->max_write and uses extended_max_write, the extended_max_write value will be used and passed to the kernel as the requested max write size. The user is responsible for ensuring that the kernel they are running on has a fuse max pages limit that supports their requested max write size.

Another alternative that was explored is transparently reallocating the buffer for the user within libfuse if in the init callback the max_write size is larger than the default. This eliminates having to pass the write size through an option and users can just set it through "conn->max_write". Unfortunately, this has three issues: 1) max write sizes larger than the default would only be supported when users do not pass in a user-allocated fuse_buf 2) there is a race condition where if the user calls fuse_session_loop_mt, then fuse_session_receive_buf, and then fuse_session_process_buf, the fuse_session_loop_mt can fail if the init request is picked up by the call to fuse_session_receive_buf, before the fuse_session_loop_mt thread and 3) reallocating the buffer violates the "const"-ness of the fuse_session_process_buf public API.

[1] https://lore.kernel.org/linux-fsdevel/20240702014627.4068146-1-joannelkoong@gmail.com/T/#u
[2] https://lore.kernel.org/linux-fsdevel/20240124070512.52207-1-jefflexu@linux.alibaba.com/T/#u

Signed-off by: Joanne Koong <joannelkoong@gmail.com>