### PR TITLE
Build fixes for -Og

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -634,7 +634,7 @@ static void lo_opendir(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi
 	int error = ENOMEM;
 	struct lo_data *lo = lo_data(req);
 	struct lo_dirp *d;
-	int fd;
+	int fd = -1;
 
 	d = calloc(1, sizeof(struct lo_dirp));
 	if (d == NULL)

--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -773,7 +773,7 @@ static int test_seekdir(void)
 	int i;
 	int res;
 	DIR *dp;
-	struct dirent *de;
+	struct dirent *de = NULL;
 
 	start_test("seekdir");
 	res = create_dir(testdir, testdir_files);


### PR DESCRIPTION
Cleaning... 18 files.
[35/69] Compiling C object example/passthrough_ll.p/passthrough_ll.c.o ../example/passthrough_ll.c: In function ‘lo_opendir’: ../example/passthrough_ll.c:666:20: warning: ‘fd’ may be used uninitialized [-Wmaybe-uninitialized]
  666 |                 if (fd != -1)
      |                    ^
../example/passthrough_ll.c:637:13: note: ‘fd’ was declared here
  637 |         int fd;
      |             ^~
[38/69] Compiling C object test/test_syscalls.p/test_syscalls.c.o
../test/test_syscalls.c: In function ‘test_seekdir’:
../test/test_syscalls.c:804:16: warning: ‘de’ may be used uninitialized [-Wmaybe-uninitialized]
  804 |         while (de)
      |                ^~
../test/test_syscalls.c:776:24: note: ‘de’ was declared here
  776 |         struct dirent *de;
      |                        ^~

These are actually valid.