### PR TITLE
FreeBSD stuff

### DIFF
--- a/lib/mount_bsd.c
+++ b/lib/mount_bsd.c
@@ -17,9 +17,7 @@
 #include <sys/param.h>
 #include "fuse_mount_compat.h"
 
-#include <sys/stat.h>
 #include <sys/wait.h>
-#include <sys/user.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -27,8 +25,6 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <string.h>
-#include <paths.h>
-#include <limits.h>
 
 #define FUSERMOUNT_PROG		"mount_fusefs"
 #define FUSE_DEV_TRUNK		"/dev/fuse"

--- a/lib/mount_bsd.c
+++ b/lib/mount_bsd.c
@@ -12,6 +12,7 @@
 #include "fuse_i.h"
 #include "fuse_misc.h"
 #include "fuse_opt.h"
+#include "util.h"
 
 #include <sys/param.h>
 #include "fuse_mount_compat.h"
@@ -151,7 +152,7 @@ static int init_backgrounded(void)
 static int fuse_mount_core(const char *mountpoint, const char *opts)
 {
 	const char *mountprog = FUSERMOUNT_PROG;
-	int fd;
+	long fd;
 	char *fdnam, *dev;
 	pid_t pid, cpid;
 	int status;
@@ -161,7 +162,7 @@ static int fuse_mount_core(const char *mountpoint, const char *opts)
 
 	if (fdnam) {
 		err = libfuse_strtol(fdnam, &fd);
-		if (err) {
+		if (err || fd < 0) {
 			fuse_log(FUSE_LOG_ERR, "invalid value given in FUSE_DEV_FD\n");
 			return -1;
 		}
@@ -216,7 +217,7 @@ mount:
 			
 			if (! fdnam)
 			{
-				ret = asprintf(&fdnam, "%d", fd); 
+				ret = asprintf(&fdnam, "%ld", fd);
 				if(ret == -1)
 				{
 					perror("fuse: failed to assemble mount arguments");

--- a/lib/mount_bsd.c
+++ b/lib/mount_bsd.c
@@ -189,7 +189,7 @@ mount:
 			const char *argv[32];
 			int a = 0;
 			int ret = -1; 
-			
+
 			if (! fdnam)
 			{
 				ret = asprintf(&fdnam, "%ld", fd);
@@ -197,7 +197,7 @@ mount:
 				{
 					perror("fuse: failed to assemble mount arguments");
 					close(fd);
-					exit(1);
+					_exit(EXIT_FAILURE);
 				}
 			}
 
@@ -212,10 +212,10 @@ mount:
 			execvp(mountprog, (char **) argv);
 			perror("fuse: failed to exec mount program");
 			free(fdnam);
-			exit(1);
+			_exit(EXIT_FAILURE);
 		}
 
-		exit(0);
+		_exit(EXIT_SUCCESS);
 	}
 
 	if (waitpid(cpid, &status, 0) == -1 || WEXITSTATUS(status) != 0) {

--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -1065,7 +1065,6 @@ static int test_create_unlink(void)
 	return 0;
 }
 
-#ifndef __FreeBSD__
 static int test_mknod(void)
 {
 	int err = 0;
@@ -1098,7 +1097,6 @@ static int test_mknod(void)
 	success();
 	return 0;
 }
-#endif
 
 #define test_open(exist, flags, mode)  do_test_open(exist, flags, #flags, mode)
 
@@ -1792,7 +1790,6 @@ fail:
 #undef PATH
 }
 
-#ifndef __FreeBSD__
 static int test_mkfifo(void)
 {
 	int res;
@@ -1824,7 +1821,6 @@ static int test_mkfifo(void)
 	success();
 	return 0;
 }
-#endif
 
 static int test_mkdir(void)
 {
@@ -2120,10 +2116,8 @@ int main(int argc, char *argv[])
 	err += test_symlink();
 	err += test_link();
 	err += test_link2();
-#ifndef __FreeBSD__	
 	err += test_mknod();
 	err += test_mkfifo();
-#endif
 	err += test_mkdir();
 	err += test_rename_file();
 	err += test_rename_dir();

--- a/test/test_syscalls.c
+++ b/test/test_syscalls.c
@@ -1957,6 +1957,7 @@ static int do_test_create_ro_dir(int flags, const char *flags_str)
 	return 0;
 }
 
+#ifndef __FreeBSD__
 /* 	this tests open with O_TMPFILE
 	note that this will only work with the fuse low level api 
 	you will get ENOTSUP with the high level api */
@@ -2054,6 +2055,7 @@ static int test_create_and_link_tmpfile(void)
 	success();
 	return 0;
 }
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -2183,8 +2185,10 @@ int main(int argc, char *argv[])
 	err += test_create_ro_dir(O_CREAT | O_WRONLY);
 	err += test_create_ro_dir(O_CREAT | O_TRUNC);
 	err += test_copy_file_range();
+#ifndef __FreeBSD__
 	err += test_create_tmpfile();
 	err += test_create_and_link_tmpfile();
+#endif
 
 	unlink(testfile2);
 	unlink(testsock);


### PR DESCRIPTION
some comments:

#### tests: Re-enable mknod and mkfifo tests on FreeBSD
On FreeBSD, device nodes may be created in file systems with mknod() but such nodes cannot be used to access devices.

#### mount_bsd: Fix usage of libfuse_strtol
Note that on platforms where long and int are of different sizes, fd could be truncated when passed to the OS. That is true for util/fusermount.c as well.

Before checking for fd < 0:
```
root@fbsd14-ufs:/home/vt/dev/fuse-archive # FUSE_DEV_FD=-1 out/fuse-archive -o debug test/data/archive.tar
fuse-archive 53467 - - Created mount point 'archive'
FUSE library version: 3.17.1-rc0
nullpath_ok: 0
mount_fusefs: invalid option -- 1
usage:
mount_fusefs [-A|-S|-v|-V|-h|-D daemon|-O args|-s special|-m node|-o option...] special node [daemon args...]
[...]
```

#### FreeBSD: Remove useless options
See https://cgit.freebsd.org/src/commit/?id=4abf87666ad69ba377a7d0aa71e87bc8824759fa
Since FreeBSD 13-RELEASE, `sysctlbyname("vfs.fuse.init_backgrounded")` returned ERR#2 'No such file or directory', so `init_backgrounded()` always returned 0.

#### mount_bsd: Remove the double-fork
This is the one I'm the less confident with.

After my naive unanswered [question](https://github.com/libfuse/libfuse/discussions/1100), I've tested by myself with [fuse-test-ready.c](https://gist.github.com/vassilit/e00d59135e3204aabcc4cca8c333c140).

It appears that with the double-fork, the FS is ready between 150µs and 1ms after returning from `fuse_main()`, and between 20µs and 100µs without.

However, I might be missing something. I'm running a patched version of libfuse2 without the double-fork for more than a month and I never got dead-locked. I've also tested successfully a libfuse3 version (without double-fork).
In particular I've run the test suite of fuse-archive many times and it never failed. 

What worries me a bit is that the code from the time `mount_bsd.c` was written has not changed much:
- Fuse for FreeBSD before inclusion into the mainline, as it was when mount_bsd.c was written: [here](https://github.com/glk/fuse-freebsd/blob/5c9d7f4881d72c7b2229989f3e59ab5266ac0b09/fuse_module/fuse_vfsops.c#L512).
- `mount_fusefs` call the `nmount` syscall, it then goes [here](https://github.com/freebsd/freebsd-src/blob/408394185fe9be0c158189b7671bde316ac14ac9/sys/fs/fuse/fuse_vfsops.c#L447) to send FUSE_INIT.

So the dead-lock, if existed, could possibly still exist, so maybe I am overlooking something. But I've never met the dead-lock in practice. And people are reporting here and there that the FS is not ready after returning from `fuse_main()`, so avoiding the double-fork and hence waiting for mount_fusefs, while not resolving the problem entirely, reduce it.

On [OSX](https://github.com/zargony/fuse-rs/issues/9#issuecomment-32167809), their analysis is « It then synchronously waits for the FUSE_INIT ». Is it specific for OSX ? It seems very similar to FreeBSD.
I've check with `truss`/`dtrace`/`dwatch`,  indeed, there is a lot of \*stat\* calls during the mount, but removing the double-fork never blocked them.

If unsure, feel free to remove this commit while waiting from more inputs.

Ideally, we could call `(n)mount()` directly in the future, but that would not solve the double-fork problem.

