### PR TITLE
Fix possible 64 bits value truncation

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1999,8 +1999,6 @@ static bool want_flags_valid(uint64_t capable, uint64_t want)
 
 /**
  * Get the wanted capability flags, converting from old format if necessary
- * Also applies the first 32 bits of capable_ext to capable
- *
  */
 static inline int convert_to_conn_want_ext(struct fuse_conn_info *conn,
 					   uint64_t want_ext_default)

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2178,7 +2178,7 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 
 	se->got_init = 1;
 	if (se->op.init) {
-		uint32_t want_ext_default = se->conn.want_ext;
+		uint64_t want_ext_default = se->conn.want_ext;
 		int rc;
 
 		// Apply the first 32 bits of capable_ext to capable


### PR DESCRIPTION
The first patch fixes a 64 bit value truncation.

The second patch is just a trivial change which removes an incorrect comment.