### PR TITLE
getattr: Make use of FUSE_GETATTR_FH in lowlevel examples

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -226,12 +226,12 @@ static void sfs_init(void *userdata, fuse_conn_info *conn) {
 }
 
 
-static void sfs_getattr(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi) {
-    (void)fi;
-    Inode& inode = get_inode(ino);
+static void sfs_getattr(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi)
+{
     struct stat attr;
-    auto res = fstatat(inode.fd, "", &attr,
-                       AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW);
+    int fd = fi ? fi->fh : get_inode(ino).fd;
+
+    auto res = fstatat(fd, "", &attr, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW);
     if (res == -1) {
         fuse_reply_err(req, errno);
         return;

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -204,10 +204,11 @@ static void lo_getattr(fuse_req_t req, fuse_ino_t ino,
 	int res;
 	struct stat buf;
 	struct lo_data *lo = lo_data(req);
+	int fd = fi ? fi->fh : lo_fd(req, ino);
 
 	(void) fi;
 
-	res = fstatat(lo_fd(req, ino), "", &buf, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW);
+	res = fstatat(fd, "", &buf, AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW);
 	if (res == -1)
 		return (void) fuse_reply_err(req, errno);
 

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -303,7 +303,7 @@ struct fuse_lowlevel_ops {
 	 *
 	 * @param req request handle
 	 * @param ino the inode number
-	 * @param fi for future use, currently always NULL
+	 * @param fi file information, or NULL
 	 */
 	void (*getattr) (fuse_req_t req, fuse_ino_t ino,
 			 struct fuse_file_info *fi);


### PR DESCRIPTION
High level examples were already using it, but not lowlevel. Also update the documentation.