### PR TITLE
refactor: use fuse_session_{receive/process}_buf() instead of _int version

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4550,14 +4550,14 @@ static int fuse_session_loop_remember(struct fuse *f)
 			else
 				break;
 		} else if (res > 0) {
-			res = fuse_session_receive_buf_int(se, &fbuf, NULL);
+			res = fuse_session_receive_buf(se, &fbuf);
 
 			if (res == -EINTR)
 				continue;
 			if (res <= 0)
 				break;
 
-			fuse_session_process_buf_int(se, &fbuf, NULL);
+			fuse_session_process_buf(se, &fbuf);
 		} else {
 			timeout = fuse_clean_cache(f);
 			curr_time(&now);

--- a/lib/fuse_loop.c
+++ b/lib/fuse_loop.c
@@ -24,14 +24,14 @@ int fuse_session_loop(struct fuse_session *se)
 	};
 
 	while (!fuse_session_exited(se)) {
-		res = fuse_session_receive_buf_int(se, &fbuf, NULL);
+		res = fuse_session_receive_buf(se, &fbuf);
 
 		if (res == -EINTR)
 			continue;
 		if (res <= 0)
 			break;
 
-		fuse_session_process_buf_int(se, &fbuf, NULL);
+		fuse_session_process_buf(se, &fbuf);
 	}
 
 	free(fbuf.mem);


### PR DESCRIPTION
Use `fuse_session_{receive/process}_buf()` in lib/fuse.c and lib/fuse_loop.c instead of the `fuse_session_{receive/process}_buf_int()` APIs, as `fuse_session_{receive/process}_buf()` pass in NULL as the 3rd argument by default.

No functional changes.