### PR TITLE
passthrough_ll: set correct keep_cache flag in opendir

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -652,8 +652,10 @@ static void lo_opendir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi
 	d->entry = NULL;
 
 	fi->fh = (uintptr_t) d;
-	if (lo->cache == CACHE_ALWAYS)
+	if (lo->cache != CACHE_NEVER)
 		fi->cache_readdir = 1;
+	if (lo->cache == CACHE_ALWAYS)
+		fi->keep_cache = 1;
 	fuse_reply_open(req, fi);
 	return;
 


### PR DESCRIPTION
In cache=always mode, set keep_cache flag in opendir(), same as done in open() and same as passthrough_hp does in opendir().

In the default cache=auto mode, use readdir cache, but do not set keep_cache, same as regular files use page cache for an open file, but do not keep_cache for a new open.

Note that passthrough_hp by default behaves the same as passthrough_ll cache=always mode and supports the cache=never mode with --nocache, but it does not support the equivalent of cache=auto mode.