### PR TITLE
fuse_log: initialize sys_log_level to avoid compiler warning

### DIFF
--- a/lib/fuse_log.c
+++ b/lib/fuse_log.c
@@ -23,7 +23,7 @@ static void default_log_func(__attribute__((unused)) enum fuse_log_level level,
 			     const char *fmt, va_list ap)
 {
 	if (to_syslog) {
-		int sys_log_level;
+		int sys_log_level = LOG_ERR;
 
 		/*
 		 * with glibc fuse_log_level has identical values as


### PR DESCRIPTION
When compiling, the compiler is currently (and inaccurately) complaining about sys_log_level maybe being uninitialized when used.

```
[vmuser@myvm build]$ ninja
[10/73] Compiling C object lib/libfuse3.so.3.17.0.p/fuse_log.c.o
../lib/fuse_log.c: In function ‘default_log_func’:
../lib/fuse_log.c:61:17: warning: ‘sys_log_level’ may be used uninitialized [-Wmaybe-uninitialized]
   61 |                 syslog(sys_log_level, "%s", log);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../lib/fuse_log.c:26:21: note: ‘sys_log_level’ was declared here
   26 |                 int sys_log_level;
      |                     ^~~~~~~~~~~~~
[73/73] Linking target example/passthrough_hp
```

Set it to LOG_ERR as the default. This is a no-op - the switch case will assign it to the correct level.