### PR TITLE
Add FOPEN_FETCH_ATTR flag for fetching attributes after an open

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -94,8 +94,12 @@ struct fuse_file_info {
 	    on close. */
 	unsigned int noflush : 1;
 
+	/** Can be filled in by open, to indicate that the file attributes
+	    should be fetched after an open */
+	unsigned int fetch_attr : 1;
+
 	/** Padding.  Reserved for future use*/
-	unsigned int padding : 23;
+	unsigned int padding : 22;
 	unsigned int padding2 : 32;
 
 	/** File handle id.  May be filled in by filesystem in create,

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -217,6 +217,9 @@
  *  - add backing_id to fuse_open_out, add FOPEN_PASSTHROUGH open flag
  *  - add FUSE_NO_EXPORT_SUPPORT init flag
  *  - add FUSE_NOTIFY_RESEND, add FUSE_HAS_RESEND init flag
+ *
+ *  7.41
+ *  - add FOPEN_FETCH_ATTR
  */
 
 #ifndef _LINUX_FUSE_H
@@ -252,7 +255,7 @@
 #define FUSE_KERNEL_VERSION 7
 
 /** Minor version number of this interface */
-#define FUSE_KERNEL_MINOR_VERSION 40
+#define FUSE_KERNEL_MINOR_VERSION 41
 
 /** The node ID of the root inode */
 #define FUSE_ROOT_ID 1
@@ -360,6 +363,7 @@ struct fuse_file_lock {
  * FOPEN_NOFLUSH: don't flush data cache on close (unless FUSE_WRITEBACK_CACHE)
  * FOPEN_PARALLEL_DIRECT_WRITES: Allow concurrent direct writes on the same inode
  * FOPEN_PASSTHROUGH: passthrough read/write io for this open file
+ * FOPEN_FETCH_ATTR: attributes are fetched after file is opened
  */
 #define FOPEN_DIRECT_IO		(1 << 0)
 #define FOPEN_KEEP_CACHE	(1 << 1)
@@ -369,6 +373,7 @@ struct fuse_file_lock {
 #define FOPEN_NOFLUSH		(1 << 5)
 #define FOPEN_PARALLEL_DIRECT_WRITES	(1 << 6)
 #define FOPEN_PASSTHROUGH	(1 << 7)
+#define FOPEN_FETCH_ATTR	(1 << 8)
 
 /**
  * INIT request/reply flags

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -423,6 +423,9 @@ static void fill_open(struct fuse_open_out *arg,
 		arg->open_flags |= FOPEN_NOFLUSH;
 	if (f->parallel_direct_writes)
 		arg->open_flags |= FOPEN_PARALLEL_DIRECT_WRITES;
+	if (f->fetch_attr)
+		arg->open_flags |= FOPEN_FETCH_ATTR;
+
 }
 
 int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param *e)


### PR DESCRIPTION
This is the corresponding libfuse change for the upstream patch https://lore.kernel.org/linux-fsdevel/20240813212149.1909627-1-joannelkoong@gmail.com/T/#u