### PR TITLE
passthrough_hp: Use Use fuse_loop_cfg_set_max_threads()

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -1451,7 +1451,7 @@ int main(int argc, char *argv[]) {
     loop_config = fuse_loop_cfg_create();
 
     if (fs.num_threads != -1)
-        fuse_loop_cfg_set_idle_threads(loop_config, fs.num_threads);
+        fuse_loop_cfg_set_max_threads(loop_config, fs.num_threads);
 
     fuse_loop_cfg_set_clone_fd(loop_config, fs.clone_fd);
 	


### PR DESCRIPTION
fuse_loop_cfg_set_idle_threads() was by accident and
setting it might cause a performance issue.