### PR TITLE
Initialize fuse session buffer size to consider max_pages_limit set in /proc/sys/fs/fuse

### DIFF
--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -196,7 +196,13 @@ int fuse_session_loop_mt_312(struct fuse_session *se, struct fuse_loop_config *c
 int fuse_loop_cfg_verify(struct fuse_loop_config *config);
 
 
-#define FUSE_MAX_MAX_PAGES 256
+/*
+ * This can be changed dynamically on recent kernels through the
+ * /proc/sys/fs/fuse/max_pages_limit interface.
+ *
+ * Older kernels will always use the default value.
+ */
+#define FUSE_DEFAULT_MAX_PAGES_LIMIT 256
 #define FUSE_DEFAULT_MAX_PAGES_PER_REQ 32
 
 /* room needed in buffer to accommodate header */

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2915,19 +2915,19 @@ static unsigned int get_max_pages(void)
 
 	fd = open("/proc/sys/fs/fuse/max_pages_limit", O_RDONLY);
 	if (fd < 0)
-		return FUSE_MAX_MAX_PAGES;
+		return FUSE_DEFAULT_MAX_PAGES_LIMIT;
 
 	res = read(fd, buf, sizeof(buf) - 1);
 
 	close(fd);
 
 	if (res < 0)
-		return FUSE_MAX_MAX_PAGES;
+		return FUSE_DEFAULT_MAX_PAGES_LIMIT;
 
 	buf[res] = '\0';
 
 	res = strtol(buf, NULL, 10);
-	return res < 0 ? FUSE_MAX_MAX_PAGES : res;
+	return res < 0 ? FUSE_DEFAULT_MAX_PAGES_LIMIT : res;
 }
 
 int fuse_session_receive_buf(struct fuse_session *se, struct fuse_buf *buf)


### PR DESCRIPTION
Currently in libfuse, the buffer size for a fuse session is capped at 1 MiB on a 4k page system. A recent [patch](https://lore.kernel.org/linux-fsdevel/20240923171311.1561917-1-joannelkoong@gmail.com/T/#t) upstream was merged that allows the max number of pages per fuse request to be dynamically configurable through the /proc/sys interface (/proc/sys/fs/fuse/max_pages_limit).

This commit adds support for this on the libfuse side to set the fuse session buffer to take into account the max pages limit set in /proc/sys/fs/fuse/max_pages_limit. If this sysctl does not exist (eg older kernels), it will default to old behavior (using FUSE_MAX_MAX_PAGES (256) as the max pages limit). This allows for things like bigger write buffers per request.

Testing:
* install kernel with [patch](https://lore.kernel.org/linux-fsdevel/20240923171311.1561917-1-joannelkoong@gmail.com/T/#t) applied
* echo 512 | sudo tee /proc/sys/fs/fuse/max_pages_limit
* mount fuse filesystem
* dd if=/dev/urandom of=~/fuse_mount/file.txt bs=4M count=4
* write sizes per request are 2 MiB
