### PR TITLE
remove unused headers in example/poll_client

### DIFF
--- a/example/poll_client.c
+++ b/example/poll_client.c
@@ -19,7 +19,6 @@
  * \include poll_client.c
  */
 
-#include <fuse_config.h>
 
 #include <sys/select.h>
 #include <sys/time.h>


### PR DESCRIPTION
fuse_config.h is used in libfuse internally. This may confuse developers that fuse_config.h is used in the examples.