### PR TITLE
fuse_session_receive_buf: Fix the pipe buf size

### DIFF
--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -72,14 +72,14 @@ struct fuse_session {
 	int broken_splice_nonblock;
 	uint64_t notify_ctr;
 	struct fuse_notify_req notify_list;
-	size_t bufsize;
+	_Atomic size_t bufsize;
 	int error;
 
 	/* This is useful if any kind of ABI incompatibility is found at
 	 * a later version, to 'fix' it at run time.
 	 */
 	struct libfuse_version version;
-	bool buf_reallocable;
+	_Atomic bool buf_reallocable;
 };
 
 struct fuse_chan {

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -79,7 +79,9 @@ struct fuse_session {
 	 * a later version, to 'fix' it at run time.
 	 */
 	struct libfuse_version version;
-	_Atomic bool buf_reallocable;
+
+	/* true if reading requests from /dev/fuse are handled internally */
+	bool buf_reallocable;
 };
 
 struct fuse_chan {

--- a/lib/util.h
+++ b/lib/util.h
@@ -1,3 +1,6 @@
 #define ROUND_UP(val, round_to) (((val) + (round_to - 1)) & ~(round_to - 1))
 
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+
 int libfuse_strtol(const char *str, long *res);


### PR DESCRIPTION
This fixes dynamic buffer allocation in commit
0e0f43b79b9b ("Reallocate fuse_session buffer transparently for extended max writes")

I noticed that when I increased the default fuse buf size as possible in recent kernels.