### PR TITLE
Identify the FD hold by parent process

### DIFF
--- a/lib/mount.c
+++ b/lib/mount.c
@@ -48,6 +48,7 @@
 
 #define FUSERMOUNT_PROG		"fusermount3"
 #define FUSE_COMMFD_ENV		"_FUSE_COMMFD"
+#define FUSE_COMMFD2_ENV	"_FUSE_COMMFD2"
 
 #ifndef MS_DIRSYNC
 #define MS_DIRSYNC 128
@@ -367,6 +368,14 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
 	char arg_fd_entry[30];
 	snprintf(arg_fd_entry, sizeof(arg_fd_entry), "%i", fds[0]);
 	setenv(FUSE_COMMFD_ENV, arg_fd_entry, 1);
+	/*
+	 * This helps to identify the FD hold by parent process.
+	 * In auto-unmount case, parent process can close this FD explicitly to do unmount.
+	 * The FD[1] can be got via getenv(FUSE_COMMFD2_ENV).
+	 * One potential use case is to satisfy FD-Leak checks.
+	 */
+	snprintf(arg_fd_entry, sizeof(arg_fd_entry), "%i", fds[1]);
+	setenv(FUSE_COMMFD2_ENV, arg_fd_entry, 1);
 
 	char const *const argv[] = {
 		FUSERMOUNT_PROG,
@@ -431,6 +440,14 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
 	char arg_fd_entry[30];
 	snprintf(arg_fd_entry, sizeof(arg_fd_entry), "%i", fds[0]);
 	setenv(FUSE_COMMFD_ENV, arg_fd_entry, 1);
+	/*
+	 * This helps to identify the FD hold by parent process.
+	 * In auto-unmount case, parent process can close this FD explicitly to do unmount.
+	 * The FD[1] can be got via getenv(FUSE_COMMFD2_ENV).
+	 * One potential use case is to satisfy FD-Leak checks.
+	 */
+	snprintf(arg_fd_entry, sizeof(arg_fd_entry), "%i", fds[1]);
+	setenv(FUSE_COMMFD2_ENV, arg_fd_entry, 1);
 
 	char const *const argv[] = {
 		FUSERMOUNT_PROG,


### PR DESCRIPTION
### Issue:
There is no directly way to get the FD hold by parent process which asked do fuse mount.
Known Issue on the FD: [fuse "-o auto_unmount" doesn't close fds[1] upon exiting the fuse loop](https://github.com/libfuse/libfuse/issues/432#top)

### Use Case:
For auto_unmount case, identify the FD can easy to close the FD and make automatically unmount manually and explicitly.
In auto-unmount case, parent process can close this FD explicitly to do unmount.
The FD[1] can be got via `getenv(FUSE_COMMFD2_ENV)`.
One potential use case is to satisfy FD-Leak checks.

### Solution:
Add an extra env _FUSE_COMMFD2 to store the FD. This will provide a easy way to get the FD via FUSE_COMMFD2_ENV.