### PR TITLE
Fix FUSE_USE_VERSION in example/notify_store_retrieve.c

### DIFF
--- a/example/notify_store_retrieve.c
+++ b/example/notify_store_retrieve.c
@@ -58,7 +58,7 @@
  */
 
 
-#define FUSE_USE_VERSION 34
+#define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 12)
 
 #include <fuse_lowlevel.h>
 #include <stdio.h>


### PR DESCRIPTION
This is an addition to commit e75d2c54a347. This example sets FUSE_USE_VERSION = 34 but uses fuse_loop_cfg_* APIs, which is not allowed since these APIs are not introduced in version 34.