### PR TITLE
Add RAMFS to fusermount permitted mount targets

### DIFF
--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1139,6 +1139,7 @@ static int check_perm(const char **mntp, struct stat *stbuf, int *mountpoint_fd)
 		0x736675005346544e /* UFSD */,
 		0x58465342 /* XFS_SB_MAGIC */,
 		0x2FC12FC1 /* ZFS_SUPER_MAGIC */,
+		0x858458f6 /* RAMFS_MAGIC */,
 	};
 	for (i = 0; i < sizeof(f_type_whitelist)/sizeof(f_type_whitelist[0]); i++) {
 		if (f_type_whitelist[i] == fs_buf.f_type)


### PR DESCRIPTION
Addresses issue https://github.com/libfuse/libfuse/issues/982