### PR TITLE
Fix build of memfs_ll without manual meson reconfigure

### DIFF
--- a/example/meson.build
+++ b/example/meson.build
@@ -37,6 +37,7 @@ if not platform.endswith('bsd') and platform != 'dragonfly' and add_languages('c
                install: false)
     executable('memfs_ll', 'memfs_ll.cc',
                dependencies: [ thread_dep, libfuse_dep ],
+               cpp_args : '-std=c++17',
                install: false)
 endif
 


### PR DESCRIPTION
After pulling latest code, memfs_ll build would fail because it builds with C++11.

Changing the default of cpp_std in meson.build is not enough to fix this problem even if user runs 'meson setup --reconfigure'.

I had to run 'meson setup -Dcpp_std= --reconfigure' to fix the build as mentioned in this meson issue:
https://github.com/mesonbuild/meson/issues/8062#issuecomment-1568249672