### PR TITLE
Add syslog and fatal signal handler feature

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,11 @@
+libfuse 3.17 (unreleased)
+========================
+
+* Allows to handle fatal signals and to print a backtrace.
+  New public function: fuse_set_fail_signal_handlers()
+* Allows fuse_log() messages to be send to syslog instead of stderr
+  New public functions: fuse_log_enable_syslog() and fuse_log_close_syslog()
+
 libfuse 3.16.2 (2023-10-10)
 ===========================
 

--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -75,6 +75,7 @@
 #include <fstream>
 #include <thread>
 #include <iomanip>
+#include <syslog.h>
 
 using namespace std;
 
@@ -1431,6 +1432,9 @@ int main(int argc, char *argv[]) {
     if (fuse_set_signal_handlers(se) != 0)
         goto err_out2;
 
+    if (fuse_set_fail_signal_handlers(se) != 0)
+        goto err_out2;
+
     // Don't apply umask, use modes exactly as specified
     umask(0);
 
@@ -1447,11 +1451,13 @@ int main(int argc, char *argv[]) {
 
     fuse_daemonize(fs.foreground);
 
+    if (!fs.foreground)
+        fuse_log_enable_syslog("passthrough-hp", LOG_PID | LOG_CONS, LOG_DAEMON);
+
     if (options.count("single"))
         ret = fuse_session_loop(se);
     else
         ret = fuse_session_loop_mt(se, loop_config);
-
 
     fuse_session_unmount(se);
 
@@ -1463,6 +1469,9 @@ err_out1:
 
     fuse_loop_cfg_destroy(loop_config);
     fuse_opt_free_args(&args);
+
+    if (!fs.foreground)
+        fuse_log_close_syslog();
 
     return ret ? 1 : 0;
 }

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -951,6 +951,23 @@ ssize_t fuse_buf_copy(struct fuse_bufvec *dst, struct fuse_bufvec *src,
 int fuse_set_signal_handlers(struct fuse_session *se);
 
 /**
+ * Print a stack backtrace diagnostic on critical signals ()
+ *
+ * Stores session in a global variable.	 May only be called once per
+ * process until fuse_remove_signal_handlers() is called.
+ *
+ * Once either of the POSIX signals arrives, the signal handler calls
+ * fuse_session_exit().
+ *
+ * @param se the session to exit
+ * @return 0 on success, -1 on failure
+ *
+ * See also:
+ * fuse_remove_signal_handlers()
+ */
+int fuse_set_fail_signal_handlers(struct fuse_session *se);
+
+/**
  * Restore default signal handlers
  *
  * Resets global session.  After this fuse_set_signal_handlers() may

--- a/include/fuse_log.h
+++ b/include/fuse_log.h
@@ -75,6 +75,18 @@ void fuse_set_log_func(fuse_log_func_t func);
  */
 void fuse_log(enum fuse_log_level level, const char *fmt, ...);
 
+/**
+ * Switch default log handler from stderr to syslog
+ *
+ * Passed options are according to 'man 3 openlog'
+ */
+void fuse_log_enable_syslog(const char *ident, int option, int facility);
+
+/**
+ * To be called at teardown to close syslog.
+*/
+void fuse_log_close_syslog(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/fuse_log.c
+++ b/lib/fuse_log.c
@@ -12,12 +12,56 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdbool.h>
+#include <syslog.h>
 
-static void default_log_func(
-		__attribute__(( unused )) enum fuse_log_level level,
-		const char *fmt, va_list ap)
+#define MAX_SYSLOG_LINE_LEN 512
+
+static bool to_syslog = false;
+
+static void default_log_func(__attribute__((unused)) enum fuse_log_level level,
+			     const char *fmt, va_list ap)
 {
-	vfprintf(stderr, fmt, ap);
+	if (to_syslog) {
+		int sys_log_level;
+
+		/*
+		 * with glibc fuse_log_level has identical values as
+		 * syslog levels, but we also support BSD - better we convert to
+		 * be sure.
+		 */
+		switch (level) {
+		case FUSE_LOG_DEBUG:
+			sys_log_level = LOG_DEBUG;
+			break;
+		case FUSE_LOG_INFO:
+			sys_log_level = LOG_INFO;
+			break;
+		case FUSE_LOG_NOTICE:
+			sys_log_level = LOG_NOTICE;
+			break;
+		case FUSE_LOG_WARNING:
+			sys_log_level = LOG_WARNING;
+			break;
+		case FUSE_LOG_ERR:
+			sys_log_level = LOG_ERR;
+			break;
+		case FUSE_LOG_CRIT:
+			sys_log_level = LOG_CRIT;
+			break;
+		case FUSE_LOG_ALERT:
+			sys_log_level = LOG_ALERT;
+			break;
+		case FUSE_LOG_EMERG:
+			sys_log_level = LOG_EMERG;
+		}
+
+		char log[MAX_SYSLOG_LINE_LEN];
+		vsnprintf(log, MAX_SYSLOG_LINE_LEN, fmt, ap);
+		syslog(sys_log_level, "%s", log);
+	} else {
+		vfprintf(stderr, fmt, ap);
+	}
 }
 
 static fuse_log_func_t log_func = default_log_func;
@@ -37,4 +81,16 @@ void fuse_log(enum fuse_log_level level, const char *fmt, ...)
 	va_start(ap, fmt);
 	log_func(level, fmt, ap);
 	va_end(ap);
+}
+
+void fuse_log_enable_syslog(const char *ident, int option, int facility)
+{
+	to_syslog = true;
+
+	openlog(ident, option, facility);
+}
+
+void fuse_log_close_syslog(void)
+{
+	closelog();
 }

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -198,6 +198,9 @@ FUSE_3.17 {
 		fuse_passthrough_close;
 		fuse_session_custom_io_30;
 		fuse_session_custom_io_317;
+		fuse_set_fail_signal_handlers;
+		fuse_log_enable_syslog;
+		fuse_log_close_syslog;
 } FUSE_3.12;
 
 # Local Variables:


### PR DESCRIPTION
I see random ENOTCONN failures in xfstest generic/013 and generic/014 in my branch, but earliest on the 2nd run - takes ~12hours to get the issue, but then there are no further information logged. ENOTCONN points to a daemon crash - I need backtraces and a core dump.

This adds optional handling of fatal signals to print a core dump and optional syslog logging with these new public functions:

fuse_set_fail_signal_handlers()
    In addition to the existing fuse_set_signal_handlers(). This is not
    enabled together with fuse_set_signal_handlers(), as it is change
    in behavior and file systems might already have their own fatal
    handlers.

fuse_log_enable_syslog
    Print logs to syslog instead of stderr

fuse_log_close_syslog
    Close syslog (for now just does closelog())

Code in fuse_signals.c is also updated, to be an array of signals, and setting signal handlers is now down with a for-loop instead of one hand coded set_one_signal_handler() per signal.