### PR TITLE
Update the version to 4.0

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -887,10 +887,10 @@ int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
 		   size_t op_size, struct libfuse_version *version,
 		   void *user_data);
 #else
-int fuse_main_real_317(int argc, char *argv[], const struct fuse_operations *op,
+int fuse_main_real_400(int argc, char *argv[], const struct fuse_operations *op,
 		   size_t op_size, struct libfuse_version *version, void *user_data);
 #define fuse_main_real(argc, argv, op, op_size, version, user_data) \
-	fuse_main_real_317(argc, argv, op, op_size, version, user_data);
+	fuse_main_real_400(argc, argv, op, op_size, version, user_data);
 #endif
 
 /**
@@ -1045,12 +1045,12 @@ fuse_new(struct fuse_args *args,
 	return _fuse_new(args, op, op_size, &version, user_data);
 }
 #else /* LIBFUSE_BUILT_WITH_VERSIONED_SYMBOLS */
-struct fuse *_fuse_new_317(struct fuse_args *args,
+struct fuse *_fuse_new_400(struct fuse_args *args,
                       const struct fuse_operations *op, size_t op_size,
 		      struct libfuse_version *version,
 		      void *private_data);
 #define _fuse_new(args, op, size, version, data) \
-	_fuse_new_317(args, op, size, version, data)
+	_fuse_new_400(args, op, size, version, data)
 static inline struct fuse *
 fuse_new(struct fuse_args *args,
 	 const struct fuse_operations *op, size_t op_size,

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -2050,7 +2050,7 @@ int fuse_parse_cmdline_312(struct fuse_args *args,
  * macro should be used, which fills in the libfuse version compilation
  * is done against automatically.
  */
-struct fuse_session *_fuse_session_new_317(struct fuse_args *args,
+struct fuse_session *_fuse_session_new_400(struct fuse_args *args,
 					  const struct fuse_lowlevel_ops *op,
 					  size_t op_size,
 					  struct libfuse_version *version,
@@ -2066,13 +2066,13 @@ _fuse_session_new(struct fuse_args *args,
 		 void *userdata);
 #else
 struct fuse_session *
-_fuse_session_new_317(struct fuse_args *args,
+_fuse_session_new_400(struct fuse_args *args,
 		      const struct fuse_lowlevel_ops *op,
 		      size_t op_size,
 		      struct libfuse_version *version,
 		      void *userdata);
 #define _fuse_session_new(args, op, op_size, version, userdata)	\
-	_fuse_session_new_317(args, op, op_size, version, userdata)
+	_fuse_session_new_400(args, op, op_size, version, userdata)
 #endif
 
 /**
@@ -2123,7 +2123,7 @@ fuse_session_new(struct fuse_args *args,
  * This should mostly not be called directly, but instead the
  * fuse_session_custom_io() should be used.
  */
-int fuse_session_custom_io_317(struct fuse_session *se,
+int fuse_session_custom_io_400(struct fuse_session *se,
 			const struct fuse_custom_io *io, size_t op_size, int fd);
 
 /**
@@ -2153,17 +2153,17 @@ int fuse_session_custom_io_317(struct fuse_session *se,
  * @return -errno  if failed to allocate memory to store `io`
  *
  **/
-#if FUSE_MAKE_VERSION(3, 17) <= FUSE_USE_VERSION
+#if FUSE_MAKE_VERSION(4, 0) <= FUSE_USE_VERSION
 static inline int fuse_session_custom_io(struct fuse_session *se,
 					const struct fuse_custom_io *io, size_t op_size, int fd)
 {
-	return fuse_session_custom_io_317(se, io, op_size, fd);
+	return fuse_session_custom_io_400(se, io, op_size, fd);
 }
 #else
 static inline int fuse_session_custom_io(struct fuse_session *se,
 					const struct fuse_custom_io *io, int fd)
 {
-	return fuse_session_custom_io_317(se, io,
+	return fuse_session_custom_io_400(se, io,
 				offsetof(struct fuse_custom_io, clone_fd), fd);
 }
 #endif

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4916,12 +4916,12 @@ void fuse_stop_cleanup_thread(struct fuse *f)
  * Not supposed to be called directly, but supposed to be called
  * through the fuse_new macro
  */
-struct fuse *_fuse_new_317(struct fuse_args *args,
+struct fuse *_fuse_new_400(struct fuse_args *args,
 			   const struct fuse_operations *op,
 			   size_t op_size, struct libfuse_version *version,
 			   void *user_data);
-FUSE_SYMVER("_fuse_new_317", "_fuse_new@@FUSE_3.17")
-struct fuse *_fuse_new_317(struct fuse_args *args,
+FUSE_SYMVER("_fuse_new_400", "_fuse_new@@FUSE_4.0")
+struct fuse *_fuse_new_400(struct fuse_args *args,
 			   const struct fuse_operations *op,
 			   size_t op_size, struct libfuse_version *version,
 			   void *user_data)
@@ -5090,7 +5090,7 @@ struct fuse *_fuse_new_30(struct fuse_args *args,
 		fuse_lib_help(args);
 		return NULL;
 	} else
-		return _fuse_new_317(args, op, op_size, version, user_data);
+		return _fuse_new_400(args, op, op_size, version, user_data);
 }
 
 /* ABI compat version */
@@ -5104,7 +5104,7 @@ struct fuse *fuse_new_31(struct fuse_args *args,
 		/* unknown version */
 	struct libfuse_version version = { 0 };
 
-	return _fuse_new_317(args, op, op_size, &version, user_data);
+	return _fuse_new_400(args, op, op_size, &version, user_data);
 }
 
 /*

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3246,8 +3246,8 @@ int fuse_session_receive_buf_internal(struct fuse_session *se,
 	return _fuse_session_receive_buf(se, buf, ch, true);
 }
 
-FUSE_SYMVER("_fuse_session_new_317", "_fuse_session_new@@FUSE_3.17")
-struct fuse_session *_fuse_session_new_317(struct fuse_args *args,
+FUSE_SYMVER("_fuse_session_new_400", "_fuse_session_new@@FUSE_4.0")
+struct fuse_session *_fuse_session_new_400(struct fuse_args *args,
 					  const struct fuse_lowlevel_ops *op,
 					  size_t op_size,
 					  struct libfuse_version *version,
@@ -3364,11 +3364,11 @@ struct fuse_session *fuse_session_new_30(struct fuse_args *args,
 	/* unknown version */
 	struct libfuse_version version = { 0 };
 
-	return _fuse_session_new_317(args, op, op_size, &version, userdata);
+	return _fuse_session_new_400(args, op, op_size, &version, userdata);
 }
 
-FUSE_SYMVER("fuse_session_custom_io_317", "fuse_session_custom_io@@FUSE_3.17")
-int fuse_session_custom_io_317(struct fuse_session *se,
+FUSE_SYMVER("fuse_session_custom_io_400", "fuse_session_custom_io@@FUSE_4.0")
+int fuse_session_custom_io_400(struct fuse_session *se,
 				const struct fuse_custom_io *io, size_t op_size, int fd)
 {
 	if (sizeof(struct fuse_custom_io) < op_size) {
@@ -3413,7 +3413,7 @@ FUSE_SYMVER("fuse_session_custom_io_30", "fuse_session_custom_io@FUSE_3.0")
 int fuse_session_custom_io_30(struct fuse_session *se,
 			const struct fuse_custom_io *io, int fd)
 {
-	return fuse_session_custom_io_317(se, io,
+	return fuse_session_custom_io_400(se, io,
 			offsetof(struct fuse_custom_io, clone_fd), fd);
 }
 

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -187,17 +187,17 @@ FUSE_3.12 {
 		fuse_lowlevel_notify_expire_entry;
 } FUSE_3.4;
 
-FUSE_3.17 {
+FUSE_4.0 {
 	global:
-		_fuse_session_new_317;
+		_fuse_session_new_400;
 		_fuse_new;
 		_fuse_new_30;
-		_fuse_new_317;
-		fuse_main_real_317;
+		_fuse_new_400;
+		fuse_main_real_400;
 		fuse_passthrough_open;
 		fuse_passthrough_close;
 		fuse_session_custom_io_30;
-		fuse_session_custom_io_317;
+		fuse_session_custom_io_400;
 		fuse_set_fail_signal_handlers;
 		fuse_log_enable_syslog;
 		fuse_log_close_syslog;

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -304,10 +304,10 @@ int fuse_daemonize(int foreground)
 	return 0;
 }
 
-int fuse_main_real_317(int argc, char *argv[], const struct fuse_operations *op,
+int fuse_main_real_400(int argc, char *argv[], const struct fuse_operations *op,
 		   size_t op_size, struct libfuse_version *version, void *user_data);
-FUSE_SYMVER("fuse_main_real_317", "fuse_main_real@@FUSE_3.17")
-int fuse_main_real_317(int argc, char *argv[], const struct fuse_operations *op,
+FUSE_SYMVER("fuse_main_real_400", "fuse_main_real@@FUSE_4.0")
+int fuse_main_real_400(int argc, char *argv[], const struct fuse_operations *op,
 		   size_t op_size, struct libfuse_version *version, void *user_data)
 {
 	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
@@ -404,7 +404,7 @@ int fuse_main_real_30(int argc, char *argv[], const struct fuse_operations *op,
 {
 	struct libfuse_version version = { 0 };
 
-	return fuse_main_real_317(argc, argv, op, op_size, &version, user_data);
+	return fuse_main_real_400(argc, argv, op, op_size, &version, user_data);
 }
 
 void fuse_apply_conn_info_opts(struct fuse_conn_info_opts *opts,

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -37,7 +37,7 @@ libfuse = library('fuse3', libfuse_sources, version: meson.project_version(),
                   soversion: '4', include_directories: include_dirs,
                   dependencies: deps, install: true,
                   link_depends: 'fuse_versionscript',
-                  c_args: [ '-DFUSE_USE_VERSION=317',
+                  c_args: [ '-DFUSE_USE_VERSION=400',
                             '-DFUSERMOUNT_DIR="@0@"'.format(fusermount_path) ],
                   link_args: ['-Wl,--version-script,' + meson.current_source_dir()
                               + '/fuse_versionscript' ])

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libfuse3', ['c'], version: '3.17.0',
+project('libfuse3', ['c'], version: '4.0.0',
         meson_version: '>= 0.51',
         default_options: [
             'buildtype=debugoptimized',


### PR DESCRIPTION
We might just follow linux kernel scheme and avoid high versions, by arbitrary increasing libfuse versionsn.
Additioanlly we have an so version bump - increasing to libfuse4 is even more justified.