### PR TITLE
Increase the .so version and more ABI breakage

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -600,7 +600,7 @@ static void lo_opendir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi
 	int error = ENOMEM;
 	struct lo_data *lo = lo_data(req);
 	struct lo_dirp *d;
-	int fd;
+	int fd = -1;
 
 	d = calloc(1, sizeof(struct lo_dirp));
 	if (d == NULL)

--- a/include/cuse_lowlevel.h
+++ b/include/cuse_lowlevel.h
@@ -31,11 +31,14 @@ extern "C" {
 struct fuse_session;
 
 struct cuse_info {
-	unsigned	dev_major;
-	unsigned	dev_minor;
-	unsigned	dev_info_argc;
+	uint32_t	flags;
+	uint32_t	dev_major;
+	uint32_t	dev_minor;
+	uint32_t	dev_info_argc;
 	const char	**dev_info_argv;
-	unsigned	flags;
+
+	/* for future additions and ABI compatibility */
+	uint64_t	reserved[16];
 };
 
 /*

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <sys/uio.h>
+#include <assert.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,28 +98,39 @@ typedef int (*fuse_fill_dir_t) (void *buf, const char *name,
  *
  * Note: this data structure is ABI sensitive, new options have to be
  * appended at the end of the structure
+ *
+ * Note: This structure is ABI sensitive, only add new fields in reserved
+ *       bits.
  */
 struct fuse_config {
 	/**
 	 * If `set_gid` is non-zero, the st_gid attribute of each file
 	 * is overwritten with the value of `gid`.
 	 */
-	int set_gid;
-	unsigned int gid;
+	int32_t set_gid;
+	uint32_t gid;
 
 	/**
 	 * If `set_uid` is non-zero, the st_uid attribute of each file
 	 * is overwritten with the value of `uid`.
 	 */
-	int set_uid;
-	unsigned int uid;
+	int32_t set_uid;
+	uint32_t uid;
 
 	/**
 	 * If `set_mode` is non-zero, the any permissions bits set in
 	 * `umask` are unset in the st_mode attribute of each file.
 	 */
-	int set_mode;
-	unsigned int umask;
+	int32_t set_mode;
+	uint32_t umask;
+
+	/**
+	 * `fmask` and `dmask` function the same way as `umask`, but apply
+	 * to files and directories separately. If non-zero, `fmask` and
+	 * `dmask` take precedence over the `umask` setting.
+	 */
+	uint32_t fmask;
+	uint32_t dmask;
 
 	/**
 	 * The timeout in seconds for which name lookups will be
@@ -145,14 +157,14 @@ struct fuse_config {
 	/**
 	 * Allow requests to be interrupted
 	 */
-	int intr;
+	int32_t intr;
 
 	/**
 	 * Specify which signal number to send to the filesystem when
 	 * a request is interrupted.  The default is hardcoded to
 	 * USR1.
 	 */
-	int intr_signal;
+	int32_t intr_signal;
 
 	/**
 	 * Normally, FUSE assigns inodes to paths only for as long as
@@ -164,7 +176,7 @@ struct fuse_config {
 	 * A number of -1 means that inodes will be remembered for the
 	 * entire life-time of the file-system process.
 	 */
-	int remember;
+	int32_t remember;
 
 	/**
 	 * The default behavior is that if an open file is deleted,
@@ -182,7 +194,7 @@ struct fuse_config {
 	 * ENOENT): read(2), write(2), fsync(2), close(2), f*xattr(2),
 	 * ftruncate(2), fstat(2), fchmod(2), fchown(2)
 	 */
-	int hard_remove;
+	uint8_t hard_remove;
 
 	/**
 	 * Honor the st_ino field in the functions getattr() and
@@ -195,7 +207,7 @@ struct fuse_config {
 	 * Note that this does *not* affect the inode that libfuse 
 	 * and the kernel use internally (also called the "nodeid").
 	 */
-	int use_ino;
+	uint8_t use_ino;
 
 	/**
 	 * If use_ino option is not given, still try to fill in the
@@ -204,7 +216,7 @@ struct fuse_config {
 	 * found there will be used.  Otherwise it will be set to -1.
 	 * If use_ino option is given, this option is ignored.
 	 */
-	int readdir_ino;
+	uint8_t readdir_ino;
 
 	/**
 	 * This option disables the use of page cache (file content cache)
@@ -223,7 +235,7 @@ struct fuse_config {
 	 * `direct_io` field of `struct fuse_file_info` - overwriting
 	 * any value that was put there by the file system.
 	 */
-	int direct_io;
+	uint8_t direct_io;
 
 	/**
 	 * This option disables flushing the cache of the file
@@ -242,7 +254,7 @@ struct fuse_config {
 	 * `keep_cache` field of `struct fuse_file_info` - overwriting
 	 * any value that was put there by the file system.
 	 */
-	int kernel_cache;
+	uint8_t kernel_cache;
 
 	/**
 	 * This option is an alternative to `kernel_cache`. Instead of
@@ -250,7 +262,7 @@ struct fuse_config {
 	 * invalidated on open(2) if if the modification time or the
 	 * size of the file has changed since it was last opened.
 	 */
-	int auto_cache;
+	uint8_t auto_cache;
 
 	/**
 	 * By default, fuse waits for all pending writes to complete
@@ -258,15 +270,7 @@ struct fuse_config {
 	 * With this option, wait and FLUSH are not done for read-only
 	 * fuse fd, similar to the behavior of NFS/SMB clients.
 	 */
-	int no_rofd_flush;
-
-	/**
-	 * The timeout in seconds for which file attributes are cached
-	 * for the purpose of checking if auto_cache should flush the
-	 * file data on open.
-	 */
-	int ac_attr_timeout_set;
-	double ac_attr_timeout;
+	uint8_t no_rofd_flush;
 
 	/**
 	 * If this option is given the file-system handlers for the
@@ -278,7 +282,7 @@ struct fuse_config {
 	 * operations the path will be provided only if the struct
 	 * fuse_file_info argument is NULL.
 	 */
-	int nullpath_ok;
+	uint8_t nullpath_ok;
 
 	/**
 	 *  Allow parallel direct-io writes to operate on the same file.
@@ -293,24 +297,37 @@ struct fuse_config {
 	 *  enabling this setting, all direct writes on the same file are
 	 *  serialized, resulting in huge data bandwidth loss).
 	 */
-	int parallel_direct_writes;
+	uint8_t parallel_direct_writes;
+
+	uint8_t padding1[3];
+
+	int32_t padding2;
+
+	/**
+	 * The timeout in seconds for which file attributes are cached
+	 * for the purpose of checking if auto_cache should flush the
+	 * file data on open.
+	 */
+	int32_t ac_attr_timeout_set;
+	double ac_attr_timeout;
+
+	/* reserved bytes for ABI compatibility */
+	uint32_t reserved[32];
 
 	/**
 	 * These 3 options are used by libfuse internally and
 	 * should not be touched.
 	 */
-	int show_help;
 	char *modules;
-	int debug;
+	uint32_t show_help;
+	uint32_t debug;
 
-	/**
-	 * `fmask` and `dmask` function the same way as `umask`, but apply
-	 * to files and directories separately. If non-zero, `fmask` and
-	 * `dmask` take precedence over the `umask` setting.
-	 */
-	unsigned int fmask;
-	unsigned int dmask;
+	/* Adding new fields might break ABI compatibility */
 };
+
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+static_assert(sizeof(struct fuse_config) == 240, "struct size must not change");
+#endif
 
 
 /**

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -24,6 +24,7 @@
 #include "fuse_log.h"
 #include <stdint.h>
 #include <sys/types.h>
+#include <assert.h>
 
 #define FUSE_MAKE_VERSION(maj, min)  ((maj) * 100 + (min))
 #define FUSE_VERSION FUSE_MAKE_VERSION(FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION)
@@ -55,48 +56,49 @@ struct fuse_file_info {
 	    the *fh* value may not match the *fh* value that would
 	    have been sent with the corresponding individual write
 	    requests if write caching had been disabled. */
-	unsigned int writepage : 1;
+	uint32_t  writepage : 1;
 
 	/** Can be filled in by open/create, to use direct I/O on this file. */
-	unsigned int direct_io : 1;
+	uint32_t  direct_io : 1;
 
 	/** Can be filled in by open and opendir. It signals the kernel that any
 	    currently cached data (ie., data that the filesystem provided the
 	    last time the file/directory was open) need not be invalidated when
 	    the file/directory is closed. */
-	unsigned int keep_cache : 1;
+	uint32_t  keep_cache : 1;
 
 	/** Can be filled by open/create, to allow parallel direct writes on this
 	    file */
-	unsigned int parallel_direct_writes : 1;
+	uint32_t  parallel_direct_writes : 1;
 
 	/** Indicates a flush operation.  Set in flush operation, also
 	    maybe set in highlevel lock operation and lowlevel release
 	    operation. */
-	unsigned int flush : 1;
+	uint32_t  flush : 1;
 
 	/** Can be filled in by open, to indicate that the file is not
 	    seekable. */
-	unsigned int nonseekable : 1;
+	uint32_t  nonseekable : 1;
 
 	/* Indicates that flock locks for this file should be
 	   released.  If set, lock_owner shall contain a valid value.
 	   May only be set in ->release(). */
-	unsigned int flock_release : 1;
+	uint32_t  flock_release : 1;
 
 	/** Can be filled in by opendir. It signals the kernel to
 	    enable caching of entries returned by readdir().  Has no
 	    effect when set in other contexts (in particular it does
 	    nothing when set by open()). */
-	unsigned int cache_readdir : 1;
+	uint32_t  cache_readdir : 1;
 
 	/** Can be filled in by open, to indicate that flush is not needed
 	    on close. */
-	unsigned int noflush : 1;
+	uint32_t  noflush : 1;
 
 	/** Padding.  Reserved for future use*/
-	unsigned int padding : 23;
-	unsigned int padding2 : 32;
+	uint32_t  padding : 23;
+    uint32_t  padding2 : 32;
+    uint32_t  padding3 : 32;
 
 	/** File handle id.  May be filled in by filesystem in create,
 	 * open, and opendir().  Available in most other file operations on the
@@ -115,8 +117,6 @@ struct fuse_file_info {
 	 * between FUSE file and backing file. */
 	int32_t backing_id;
 };
-
-
 
 /**
  * Configuration parameters passed to fuse_session_loop_mt() and
@@ -138,7 +138,7 @@ struct fuse_loop_config_v1 {
 	 * whether to use separate device fds for each thread
 	 * (may increase performance)
 	 */
-	int clone_fd;
+	uint32_t clone_fd;
 
 	/**
 	 * The maximum number of available worker threads before they
@@ -150,9 +150,8 @@ struct fuse_loop_config_v1 {
 	 * deletion overhead and performance may suffer. When set to 0, a new
 	 * thread will be created to service every operation.
 	 */
-	unsigned int max_idle_threads;
+	uint32_t  max_idle_threads;
 };
-
 
 /**************************************************************************
  * Capability bits for 'fuse_conn_info.capable' and 'fuse_conn_info.want' *
@@ -521,17 +520,17 @@ struct fuse_conn_info {
 	/**
 	 * Major version of the protocol (read-only)
 	 */
-	unsigned proto_major;
+	uint32_t  proto_major;
 
 	/**
 	 * Minor version of the protocol (read-only)
 	 */
-	unsigned proto_minor;
+	uint32_t  proto_minor;
 
 	/**
 	 * Maximum size of the write buffer
 	 */
-	unsigned max_write;
+	uint32_t  max_write;
 
 	/**
 	 * Maximum size of read requests. A value of zero indicates no
@@ -545,17 +544,17 @@ struct fuse_conn_info {
 	 * in the future, specifying the mount option will no longer
 	 * be necessary.
 	 */
-	unsigned max_read;
+	uint32_t  max_read;
 
 	/**
 	 * Maximum readahead
 	 */
-	unsigned max_readahead;
+	uint32_t  max_readahead;
 
 	/**
 	 * Capability flags that the kernel supports (read-only)
 	 */
-	unsigned capable;
+	uint32_t  capable;
 
 	/**
 	 * Capability flags that the filesystem wants to enable.
@@ -563,7 +562,7 @@ struct fuse_conn_info {
 	 * libfuse attempts to initialize this field with
 	 * reasonable default values before calling the init() handler.
 	 */
-	unsigned want;
+	uint32_t  want;
 
 	/**
 	 * Maximum number of pending "background" requests. A
@@ -593,7 +592,7 @@ struct fuse_conn_info {
 	 * call actually blocks, so these are also limited to one per
 	 * thread).
 	 */
-	unsigned max_background;
+	uint32_t  max_background;
 
 	/**
 	 * Kernel congestion threshold parameter. If the number of pending
@@ -603,7 +602,7 @@ struct fuse_conn_info {
 	 * adjust its algorithms accordingly (e.g. by putting a waiting thread
 	 * to sleep instead of using a busy-loop).
 	 */
-	unsigned congestion_threshold;
+	uint32_t  congestion_threshold;
 
 	/**
 	 * When FUSE_CAP_WRITEBACK_CACHE is enabled, the kernel is responsible
@@ -620,7 +619,7 @@ struct fuse_conn_info {
 	 * nano-second resolution. Filesystems supporting only second resolution
 	 * should set this to 1000000000.
 	 */
-	unsigned time_gran;
+	uint32_t  time_gran;
 
 	/**
 	 * When FUSE_CAP_PASSTHROUGH is enabled, this is the maximum allowed
@@ -640,7 +639,7 @@ struct fuse_conn_info {
 	 */
 #define FUSE_BACKING_STACKED_UNDER	(0)
 #define FUSE_BACKING_STACKED_OVER	(1)
-	unsigned max_backing_stack_depth;
+	uint32_t  max_backing_stack_depth;
 
 	/**
 	 * Disable FUSE_INTERRUPT requests.
@@ -650,13 +649,15 @@ struct fuse_conn_info {
 	 * 2) Return ENOSYS for the reply of FUSE_INTERRUPT request to
 	 * inform the kernel not to send the FUSE_INTERRUPT request.
 	 */
-	unsigned no_interrupt;
+	uint32_t  no_interrupt;
 
 	/**
 	 * For future use.
 	 */
-	unsigned reserved[20];
+	uint32_t  reserved[20];
 };
+static_assert(sizeof(struct fuse_conn_info) == 128,
+	      "struct size must not change");
 
 struct fuse_session;
 struct fuse_pollhandle;

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -34,7 +34,7 @@ endif
 
 fusermount_path = join_paths(get_option('prefix'), get_option('bindir'))
 libfuse = library('fuse3', libfuse_sources, version: meson.project_version(),
-                  soversion: '3', include_directories: include_dirs,
+                  soversion: '4', include_directories: include_dirs,
                   dependencies: deps, install: true,
                   link_depends: 'fuse_versionscript',
                   c_args: [ '-DFUSE_USE_VERSION=317',

--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -801,8 +801,9 @@ static int test_seekdir(void)
 	}
 
 	/* Walk until the end of directory */
-	while (de)
+	do {
 		de = readdir(dp);
+    } while (de);
 
 	/* Start from the last valid dir offset and seek backwards */
 	for (i--; i >= 0; i--) {


### PR DESCRIPTION
There had been a slight ABI breakage in 3.11 (wrong position of `struct fuse_config::no_rofd_flush`), with a similar issue in 3.14.1 (wrong position of `struct fuse_config::parallel_direct_writes`). Much worse in 3.14. is `struct fuse_file_info::parallel_direct_writes` which has the risk of causing unintended behavior (which could lead in worst cast to data corruption).
  `abi-compliance-checker` also annotates in master/3.17 several issue when comparing to 3.16.2, although most of these are false positives. 
Some of these reported issues are in `struct fuse_config`  due to extension of that struct. Typically that struct is created internally, but we still better add reserved fields and also convert from int to int32_t (similar for uint32_t) (and re-order some fields) - when we do an ABI version bump anyway.
The main ABI breakage in  3.14.1 could be handled with heuristics, but it would be not beautiful and we wouldn't know when we could disable it. Only the upcoming 3.17 has encoded the version into the lib to be prepared to handle such situations. For now we better go with an so version bump to enforce recompilation.