### PR TITLE
Gate #include <execinfo.h> behind #ifdef HAVE_BACKTRACE

### DIFF
--- a/lib/fuse_signals.c
+++ b/lib/fuse_signals.c
@@ -16,8 +16,11 @@
 #include <string.h>
 #include <signal.h>
 #include <stdlib.h>
-#include <execinfo.h>
 #include <errno.h>
+
+#ifdef HAVE_BACKTRACE
+#include <execinfo.h>
+#endif
 
 static int teardown_sigs[] = { SIGHUP, SIGINT, SIGTERM };
 static int ignore_sigs[] = { SIGPIPE};


### PR DESCRIPTION
#include <execinfo.h> is unnecessary if HAVE_BACKTRACE is not defined.

This increases portability for systems without execinfo.h