### PR TITLE
Avoid function nested declarations

### DIFF
--- a/include/fuse.h
+++ b/include/fuse.h
@@ -882,6 +882,9 @@ struct fuse_context {
  *
  * Do not call this directly, use fuse_main()
  */
+int fuse_main_real_versioned(int argc, char *argv[],
+			     const struct fuse_operations *op, size_t op_size,
+			     struct libfuse_version *version, void *user_data);
 static inline int fuse_main_real(int argc, char *argv[],
 				 const struct fuse_operations *op,
 				 size_t op_size, void *user_data)
@@ -894,13 +897,6 @@ static inline int fuse_main_real(int argc, char *argv[],
 	fuse_log(FUSE_LOG_ERR,
 		 "%s is a libfuse internal function, please use fuse_main()\n",
 		 __func__);
-
-	/* not declared globally, to restrict usage of this function */
-	int fuse_main_real_versioned(int argc, char *argv[],
-				     const struct fuse_operations *op,
-				     size_t op_size,
-				     struct libfuse_version *version,
-				     void *user_data);
 
 	return fuse_main_real_versioned(argc, argv, op, op_size, &version,
 					user_data);
@@ -960,6 +956,9 @@ static inline int fuse_main_real(int argc, char *argv[],
  *
  * Example usage, see hello.c
  */
+int fuse_main_real_versioned(int argc, char *argv[],
+			     const struct fuse_operations *op, size_t op_size,
+			     struct libfuse_version *version, void *user_data);
 static inline int fuse_main_fn(int argc, char *argv[],
 			       const struct fuse_operations *op,
 			       void *user_data)
@@ -971,12 +970,6 @@ static inline int fuse_main_fn(int argc, char *argv[],
 		.padding = 0
 	};
 
-	/* not declared globally, to restrict usage of this function */
-	int fuse_main_real_versioned(int argc, char *argv[],
-				     const struct fuse_operations *op,
-				     size_t op_size,
-				     struct libfuse_version *version,
-				     void *user_data);
 	return fuse_main_real_versioned(argc, argv, op, sizeof(*(op)), &version,
 					user_data);
 }
@@ -999,6 +992,14 @@ static inline int fuse_main_fn(int argc, char *argv[],
  * @param args the argument vector.
  */
 void fuse_lib_help(struct fuse_args *args);
+
+/* Do not call this directly, use fuse_new() instead */
+struct fuse *_fuse_new_30(struct fuse_args *args,
+			  const struct fuse_operations *op, size_t op_size,
+			  struct libfuse_version *version, void *user_data);
+struct fuse *_fuse_new_31(struct fuse_args *args,
+			  const struct fuse_operations *op, size_t op_size,
+			  struct libfuse_version *version, void *user_data);
 
 /**
  * Create a new FUSE filesystem.
@@ -1028,22 +1029,10 @@ void fuse_lib_help(struct fuse_args *args);
  * @return the created FUSE handle
  */
 #if FUSE_USE_VERSION == 30
-struct fuse *_fuse_new_30(struct fuse_args *args,
-			 const struct fuse_operations *op,
-			 size_t op_size,
-			 struct libfuse_version *version,
-			 void *user_data);
-static inline struct fuse *
-fuse_new_fn(struct fuse_args *args,
-	 const struct fuse_operations *op, size_t op_size,
-	 void *user_data)
+static inline struct fuse *fuse_new_fn(struct fuse_args *args,
+				       const struct fuse_operations *op,
+				       size_t op_size, void *user_data)
 {
-	/* not declared globally, to restrict usage of this function */
-	struct fuse *_fuse_new_30(struct fuse_args *args,
-			       const struct fuse_operations *op, size_t op_size,
-			       struct libfuse_version *version,
-			       void *user_data);
-
 	struct libfuse_version version = {
 		.major = FUSE_MAJOR_VERSION,
 		.minor = FUSE_MINOR_VERSION,
@@ -1054,10 +1043,9 @@ fuse_new_fn(struct fuse_args *args,
 	return _fuse_new_30(args, op, op_size, &version, user_data);
 }
 #else /* FUSE_USE_VERSION */
-static inline struct fuse *
-fuse_new_fn(struct fuse_args *args,
-	 const struct fuse_operations *op, size_t op_size,
-	 void *user_data)
+static inline struct fuse *fuse_new_fn(struct fuse_args *args,
+				       const struct fuse_operations *op,
+				       size_t op_size, void *user_data)
 {
 	struct libfuse_version version = {
 		.major = FUSE_MAJOR_VERSION,
@@ -1066,11 +1054,6 @@ fuse_new_fn(struct fuse_args *args,
 		.padding = 0
 	};
 
-	/* not declared globally, to restrict usage of this function */
-	struct fuse *_fuse_new_31(struct fuse_args *args,
-		const struct fuse_operations *op,
-		size_t op_size, struct libfuse_version *version,
-		void *user_data);
 	return _fuse_new_31(args, op, op_size, &version, user_data);
 }
 #endif

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -2047,6 +2047,12 @@ int fuse_parse_cmdline_312(struct fuse_args *args,
 #endif
 #endif
 
+/* Do not call this directly, use fuse_session_new() instead */
+struct fuse_session *
+fuse_session_new_versioned(struct fuse_args *args,
+			   const struct fuse_lowlevel_ops *op, size_t op_size,
+			   struct libfuse_version *version, void *userdata);
+
 /**
  * Create a low level session.
  *
@@ -2085,12 +2091,6 @@ fuse_session_new_fn(struct fuse_args *args, const struct fuse_lowlevel_ops *op,
 		.hotfix = FUSE_HOTFIX_VERSION,
 		.padding = 0
 	};
-
-	/* not declared globally, to restrict usage of this function */
-	struct fuse_session *fuse_session_new_versioned(
-		struct fuse_args *args, const struct fuse_lowlevel_ops *op,
-		size_t op_size, struct libfuse_version *version,
-		void *userdata);
 
 	return fuse_session_new_versioned(args, op, op_size, &version,
 					  userdata);

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4924,13 +4924,8 @@ void fuse_stop_cleanup_thread(struct fuse *f)
  * through the fuse_new macro
  */
 struct fuse *_fuse_new_31(struct fuse_args *args,
-			   const struct fuse_operations *op,
-			   size_t op_size, struct libfuse_version *version,
-			   void *user_data);
-struct fuse *_fuse_new_31(struct fuse_args *args,
-			   const struct fuse_operations *op,
-			   size_t op_size, struct libfuse_version *version,
-			   void *user_data)
+			  const struct fuse_operations *op, size_t op_size,
+			  struct libfuse_version *version, void *user_data)
 {
 	struct fuse *f;
 	struct node *root;
@@ -5075,10 +5070,6 @@ out:
 }
 
 /* Emulates 3.0-style fuse_new(), which processes --help */
-struct fuse *_fuse_new_30(struct fuse_args *args, const struct fuse_operations *op,
-			 size_t op_size,
-			 struct libfuse_version *version,
-			 void *user_data);
 FUSE_SYMVER("_fuse_new_30", "_fuse_new@FUSE_3.0")
 struct fuse *_fuse_new_30(struct fuse_args *args,
 			 const struct fuse_operations *op,

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3247,10 +3247,6 @@ int fuse_session_receive_buf_internal(struct fuse_session *se,
 struct fuse_session *
 fuse_session_new_versioned(struct fuse_args *args,
 			   const struct fuse_lowlevel_ops *op, size_t op_size,
-			   struct libfuse_version *version, void *userdata);
-struct fuse_session *
-fuse_session_new_versioned(struct fuse_args *args,
-			   const struct fuse_lowlevel_ops *op, size_t op_size,
 			   struct libfuse_version *version, void *userdata)
 {
 	int err;

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -304,10 +304,6 @@ int fuse_daemonize(int foreground)
 	return 0;
 }
 
-/* Not symboled, as not part of the official API */
-int fuse_main_real_versioned(int argc, char *argv[],
-			     const struct fuse_operations *op, size_t op_size,
-			     struct libfuse_version *version, void *user_data);
 int fuse_main_real_versioned(int argc, char *argv[],
 			     const struct fuse_operations *op, size_t op_size,
 			     struct libfuse_version *version, void *user_data)


### PR DESCRIPTION
libfuse-3.17 includes a few new functions that should be called from inlined helper functions, but never directly. In order to prevent accidental usage these function were declared within the inlined function. This migh trigger the compiler warning "-Werror=nested-externs" - which is valid, but intended here. We could have tried to suppress it with pragmas, but that wouldn't have been ideal either - these functions are no declared outside of the helper functions.

Addresses: https://github.com/libfuse/libfuse/issues/1134