### PR TITLE
Fix program-path in util/parse-backtrace and dump_stack function

### DIFF
--- a/lib/fuse_signals.c
+++ b/lib/fuse_signals.c
@@ -32,14 +32,11 @@ static void *backtrace_buffer[BT_STACK_SZ];
 
 static void dump_stack(void)
 {
-	fprintf(stderr, "%s:%d\n", __func__, __LINE__);
 #ifdef HAVE_BACKTRACE
 	char **strings;
 
 	int nptrs = backtrace(backtrace_buffer, BT_STACK_SZ);
 	strings = backtrace_symbols(backtrace_buffer, nptrs);
-
-	fprintf(stderr, "%s: nptrs=%d\n", __func__, nptrs);
 
 	if (strings == NULL) {
 		fuse_log(FUSE_LOG_ERR, "Failed to get backtrace symbols: %s\n",

--- a/util/parse-backtrace.sh
+++ b/util/parse-backtrace.sh
@@ -23,7 +23,7 @@ if [ -z "$1" -o "$1" = "-h" -o "$1" = "--help" ]; then
     print_help
 fi
 
-while getopts "hf:t:" opt; do
+while getopts "hf:t:p:" opt; do
     case $opt in
     h)
         print_help
@@ -33,6 +33,9 @@ while getopts "hf:t:" opt; do
         ;;
     t)
         TRACE="$OPTARG"
+        ;;
+    p)
+        PROGRAM_PATH="$OPTARG"
         ;;
     *)
         print_help


### PR DESCRIPTION
The option to the path of the binary had been accidentally removed in the scripts that can parse backtraces.
The dump_stack() function had left over debug messages.