### PR TITLE
fusermount -u vs NFS root_squash

### DIFF
--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -523,11 +523,13 @@ static int unmount_fuse_locked(const char *mnt, int quiet, int lazy)
 
 	drop_privs();
 	res = chdir_to_parent(copy, &last);
-	restore_privs();
-	if (res == -1)
+	if (res == -1) {
+		restore_privs();
 		goto out;
+	}
 
 	res = umount2(last, umount_flags);
+	restore_privs();
 	if (res == -1 && !quiet) {
 		fprintf(stderr, "%s: failed to unmount %s: %s\n",
 			progname, mnt, strerror(errno));


### PR DESCRIPTION
Rearrange util/fusermount.c umount_fuse_locked() so that umount2 is called with privs dropped, not raised.  This works around a clash with NFS permissions: if FUSE mounted on NFS client directory with root_squash in effect, and some directory in the path leading to the mount point denies permissions to others, umount2 will fail because userid 0 cannot search it.  Since drop_privs now merely sets fsuid/fsgid, and effective userid is still 0, umount2 works fine.

See also issue #1009 .