### PR TITLE
mount: fix closing stdout/err and error logs

### DIFF
--- a/lib/mount.c
+++ b/lib/mount.c
@@ -153,7 +153,7 @@ static int fusermount_posix_spawn(posix_spawn_file_actions_t *action,
 	if (out_pid)
 		*out_pid = pid;
 	else
-		waitpid(pid, NULL, 0);
+		waitpid(pid, NULL, 0); /* FIXME: check exit code and return error if any */
 
 	return 0;
 }
@@ -341,8 +341,8 @@ void fuse_kern_unmount(const char *mountpoint, int fd)
 				"--", mountpoint, NULL };
 	int status = fusermount_posix_spawn(NULL, argv, NULL);
 	if(status != 0) {
-		fuse_log(FUSE_LOG_ERR, "Spawaning %s to unumount failed",
-			 FUSERMOUNT_PROG);
+		fuse_log(FUSE_LOG_ERR, "Spawning %s to unmount failed: %s",
+			 FUSERMOUNT_PROG, strerror(-status));
 		return;
 	}
 }
@@ -390,8 +390,8 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
 	posix_spawn_file_actions_init(&action);
 
 	if (quiet) {
-		posix_spawn_file_actions_addclose(&action, 1);
-		posix_spawn_file_actions_addclose(&action, 2);
+		posix_spawn_file_actions_addopen(&action, STDOUT_FILENO, "/dev/null", O_WRONLY, 0);
+		posix_spawn_file_actions_addopen(&action, STDERR_FILENO, "/dev/null", O_WRONLY, 0);
 	}
 	posix_spawn_file_actions_addclose(&action, fds[1]);
 
@@ -406,7 +406,8 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
 	if(status != 0) {
 		close(fds[0]);
 		close(fds[1]);
-		fuse_log(FUSE_LOG_ERR, "fuse: Setting up auto-unmount failed");
+		fuse_log(FUSE_LOG_ERR, "fuse: Setting up auto-unmount failed (spawn): %s",
+			     strerror(-status));
 		return -1;
 	}
 	// passed to child now, so can close here.
@@ -462,8 +463,8 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
 	posix_spawn_file_actions_init(&action);
 
 	if (quiet) {
-		posix_spawn_file_actions_addclose(&action, 1);
-		posix_spawn_file_actions_addclose(&action, 2);
+		posix_spawn_file_actions_addopen(&action, STDOUT_FILENO, "/dev/null", O_WRONLY, 0);
+		posix_spawn_file_actions_addopen(&action, STDERR_FILENO, "/dev/null", O_WRONLY, 0);
 	}
 	posix_spawn_file_actions_addclose(&action, fds[1]);
 
@@ -474,8 +475,8 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
 	if(status != 0) {
 		close(fds[0]);
 		close(fds[1]);
-		fuse_log(FUSE_LOG_ERR, "posix_spawnp() for %s failed",
-			 FUSERMOUNT_PROG, strerror(errno));
+		fuse_log(FUSE_LOG_ERR, "posix_spawn(p)() for %s failed: %s",
+			 FUSERMOUNT_PROG, strerror(-status));
 		return -1;
 	}
 


### PR DESCRIPTION
Don't spawn a setuid children with FD 1&2 closed.
Check status and not errno after posix_spawn(p).
Add comments to fix later error checking, as
posix_spawn(p) returns non-zero status only if
clone/vfork/rfork fails. If only setup (open, dup2) or execve fails, the forked process exit with 127
but posix_spawn returns zero.