### PR TITLE
xfstests: Add '-odev' to passthrough mount options

### DIFF
--- a/xfstests/mount.fuse.passthrough
+++ b/xfstests/mount.fuse.passthrough
@@ -37,4 +37,4 @@ fi
 
 #echo "EXTRA_BIN_OPTIONS='${EXTRA_BIN_OPTIONS}'"
 
-exec "$PASSTHROUGH_PATH" ${EXTRA_BIN_OPTIONS} -o fsname=$dev,allow_other $source "$mnt" -o "$mntopts" "$@"
+exec "$PASSTHROUGH_PATH" ${EXTRA_BIN_OPTIONS} -o fsname=$dev,allow_other,dev $source "$mnt" -o "$mntopts" "$@"


### PR DESCRIPTION
generic/434 and generic/184 are testing device files and fail because fuse sets 'nodev' by default.