### PR TITLE
fuse_log: simplify default log function

### DIFF
--- a/lib/fuse_log.c
+++ b/lib/fuse_log.c
@@ -10,58 +10,21 @@
 
 #include "fuse_log.h"
 
-#include <stdarg.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <syslog.h>
+#include <stdarg.h>
 
 #define MAX_SYSLOG_LINE_LEN 512
 
 static bool to_syslog = false;
 
-static void default_log_func(__attribute__((unused)) enum fuse_log_level level,
-			     const char *fmt, va_list ap)
+static void default_log_func(enum fuse_log_level level, const char *fmt, va_list ap)
 {
-	if (to_syslog) {
-		int sys_log_level = LOG_ERR;
-
-		/*
-		 * with glibc fuse_log_level has identical values as
-		 * syslog levels, but we also support BSD - better we convert to
-		 * be sure.
-		 */
-		switch (level) {
-		case FUSE_LOG_DEBUG:
-			sys_log_level = LOG_DEBUG;
-			break;
-		case FUSE_LOG_INFO:
-			sys_log_level = LOG_INFO;
-			break;
-		case FUSE_LOG_NOTICE:
-			sys_log_level = LOG_NOTICE;
-			break;
-		case FUSE_LOG_WARNING:
-			sys_log_level = LOG_WARNING;
-			break;
-		case FUSE_LOG_ERR:
-			sys_log_level = LOG_ERR;
-			break;
-		case FUSE_LOG_CRIT:
-			sys_log_level = LOG_CRIT;
-			break;
-		case FUSE_LOG_ALERT:
-			sys_log_level = LOG_ALERT;
-			break;
-		case FUSE_LOG_EMERG:
-			sys_log_level = LOG_EMERG;
-		}
-
-		char log[MAX_SYSLOG_LINE_LEN];
-		vsnprintf(log, MAX_SYSLOG_LINE_LEN, fmt, ap);
-		syslog(sys_log_level, "%s", log);
-	} else {
+	if (to_syslog)
+		vsyslog(level, fmt, ap);
+	else
 		vfprintf(stderr, fmt, ap);
-	}
 }
 
 static fuse_log_func_t log_func = default_log_func;


### PR DESCRIPTION
fuse_log_level is garanteed to be the same as libc as syslog is a cross-platform network protocol and levels are numerical constants enforced in RFCs. Syslog is originally BSD-only and was later imported by glibc and standardised in SUS and POSIX, so the definitions are cross-platform.
Use vsyslog directly