### PR TITLE
Fixes for commit 58f85bfa9b7d "Add in the libfuse version a program was compiled with"

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -24,7 +24,7 @@ jobs:
         git rev-list --reverse $base_commit..HEAD | while read commit; do
           subject=$(git log -1 --format=%s $commit)
           echo "Checking commit: $commit - $subject"
-          if ! ./checkpatch.pl --no-tree --ignore MAINTAINERS,SPDX_LICENSE_TAG,COMMIT_MESSAGE,FILE_PATH_CHANGES,EMAIL_SUBJECT -g $commit; then
+          if ! ./checkpatch.pl --no-tree --ignore MAINTAINERS,SPDX_LICENSE_TAG,COMMIT_MESSAGE,FILE_PATH_CHANGES,EMAIL_SUBJECT,AVOID_EXTERNS,GIT_COMMIT_ID -g $commit; then
             echo "checkpatch.pl found issues in commit $commit - $subject"
             exit 1
           fi

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -76,7 +76,7 @@ enum fuse_fill_dir_flags {
  * stream. It does not need to be the actual physical position. A
  * value of zero is reserved to indicate that seeking in directories
  * is not supported.
- * 
+ *
  * @param buf the buffer passed to the readdir() operation
  * @param name the file name of the directory entry
  * @param stbuf file attributes, can be NULL
@@ -192,7 +192,7 @@ struct fuse_config {
 	 * have to guarantee uniqueness, however some applications
 	 * rely on this value being unique for the whole filesystem.
 	 *
-	 * Note that this does *not* affect the inode that libfuse 
+	 * Note that this does *not* affect the inode that libfuse
 	 * and the kernel use internally (also called the "nodeid").
 	 */
 	int32_t use_ino;
@@ -522,9 +522,9 @@ struct fuse_operations {
 	 *
 	 * Flush is called on each close() of a file descriptor, as opposed to
 	 * release which is called on the close of the last file descriptor for
-	 * a file.  Under Linux, errors returned by flush() will be passed to 
+	 * a file.  Under Linux, errors returned by flush() will be passed to
 	 * userspace as errors from close(), so flush() is a good place to write
-	 * back any cached dirty data. However, many applications ignore errors 
+	 * back any cached dirty data. However, many applications ignore errors
 	 * on close(), and on non-Linux systems, close() may succeed even if flush()
 	 * returns an error. For these reasons, filesystems should not assume
 	 * that errors returned by flush will ever be noticed or even
@@ -978,11 +978,6 @@ fuse_main(int argc, char *argv[], const struct fuse_operations *op,
  */
 void fuse_lib_help(struct fuse_args *args);
 
-struct fuse *_fuse_new(struct fuse_args *args,
-		       const struct fuse_operations *op,
-		       size_t op_size, struct libfuse_version *version,
-		       void *user_data);
-
 /**
  * Create a new FUSE filesystem.
  *
@@ -1021,6 +1016,12 @@ fuse_new(struct fuse_args *args,
 	 const struct fuse_operations *op, size_t op_size,
 	 void *user_data)
 {
+	/* not declared globally, to restrict usage of this function */
+	struct fuse *_fuse_new(struct fuse_args *args,
+			       const struct fuse_operations *op, size_t op_size,
+			       struct libfuse_version *version,
+			       void *user_data);
+
 	struct libfuse_version version = {
 		.major = FUSE_MAJOR_VERSION,
 		.minor = FUSE_MINOR_VERSION,
@@ -1043,6 +1044,12 @@ fuse_new(struct fuse_args *args,
 		.hotfix = FUSE_HOTFIX_VERSION,
 		.padding = 0
 	};
+
+	/* not declared globally, to restrict usage of this function */
+	struct fuse *_fuse_new(struct fuse_args *args,
+			       const struct fuse_operations *op, size_t op_size,
+			       struct libfuse_version *version,
+			       void *user_data);
 
 	return _fuse_new(args, op, op_size, &version, user_data);
 }

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -2045,26 +2045,8 @@ int fuse_parse_cmdline_312(struct fuse_args *args,
 #endif
 #endif
 
-/*
- * This should mostly not be called directly, but instead the fuse_session_new()
- * macro should be used, which fills in the libfuse version compilation
- * is done against automatically.
- */
-struct fuse_session *_fuse_session_new_317(struct fuse_args *args,
-					  const struct fuse_lowlevel_ops *op,
-					  size_t op_size,
-					  struct libfuse_version *version,
-					  void *userdata);
-
 /* Do not call this directly, but only through fuse_session_new() */
-#if (defined(LIBFUSE_BUILT_WITH_VERSIONED_SYMBOLS))
-struct fuse_session *
-_fuse_session_new(struct fuse_args *args,
-		 const struct fuse_lowlevel_ops *op,
-		 size_t op_size,
-		 struct libfuse_version *version,
-		 void *userdata);
-#else
+#if (!defined(LIBFUSE_BUILT_WITH_VERSIONED_SYMBOLS))
 struct fuse_session *
 _fuse_session_new_317(struct fuse_args *args,
 		      const struct fuse_lowlevel_ops *op,
@@ -2115,6 +2097,12 @@ fuse_session_new(struct fuse_args *args,
 		.hotfix = FUSE_HOTFIX_VERSION,
 		.padding = 0
 	};
+
+	/* not declared globally, to restrict usage of this function */
+	struct fuse_session *_fuse_session_new(
+		struct fuse_args *args, const struct fuse_lowlevel_ops *op,
+		size_t op_size, struct libfuse_version *version,
+		void *userdata);
 
 	return _fuse_session_new(args, op, op_size, &version, userdata);
 }

--- a/lib/compat.c
+++ b/lib/compat.c
@@ -17,12 +17,15 @@
 
 #include "libfuse_config.h"
 
+#include <stddef.h>
+
 struct fuse_args;
 struct fuse_cmdline_opts;
 struct fuse_cmdline_opts;
 struct fuse_session;
 struct fuse_custom_io;
-
+struct fuse_operations;
+struct fuse_lowlevel_ops;
 
 /**
  * Compatibility ABI symbol for systems that do not support version symboling
@@ -36,7 +39,7 @@ struct fuse_custom_io;
 #undef fuse_parse_cmdline
 #endif
 int fuse_parse_cmdline_30(struct fuse_args *args,
-                           struct fuse_cmdline_opts *opts);
+			  struct fuse_cmdline_opts *opts);
 int fuse_parse_cmdline(struct fuse_args *args,
 		       struct fuse_cmdline_opts *opts);
 int fuse_parse_cmdline(struct fuse_args *args,
@@ -55,6 +58,30 @@ int fuse_session_custom_io(struct fuse_session *se,
 {
 	return fuse_session_custom_io_30(se, io, fd);
 }
+
+int fuse_main_real_30(int argc, char *argv[], const struct fuse_operations *op,
+		      size_t op_size, void *user_data);
+int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
+		   size_t op_size, void *user_data);
+int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
+		   size_t op_size, void *user_data)
+{
+	return fuse_main_real_30(argc, argv, op, op_size, user_data);
+}
+
+struct fuse_session *fuse_session_new_30(struct fuse_args *args,
+					 const struct fuse_lowlevel_ops *op,
+					 size_t op_size, void *userdata);
+struct fuse_session *fuse_session_new(struct fuse_args *args,
+				      const struct fuse_lowlevel_ops *op,
+				      size_t op_size, void *userdata);
+struct fuse_session *fuse_session_new(struct fuse_args *args,
+				      const struct fuse_lowlevel_ops *op,
+				      size_t op_size, void *userdata)
+{
+	return fuse_session_new_30(args, op, op_size, userdata);
+}
+
 #endif
 
 

--- a/lib/compat.c
+++ b/lib/compat.c
@@ -18,6 +18,7 @@
 #include "libfuse_config.h"
 
 #include <stddef.h>
+#include <stdint.h>
 
 struct fuse_args;
 struct fuse_cmdline_opts;
@@ -59,16 +60,6 @@ int fuse_session_custom_io(struct fuse_session *se,
 	return fuse_session_custom_io_30(se, io, fd);
 }
 
-int fuse_main_real_30(int argc, char *argv[], const struct fuse_operations *op,
-		      size_t op_size, void *user_data);
-int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
-		   size_t op_size, void *user_data);
-int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
-		   size_t op_size, void *user_data)
-{
-	return fuse_main_real_30(argc, argv, op, op_size, user_data);
-}
-
 struct fuse_session *fuse_session_new_30(struct fuse_args *args,
 					 const struct fuse_lowlevel_ops *op,
 					 size_t op_size, void *userdata);
@@ -82,6 +73,14 @@ struct fuse_session *fuse_session_new(struct fuse_args *args,
 	return fuse_session_new_30(args, op, op_size, userdata);
 }
 
-#endif
+#endif /* LIBFUSE_BUILT_WITH_VERSIONED_SYMBOLS */
 
-
+int fuse_main_real_30(int argc, char *argv[], const struct fuse_operations *op,
+		      size_t op_size, void *user_data);
+int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
+		   size_t op_size, void *user_data);
+int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op,
+		   size_t op_size, void *user_data)
+{
+	return fuse_main_real_30(argc, argv, op, op_size, user_data);
+}

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -5009,6 +5009,12 @@ struct fuse *_fuse_new_317(struct fuse_args *args,
 	f->conf.readdir_ino = 1;
 #endif
 
+	/* not declared globally, to restrict usage of this function */
+	struct fuse_session *_fuse_session_new(
+		struct fuse_args *args, const struct fuse_lowlevel_ops *op,
+		size_t op_size, struct libfuse_version *version,
+		void *userdata);
+
 	f->se = _fuse_session_new(args, &llop, sizeof(llop), version, f);
 	if (f->se == NULL)
 		goto out_free_fs;

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3248,10 +3248,15 @@ int fuse_session_receive_buf_internal(struct fuse_session *se,
 
 FUSE_SYMVER("_fuse_session_new_317", "_fuse_session_new@@FUSE_3.17")
 struct fuse_session *_fuse_session_new_317(struct fuse_args *args,
-					  const struct fuse_lowlevel_ops *op,
-					  size_t op_size,
-					  struct libfuse_version *version,
-					  void *userdata)
+					   const struct fuse_lowlevel_ops *op,
+					   size_t op_size,
+					   struct libfuse_version *version,
+					   void *userdata);
+struct fuse_session *_fuse_session_new_317(struct fuse_args *args,
+					   const struct fuse_lowlevel_ops *op,
+					   size_t op_size,
+					   struct libfuse_version *version,
+					   void *userdata)
 {
 	int err;
 	struct fuse_session *se;

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -189,10 +189,10 @@ FUSE_3.12 {
 
 FUSE_3.17 {
 	global:
+		fuse_main_real_317;
 #if !defined(LIBFUSE_BUILT_WITH_VERSIONED_SYMBOLS)
 		_fuse_session_new_317;
 		_fuse_new_317;
-		fuse_main_real_317;
 #endif
 		fuse_passthrough_open;
 		fuse_passthrough_close;

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -189,11 +189,11 @@ FUSE_3.12 {
 
 FUSE_3.17 {
 	global:
+#if !defined(LIBFUSE_BUILT_WITH_VERSIONED_SYMBOLS)
 		_fuse_session_new_317;
-		_fuse_new;
-		_fuse_new_30;
 		_fuse_new_317;
 		fuse_main_real_317;
+#endif
 		fuse_passthrough_open;
 		fuse_passthrough_close;
 		fuse_session_custom_io_30;

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -304,9 +304,10 @@ int fuse_daemonize(int foreground)
 	return 0;
 }
 
+/* Not symboled, as not part of the official API */
 int fuse_main_real_317(int argc, char *argv[], const struct fuse_operations *op,
-		   size_t op_size, struct libfuse_version *version, void *user_data);
-FUSE_SYMVER("fuse_main_real_317", "fuse_main_real@@FUSE_3.17")
+		       size_t op_size, struct libfuse_version *version,
+		       void *user_data);
 int fuse_main_real_317(int argc, char *argv[], const struct fuse_operations *op,
 		   size_t op_size, struct libfuse_version *version, void *user_data)
 {
@@ -400,14 +401,13 @@ out1:
 	return res;
 }
 
+/* Not symboled, as not part of the official API */
 int fuse_main_real_30(int argc, char *argv[], const struct fuse_operations *op,
 		      size_t op_size, void *user_data);
-FUSE_SYMVER("fuse_main_real_30", "fuse_main_real@FUSE_3.0")
 int fuse_main_real_30(int argc, char *argv[], const struct fuse_operations *op,
 		      size_t op_size, void *user_data)
 {
 	struct libfuse_version version = { 0 };
-
 	return fuse_main_real_317(argc, argv, op, op_size, &version, user_data);
 }
 

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -344,6 +344,10 @@ int fuse_main_real_317(int argc, char *argv[], const struct fuse_operations *op,
 		goto out1;
 	}
 
+	struct fuse *_fuse_new(struct fuse_args *args,
+			       const struct fuse_operations *op, size_t op_size,
+			       struct libfuse_version *version,
+			       void *user_data);
 	fuse = _fuse_new(&args, op, op_size, version, user_data);
 	if (fuse == NULL) {
 		res = 3;


### PR DESCRIPTION
1) Some compat functions for libfuse without versioned symbols were missing

2) Related to issue #1092 we should avoid exporting any function that does not absolutely need to be exported - some random users might pick it up and use it. Same goes for function declarations - internal functions should not be declared globally. Too late for fuse_main_real and other as used in issue #1092  , but at least for new functions we can avoid that.