### PR TITLE
Add FUSE_OPEN_GETATTR support

### DIFF
--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -217,6 +217,9 @@
  *  - add backing_id to fuse_open_out, add FOPEN_PASSTHROUGH open flag
  *  - add FUSE_NO_EXPORT_SUPPORT init flag
  *  - add FUSE_NOTIFY_RESEND, add FUSE_HAS_RESEND init flag
+ *
+ * 7.41
+* - add FUSE_OPEN_GETATTR/FUSE_OPENDIR_GETATTR
  */
 
 #ifndef _LINUX_FUSE_H
@@ -633,6 +636,8 @@ enum fuse_opcode {
 	FUSE_SYNCFS		= 50,
 	FUSE_TMPFILE		= 51,
 	FUSE_STATX		= 52,
+	FUSE_OPEN_GETATTR	= 53,
+	FUSE_OPENDIR_GETATTR	= 54,
 
 	/* CUSE specific operations */
 	CUSE_INIT		= 4096,

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1302,6 +1302,21 @@ struct fuse_lowlevel_ops {
 	 */
 	void (*lseek) (fuse_req_t req, fuse_ino_t ino, off_t off, int whence,
 		       struct fuse_file_info *fi);
+
+	/**
+	 * Open a file and also retrieve file attributes
+	 * Similar (*open) with the addition of file attributes
+	 *
+	 * Valid replies:
+	 *   fuse_reply_open_getattr
+	 *   fuse_reply_err
+	 *
+	 * @param req request handle
+	 * @param node_if the node id (called inode number for other methods)
+	 * @param fi file information
+	 */
+	void (*open_getattr)(fuse_req_t req, fuse_ino_t node_id,
+			     struct fuse_file_info *fi);
 };
 
 /**
@@ -1427,6 +1442,25 @@ int fuse_passthrough_close(fuse_req_t req, int backing_id);
  * @return zero for success, -errno for failure to send reply
  */
 int fuse_reply_open(fuse_req_t req, const struct fuse_file_info *fi);
+
+/**
+ * Reply with open parameters
+ *
+ * currently the following members of 'fi' are used:
+ *   fh, direct_io, keep_cache
+ *
+ * Possible requests:
+ *   open, opendir
+ *
+ * @param req request handle
+ * @param fi file information
+ * @param attr inode attributes
+ * @param attr_timeout timeout for the attributes
+ * @return zero for success, -errno for failure to send reply
+ */
+int fuse_reply_open_getattr(fuse_req_t req, const struct fuse_file_info *fi,
+			    const struct stat *attr,
+			    struct timespec *attr_timeout);
 
 /**
  * Reply with number of bytes written

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -201,6 +201,7 @@ FUSE_3.17 {
 		fuse_set_fail_signal_handlers;
 		fuse_log_enable_syslog;
 		fuse_log_close_syslog;
+		fuse_reply_open_getattr;
 } FUSE_3.12;
 
 # Local Variables:


### PR DESCRIPTION
Additional notes:
fuse_reply_open_getattr takes 'struct timespec *' to avoid the conversion from double to sec/nsec. Especially with timeouts in the µsec and nsec area converting to double is awkward. If needed we can add a generic function to convert from struct timespec to double.

FUSE_OPENDIR_GETATTR is not implemented yet.