### PR TITLE
Allow to use struct timespec for attribute timeout

### DIFF
--- a/.github/workflows/abicheck.yml
+++ b/.github/workflows/abicheck.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Run abidiff
         run: abidiff 
+          --no-added-syms
           --headers-dir1 previous/include/ 
           --headers-dir2 current/include/ 
           previous/build/lib/libfuse3.so 

--- a/include/fuse_util.h
+++ b/include/fuse_util.h
@@ -9,7 +9,15 @@
 #define _FUSE_UTIL_H_
 
 #include <stdbool.h>
+#include <time.h>
+
+static inline bool fuse_timeout_is_zero(struct timespec *ts)
+{
+	return ts->tv_sec == 0 && ts->tv_nsec == 0;
+}
 
 int libfuse_strtol(const char *str, long *res);
+unsigned long fuse_calc_timeout_sec(const double t);
+unsigned int fuse_calc_timeout_nsec(const double t);
 
 #endif /* _FUSE_UTIL_H_ */

--- a/include/fuse_util.h
+++ b/include/fuse_util.h
@@ -1,0 +1,15 @@
+/*
+  FUSE: Filesystem in Userspace
+
+  This program can be distributed under the terms of the GNU LGPLv2.
+  See the file COPYING.LIB.
+*/
+
+#ifndef _FUSE_UTIL_H_
+#define _FUSE_UTIL_H_
+
+#include <stdbool.h>
+
+int libfuse_strtol(const char *str, long *res);
+
+#endif /* _FUSE_UTIL_H_ */

--- a/lib/compat.c
+++ b/lib/compat.c
@@ -15,14 +15,52 @@
     support version symboling
 */
 
+#include "fuse_util.h"
 #include "libfuse_config.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/stat.h>
 
 struct fuse_args;
 struct fuse_cmdline_opts;
 struct fuse_cmdline_opts;
 struct fuse_session;
 struct fuse_custom_io;
+struct fuse_file_info;
 
+typedef uint64_t fuse_nodeid_t;
+
+typedef struct fuse_req *fuse_req_t;
+
+/** Directory entry parameters supplied to fuse_reply_entry() */
+struct fuse_entry_param_old {
+	fuse_nodeid_t ino;
+
+	uint64_t generation;
+
+	struct stat attr;
+
+	double attr_timeout;
+	double entry_timeout;
+};
+
+struct fuse_entry_param_new {
+	fuse_nodeid_t ino;
+
+	uint64_t generation;
+
+	struct stat attr;
+
+	union {
+		double attr_timeout;
+		struct timespec attr_timeout_ts;
+	};
+
+	union {
+		double entry_timeout;
+		struct timespec entry_timeout_ts;
+	};
+};
 
 /**
  * Compatibility ABI symbol for systems that do not support version symboling
@@ -57,4 +95,74 @@ int fuse_session_custom_io(struct fuse_session *se,
 }
 #endif
 
+int _fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param_new *e,
+		      unsigned int timeout_as_double);
+int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param_old *e);
+int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param_old *e)
+{
+	struct fuse_entry_param_new entry = {
+		.ino = e->ino,
+		.generation = e->generation,
+		.attr = e->attr,
+		.attr_timeout = e->attr_timeout,
+		.entry_timeout = e->entry_timeout,
+	};
 
+	return _fuse_reply_entry(req, &entry, 1);
+}
+
+int _fuse_reply_create(fuse_req_t req, const struct fuse_entry_param_new *e,
+		       const struct fuse_file_info *f,
+		       unsigned int timeout_as_double);
+int fuse_reply_create(fuse_req_t req, const struct fuse_entry_param_old *e,
+		      const struct fuse_file_info *fi);
+int fuse_reply_create(fuse_req_t req, const struct fuse_entry_param_old *e,
+		      const struct fuse_file_info *fi)
+{
+	struct fuse_entry_param_new entry = {
+		.ino = e->ino,
+		.generation = e->generation,
+		.attr = e->attr,
+		.attr_timeout = e->attr_timeout,
+		.entry_timeout = e->entry_timeout,
+	};
+
+	return _fuse_reply_create(req, &entry, fi, 1);
+}
+
+int _fuse_reply_attr(fuse_req_t req, const struct stat *attr,
+		     struct timespec *attr_timeout);
+int fuse_reply_attr(fuse_req_t req, const struct stat *attr,
+		    double attr_timeout);
+int fuse_reply_attr(fuse_req_t req, const struct stat *attr,
+		    double attr_timeout)
+{
+	struct timespec attr_timeout_ts;
+
+	attr_timeout_ts.tv_sec = fuse_calc_timeout_sec(attr_timeout);
+	attr_timeout_ts.tv_nsec = fuse_calc_timeout_nsec(attr_timeout);
+
+	return _fuse_reply_attr(req, attr, &attr_timeout_ts);
+}
+
+size_t _fuse_add_direntry_plus(fuse_req_t req, char *buf, size_t bufsize,
+			       const char *name,
+			       const struct fuse_entry_param_new *e, off_t off,
+			       unsigned int timeout_as_double);
+size_t fuse_add_direntry_plus(fuse_req_t req, char *buf, size_t bufsize,
+			      const char *name,
+			      const struct fuse_entry_param_old *e, off_t off);
+size_t fuse_add_direntry_plus(fuse_req_t req, char *buf, size_t bufsize,
+			      const char *name,
+			      const struct fuse_entry_param_old *e, off_t off)
+{
+	struct fuse_entry_param_new entry = {
+		.ino = e->ino,
+		.generation = e->generation,
+		.attr = e->attr,
+		.attr_timeout = e->attr_timeout,
+		.entry_timeout = e->entry_timeout,
+	};
+
+	return _fuse_add_direntry_plus(req, buf, bufsize, name, &entry, off, 1);
+}

--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -13,7 +13,7 @@
 #include "fuse_misc.h"
 #include "fuse_kernel.h"
 #include "fuse_i.h"
-#include "util.h"
+#include "fuse_util.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -11,6 +11,8 @@
 
 #define _GNU_SOURCE
 
+#define FUSE_ATTR_TIMEOUT_AS_TIMESPEC
+
 #include "fuse_config.h"
 #include "fuse_i.h"
 #include "fuse_kernel.h"
@@ -340,22 +342,34 @@ void fuse_reply_none(fuse_req_t req)
 }
 
 static void fill_entry(struct fuse_entry_out *arg,
-		       const struct fuse_entry_param *e)
+		       const struct fuse_entry_param *e,
+		       unsigned int timeout_as_double)
 {
 	arg->nodeid = e->ino;
 	arg->generation = e->generation;
-	arg->entry_valid = fuse_calc_timeout_sec(e->entry_timeout);
-	arg->entry_valid_nsec = fuse_calc_timeout_nsec(e->entry_timeout);
-	arg->attr_valid = fuse_calc_timeout_sec(e->attr_timeout);
-	arg->attr_valid_nsec = fuse_calc_timeout_nsec(e->attr_timeout);
+	if (timeout_as_double) {
+		double entry_timeout = e->__do_not_use_entry_timeout_d;
+		double attr_timeout = e->__do_not_use_attr_timeout_d;
+
+		arg->entry_valid = fuse_calc_timeout_sec(entry_timeout);
+		arg->entry_valid_nsec = fuse_calc_timeout_nsec(entry_timeout);
+		arg->attr_valid = fuse_calc_timeout_sec(attr_timeout);
+		arg->attr_valid_nsec = fuse_calc_timeout_nsec(attr_timeout);
+	} else {
+		arg->entry_valid = e->entry_timeout.tv_sec;
+		arg->entry_valid_nsec = e->entry_timeout.tv_nsec;
+		arg->attr_valid = e->attr_timeout.tv_sec;
+		arg->attr_valid_nsec = e->attr_timeout.tv_nsec;
+	}
 	convert_stat(&e->attr, &arg->attr);
 }
 
 /* `buf` is allowed to be empty so that the proper size may be
    allocated by the caller */
-size_t fuse_add_direntry_plus(fuse_req_t req, char *buf, size_t bufsize,
-			      const char *name,
-			      const struct fuse_entry_param *e, off_t off)
+size_t _fuse_add_direntry_plus(fuse_req_t req, char *buf, size_t bufsize,
+			       const char *name,
+			       const struct fuse_entry_param *e, off_t off,
+			       unsigned int timeout_as_double)
 {
 	(void)req;
 	size_t namelen;
@@ -370,7 +384,7 @@ size_t fuse_add_direntry_plus(fuse_req_t req, char *buf, size_t bufsize,
 
 	struct fuse_direntplus *dp = (struct fuse_direntplus *) buf;
 	memset(&dp->entry_out, 0, sizeof(dp->entry_out));
-	fill_entry(&dp->entry_out, e);
+	fill_entry(&dp->entry_out, e, timeout_as_double);
 
 	struct fuse_dirent *dirent = &dp->dirent;
 	dirent->ino = e->attr.st_ino;
@@ -405,7 +419,8 @@ static void fill_open(struct fuse_open_out *arg,
 		arg->open_flags |= FOPEN_PARALLEL_DIRECT_WRITES;
 }
 
-int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param *e)
+int _fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param *e,
+		      unsigned int timeout_as_double)
 {
 	struct fuse_entry_out arg;
 	size_t size = req->se->conn.proto_minor < 9 ?
@@ -417,12 +432,13 @@ int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param *e)
 		return fuse_reply_err(req, ENOENT);
 
 	memset(&arg, 0, sizeof(arg));
-	fill_entry(&arg, e);
+	fill_entry(&arg, e, timeout_as_double);
 	return send_reply_ok(req, &arg, size);
 }
 
-int fuse_reply_create(fuse_req_t req, const struct fuse_entry_param *e,
-		      const struct fuse_file_info *f)
+int _fuse_reply_create(fuse_req_t req, const struct fuse_entry_param *e,
+		       const struct fuse_file_info *f,
+		       unsigned int timeout_as_double)
 {
 	char buf[sizeof(struct fuse_entry_out) + sizeof(struct fuse_open_out)];
 	size_t entrysize = req->se->conn.proto_minor < 9 ?
@@ -431,22 +447,23 @@ int fuse_reply_create(fuse_req_t req, const struct fuse_entry_param *e,
 	struct fuse_open_out *oarg = (struct fuse_open_out *) (buf + entrysize);
 
 	memset(buf, 0, sizeof(buf));
-	fill_entry(earg, e);
+	fill_entry(earg, e, timeout_as_double);
 	fill_open(oarg, f);
 	return send_reply_ok(req, buf,
 			     entrysize + sizeof(struct fuse_open_out));
 }
 
-int fuse_reply_attr(fuse_req_t req, const struct stat *attr,
-		    double attr_timeout)
+int _fuse_reply_attr(fuse_req_t req, const struct stat *attr,
+		     struct timespec *attr_timeout)
 {
 	struct fuse_attr_out arg;
 	size_t size = req->se->conn.proto_minor < 9 ?
-		FUSE_COMPAT_ATTR_OUT_SIZE : sizeof(arg);
+			      FUSE_COMPAT_ATTR_OUT_SIZE :
+			      sizeof(arg);
 
 	memset(&arg, 0, sizeof(arg));
-	arg.attr_valid = fuse_calc_timeout_sec(attr_timeout);
-	arg.attr_valid_nsec = fuse_calc_timeout_nsec(attr_timeout);
+	arg.attr_valid = attr_timeout->tv_sec;
+	arg.attr_valid_nsec = attr_timeout->tv_nsec;
 	convert_stat(attr, &arg.attr);
 
 	return send_reply_ok(req, &arg, size);

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -17,7 +17,7 @@
 #include "fuse_opt.h"
 #include "fuse_misc.h"
 #include "mount_util.h"
-#include "util.h"
+#include "fuse_util.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -339,36 +339,15 @@ void fuse_reply_none(fuse_req_t req)
 	fuse_free_req(req);
 }
 
-static unsigned long calc_timeout_sec(double t)
-{
-	if (t > (double) ULONG_MAX)
-		return ULONG_MAX;
-	else if (t < 0.0)
-		return 0;
-	else
-		return (unsigned long) t;
-}
-
-static unsigned int calc_timeout_nsec(double t)
-{
-	double f = t - (double) calc_timeout_sec(t);
-	if (f < 0.0)
-		return 0;
-	else if (f >= 0.999999999)
-		return 999999999;
-	else
-		return (unsigned int) (f * 1.0e9);
-}
-
 static void fill_entry(struct fuse_entry_out *arg,
 		       const struct fuse_entry_param *e)
 {
 	arg->nodeid = e->ino;
 	arg->generation = e->generation;
-	arg->entry_valid = calc_timeout_sec(e->entry_timeout);
-	arg->entry_valid_nsec = calc_timeout_nsec(e->entry_timeout);
-	arg->attr_valid = calc_timeout_sec(e->attr_timeout);
-	arg->attr_valid_nsec = calc_timeout_nsec(e->attr_timeout);
+	arg->entry_valid = fuse_calc_timeout_sec(e->entry_timeout);
+	arg->entry_valid_nsec = fuse_calc_timeout_nsec(e->entry_timeout);
+	arg->attr_valid = fuse_calc_timeout_sec(e->attr_timeout);
+	arg->attr_valid_nsec = fuse_calc_timeout_nsec(e->attr_timeout);
 	convert_stat(&e->attr, &arg->attr);
 }
 
@@ -466,8 +445,8 @@ int fuse_reply_attr(fuse_req_t req, const struct stat *attr,
 		FUSE_COMPAT_ATTR_OUT_SIZE : sizeof(arg);
 
 	memset(&arg, 0, sizeof(arg));
-	arg.attr_valid = calc_timeout_sec(attr_timeout);
-	arg.attr_valid_nsec = calc_timeout_nsec(attr_timeout);
+	arg.attr_valid = fuse_calc_timeout_sec(attr_timeout);
+	arg.attr_valid_nsec = fuse_calc_timeout_nsec(attr_timeout);
 	convert_stat(attr, &arg.attr);
 
 	return send_reply_ok(req, &arg, size);

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -203,6 +203,10 @@ FUSE_3.17 {
 		fuse_log_close_syslog;
 		fuse_calc_timeout_sec;
 		fuse_calc_timeout_nsec;
+		_fuse_reply_create;
+		_fuse_reply_entry;
+		_fuse_reply_attr;
+		_fuse_add_direntry_plus;
 } FUSE_3.12;
 
 # Local Variables:

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -201,6 +201,8 @@ FUSE_3.17 {
 		fuse_set_fail_signal_handlers;
 		fuse_log_enable_syslog;
 		fuse_log_close_syslog;
+		fuse_calc_timeout_sec;
+		fuse_calc_timeout_nsec;
 } FUSE_3.12;
 
 # Local Variables:

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -2,7 +2,7 @@ libfuse_sources = ['fuse.c', 'fuse_i.h', 'fuse_loop.c', 'fuse_loop_mt.c',
                    'fuse_lowlevel.c', 'fuse_misc.h', 'fuse_opt.c',
                    'fuse_signals.c', 'buffer.c', 'cuse_lowlevel.c',
                    'helper.c', 'modules/subdir.c', 'mount_util.c',
-                   'fuse_log.c', 'compat.c', 'util.c', 'util.h' ]
+                   'fuse_log.c', 'compat.c', 'util.c' ]
 
 if host_machine.system().startswith('linux')
    libfuse_sources += [ 'mount.c' ]

--- a/lib/util.c
+++ b/lib/util.c
@@ -33,3 +33,24 @@ int libfuse_strtol(const char *str, long *res)
 	*res = val;
 	return 0;
 }
+
+unsigned long fuse_calc_timeout_sec(const double t)
+{
+	if (t > (double)ULONG_MAX)
+		return ULONG_MAX;
+	else if (t < 0.0)
+		return 0;
+	else
+		return (unsigned long)t;
+}
+
+unsigned int fuse_calc_timeout_nsec(const double t)
+{
+	double f = t - (double)fuse_calc_timeout_sec(t);
+	if (f < 0.0)
+		return 0;
+	else if (f >= 0.999999999)
+		return 999999999;
+	else
+		return (unsigned int)(f * 1.0e9);
+}

--- a/lib/util.c
+++ b/lib/util.c
@@ -1,7 +1,15 @@
+/*
+  FUSE: Filesystem in Userspace
+
+  This program can be distributed under the terms of the GNU GPLv2.
+  See the file COPYING.
+*/
+
 #include <stdlib.h>
 #include <errno.h>
+#include <limits.h>
 
-#include "util.h"
+#include <fuse_util.h>
 
 int libfuse_strtol(const char *str, long *res)
 {
@@ -17,7 +25,7 @@ int libfuse_strtol(const char *str, long *res)
 	val = strtol(str, &endptr, base);
 
 	if (errno)
-	       return -errno;
+		return -errno;
 
 	if (endptr == str || *endptr != '\0')
 		return -EINVAL;

--- a/lib/util.h
+++ b/lib/util.h
@@ -1,1 +1,0 @@
-int libfuse_strtol(const char *str, long *res);

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -10,7 +10,7 @@
 #define _GNU_SOURCE /* for clone and strchrnul */
 #include "fuse_config.h"
 #include "mount_util.h"
-#include "util.h"
+#include <fuse_util.h>
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This is rather ugly and mostly copy-and-paste. Main change for the new v2 functions/structs is that the attribute timeout is given as struct timespec instead of double.