### PR TITLE
Ignore mtab on android

### DIFF
--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -21,7 +21,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <paths.h>
-#if !defined( __NetBSD__) && !defined(__FreeBSD__) && !defined(__DragonFly__)
+#if !defined( __NetBSD__) && !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__ANDROID__)
 #include <mntent.h>
 #else
 #define IGNORE_MTAB


### PR DESCRIPTION
Updating the mtab on Android fails due to differences in toybox's mount command. Setting IGNORE_MTAB avoids that issue.