### PR TITLE
example/passthrough_hp: No auto FOPEN_DIRECT_IO in passthrough mode

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -871,6 +871,9 @@ static void sfs_create_open_flags(fuse_file_info *fi)
     To make parallel_direct_writes valid, need set fi->direct_io
     in current function. */
     fi->parallel_direct_writes = 1;
+
+    fi->keep_cache = (fs.timeout != 0);
+    fi->noflush = (fs.timeout == 0 && (fi->flags & O_ACCMODE) == O_RDONLY);
 }
 
 static void sfs_create(fuse_req_t req, fuse_ino_t parent, const char *name,
@@ -956,8 +959,6 @@ static void sfs_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi) {
 
     lock_guard<mutex> g {inode.m};
     inode.nopen++;
-    fi->keep_cache = (fs.timeout != 0);
-    fi->noflush = (fs.timeout == 0 && (fi->flags & O_ACCMODE) == O_RDONLY);
 
     sfs_create_open_flags(fi);
 


### PR DESCRIPTION
sfs_open and sfs_create set fi->direct_io (FOPEN_DIRECT_IO) when O_DIRECT is given, in order to benefit from a shared inode lock in kernel, i.e. to get parallel DIO writes. However, kernel side disabled passthrough when FOPEN_DIRECT_IO is set. Reads/writes had been totally failing in this case for O_DIRECT as sfs_write_buf() and sfs_read() have a sanity check. That sanity check could be modified, but for performance passthrough is better than parallel DIO, hence, we only want automatic FOPEN_DIRECT_IO for O_DIRECT when passthrough is not enabled.

Fixes: https://github.com/libfuse/libfuse/issues/1027