### PR TITLE
fuse_common.h: Convert back FUSE_CAP_ from enum to defines

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -174,355 +174,348 @@ struct fuse_loop_config_v1 {
  * Capability bits for 'fuse_conn_info.capable' and 'fuse_conn_info.want' *
  **************************************************************************/
 
-enum fuse_capability {
-	/**
-	 * Indicates that the filesystem supports asynchronous read requests.
-	 *
-	 * If this capability is not requested/available, the kernel will
-	 * ensure that there is at most one pending read request per
-	 * file-handle at any time, and will attempt to order read requests by
-	 * increasing offset.
-	 *
-	 * This feature is enabled by default when supported by the kernel.
-	 */
-	FUSE_CAP_ASYNC_READ = (1 << 0),
+/**
+ * Indicates that the filesystem supports asynchronous read requests.
+ *
+ * If this capability is not requested/available, the kernel will
+ * ensure that there is at most one pending read request per
+ * file-handle at any time, and will attempt to order read requests by
+ * increasing offset.
+ *
+ * This feature is enabled by default when supported by the kernel.
+ */
+#define FUSE_CAP_ASYNC_READ (1 << 0)
 
-	/**
-	 * Indicates that the filesystem supports "remote" locking.
-	 *
-	 * This feature is enabled by default when supported by the kernel,
-	 * and if getlk() and setlk() handlers are implemented.
-	 */
-	FUSE_CAP_POSIX_LOCKS = (1 << 1),
+/**
+ * Indicates that the filesystem supports "remote" locking.
+ *
+ * This feature is enabled by default when supported by the kernel,
+ * and if getlk() and setlk() handlers are implemented.
+ */
+#define FUSE_CAP_POSIX_LOCKS (1 << 1)
 
-	/**
-	 * Indicates that the filesystem supports the O_TRUNC open flag.  If
-	 * disabled, and an application specifies O_TRUNC, fuse first calls
-	 * truncate() and then open() with O_TRUNC filtered out.
-	 *
-	 * This feature is enabled by default when supported by the kernel.
-	 */
-	FUSE_CAP_ATOMIC_O_TRUNC = (1 << 3),
+/**
+ * Indicates that the filesystem supports the O_TRUNC open flag.  If
+ * disabled, and an application specifies O_TRUNC, fuse first calls
+ * truncate() and then open() with O_TRUNC filtered out.
+ *
+ * This feature is enabled by default when supported by the kernel.
+ */
+#define FUSE_CAP_ATOMIC_O_TRUNC (1 << 3)
 
-	/**
-	 * Indicates that the filesystem supports lookups of "." and "..".
-	 *
-	 * When this flag is set, the filesystem must be prepared to receive requests
-	 * for invalid inodes (i.e., for which a FORGET request was received or
-	 * which have been used in a previous instance of the filesystem daemon) and
-	 * must not reuse node-ids (even when setting generation numbers).
-	 *
-	 * This feature is disabled by default.
-	 */
-	FUSE_CAP_EXPORT_SUPPORT = (1 << 4),
+/**
+ * Indicates that the filesystem supports lookups of "." and "..".
+ *
+ * When this flag is set, the filesystem must be prepared to receive requests
+ * for invalid inodes (i.e., for which a FORGET request was received or
+ * which have been used in a previous instance of the filesystem daemon) and
+ * must not reuse node-ids (even when setting generation numbers).
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_EXPORT_SUPPORT (1 << 4)
 
-	/**
-	 * Indicates that the kernel should not apply the umask to the
-	 * file mode on create operations.
-	 *
-	 * This feature is disabled by default.
-	 */
-	FUSE_CAP_DONT_MASK = (1 << 6),
+/**
+ * Indicates that the kernel should not apply the umask to the
+ * file mode on create operations.
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_DONT_MASK (1 << 6)
 
-	/**
-	 * Indicates that libfuse should try to use splice() when writing to
-	 * the fuse device. This may improve performance.
-	 *
-	 * This feature is disabled by default.
-	 */
-	FUSE_CAP_SPLICE_WRITE = (1 << 7),
+/**
+ * Indicates that libfuse should try to use splice() when writing to
+ * the fuse device. This may improve performance.
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_SPLICE_WRITE (1 << 7)
 
-	/**
-	 * Indicates that libfuse should try to move pages instead of copying when
-	 * writing to / reading from the fuse device. This may improve performance.
-	 *
-	 * This feature is disabled by default.
-	 */
-	FUSE_CAP_SPLICE_MOVE = (1 << 8),
+/**
+ * Indicates that libfuse should try to move pages instead of copying when
+ * writing to / reading from the fuse device. This may improve performance.
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_SPLICE_MOVE (1 << 8)
 
-	/**
-	 * Indicates that libfuse should try to use splice() when reading from
-	 * the fuse device. This may improve performance.
-	 *
-	 * This feature is enabled by default when supported by the kernel and
-	 * if the filesystem implements a write_buf() handler.
-	 */
-	FUSE_CAP_SPLICE_READ = (1 << 9),
+/**
+ * Indicates that libfuse should try to use splice() when reading from
+ * the fuse device. This may improve performance.
+ *
+ * This feature is enabled by default when supported by the kernel and
+ * if the filesystem implements a write_buf() handler.
+ */
+#define FUSE_CAP_SPLICE_READ (1 << 9)
 
-	/**
-	 * If set, the calls to flock(2) will be emulated using POSIX locks and must
-	 * then be handled by the filesystem's setlock() handler.
-	 *
-	 * If not set, flock(2) calls will be handled by the FUSE kernel module
-	 * internally (so any access that does not go through the kernel cannot be taken
-	 * into account).
-	 *
-	 * This feature is enabled by default when supported by the kernel and
-	 * if the filesystem implements a flock() handler.
-	 */
-	FUSE_CAP_FLOCK_LOCKS = (1 << 10),
+/**
+ * If set, the calls to flock(2) will be emulated using POSIX locks and must
+ * then be handled by the filesystem's setlock() handler.
+ *
+ * If not set, flock(2) calls will be handled by the FUSE kernel module
+ * internally (so any access that does not go through the kernel cannot be taken
+ * into account).
+ *
+ * This feature is enabled by default when supported by the kernel and
+ * if the filesystem implements a flock() handler.
+ */
+#define FUSE_CAP_FLOCK_LOCKS (1 << 10)
 
-	/**
-	 * Indicates that the filesystem supports ioctl's on directories.
-	 *
-	 * This feature is enabled by default when supported by the kernel.
-	 */
-	FUSE_CAP_IOCTL_DIR = (1 << 11),
+/**
+ * Indicates that the filesystem supports ioctl's on directories.
+ *
+ * This feature is enabled by default when supported by the kernel.
+ */
+#define FUSE_CAP_IOCTL_DIR (1 << 11)
 
-	/**
-	 * Traditionally, while a file is open the FUSE kernel module only
-	 * asks the filesystem for an update of the file's attributes when a
-	 * client attempts to read beyond EOF. This is unsuitable for
-	 * e.g. network filesystems, where the file contents may change
-	 * without the kernel knowing about it.
-	 *
-	 * If this flag is set, FUSE will check the validity of the attributes
-	 * on every read. If the attributes are no longer valid (i.e., if the
-	 * *attr_timeout* passed to fuse_reply_attr() or set in `struct
-	 * fuse_entry_param` has passed), it will first issue a `getattr`
-	 * request. If the new mtime differs from the previous value, any
-	 * cached file *contents* will be invalidated as well.
-	 *
-	 * This flag should always be set when available. If all file changes
-	 * go through the kernel, *attr_timeout* should be set to a very large
-	 * number to avoid unnecessary getattr() calls.
-	 *
-	 * This feature is enabled by default when supported by the kernel.
-	 */
-	FUSE_CAP_AUTO_INVAL_DATA = (1 << 12),
+/**
+ * Traditionally, while a file is open the FUSE kernel module only
+ * asks the filesystem for an update of the file's attributes when a
+ * client attempts to read beyond EOF. This is unsuitable for
+ * e.g. network filesystems, where the file contents may change
+ * without the kernel knowing about it.
+ *
+ * If this flag is set, FUSE will check the validity of the attributes
+ * on every read. If the attributes are no longer valid (i.e., if the
+ * *attr_timeout* passed to fuse_reply_attr() or set in `struct
+ * fuse_entry_param` has passed), it will first issue a `getattr`
+ * request. If the new mtime differs from the previous value, any
+ * cached file *contents* will be invalidated as well.
+ *
+ * This flag should always be set when available. If all file changes
+ * go through the kernel, *attr_timeout* should be set to a very large
+ * number to avoid unnecessary getattr() calls.
+ *
+ * This feature is enabled by default when supported by the kernel.
+ */
+#define FUSE_CAP_AUTO_INVAL_DATA (1 << 12)
 
-	/**
-	 * Indicates that the filesystem supports readdirplus.
-	 *
-	 * This feature is enabled by default when supported by the kernel and if the
-	 * filesystem implements a readdirplus() handler.
-	 */
-	FUSE_CAP_READDIRPLUS = (1 << 13),
+/**
+ * Indicates that the filesystem supports readdirplus.
+ *
+ * This feature is enabled by default when supported by the kernel and if the
+ * filesystem implements a readdirplus() handler.
+ */
+#define FUSE_CAP_READDIRPLUS (1 << 13)
 
-	/**
-	 * Indicates that the filesystem supports adaptive readdirplus.
-	 *
-	 * If FUSE_CAP_READDIRPLUS is not set, this flag has no effect.
-	 *
-	 * If FUSE_CAP_READDIRPLUS is set and this flag is not set, the kernel
-	 * will always issue readdirplus() requests to retrieve directory
-	 * contents.
-	 *
-	 * If FUSE_CAP_READDIRPLUS is set and this flag is set, the kernel
-	 * will issue both readdir() and readdirplus() requests, depending on
-	 * how much information is expected to be required.
-	 *
-	 * As of Linux 4.20, the algorithm is as follows: when userspace
-	 * starts to read directory entries, issue a READDIRPLUS request to
-	 * the filesystem. If any entry attributes have been looked up by the
-	 * time userspace requests the next batch of entries continue with
-	 * READDIRPLUS, otherwise switch to plain READDIR.  This will reasult
-	 * in eg plain "ls" triggering READDIRPLUS first then READDIR after
-	 * that because it doesn't do lookups.  "ls -l" should result in all
-	 * READDIRPLUS, except if dentries are already cached.
-	 *
-	 * This feature is enabled by default when supported by the kernel and
-	 * if the filesystem implements both a readdirplus() and a readdir()
-	 * handler.
-	 */
-	FUSE_CAP_READDIRPLUS_AUTO = (1 << 14),
+/**
+ * Indicates that the filesystem supports adaptive readdirplus.
+ *
+ * If FUSE_CAP_READDIRPLUS is not set, this flag has no effect.
+ *
+ * If FUSE_CAP_READDIRPLUS is set and this flag is not set, the kernel
+ * will always issue readdirplus() requests to retrieve directory
+ * contents.
+ *
+ * If FUSE_CAP_READDIRPLUS is set and this flag is set, the kernel
+ * will issue both readdir() and readdirplus() requests, depending on
+ * how much information is expected to be required.
+ *
+ * As of Linux 4.20, the algorithm is as follows: when userspace
+ * starts to read directory entries, issue a READDIRPLUS request to
+ * the filesystem. If any entry attributes have been looked up by the
+ * time userspace requests the next batch of entries continue with
+ * READDIRPLUS, otherwise switch to plain READDIR.  This will reasult
+ * in eg plain "ls" triggering READDIRPLUS first then READDIR after
+ * that because it doesn't do lookups.  "ls -l" should result in all
+ * READDIRPLUS, except if dentries are already cached.
+ *
+ * This feature is enabled by default when supported by the kernel and
+ * if the filesystem implements both a readdirplus() and a readdir()
+ * handler.
+ */
+#define FUSE_CAP_READDIRPLUS_AUTO (1 << 14)
 
-	/**
-	 * Indicates that the filesystem supports asynchronous direct I/O submission.
-	 *
-	 * If this capability is not requested/available, the kernel will ensure that
-	 * there is at most one pending read and one pending write request per direct
-	 * I/O file-handle at any time.
-	 *
-	 * This feature is enabled by default when supported by the kernel.
-	 */
-	FUSE_CAP_ASYNC_DIO = (1 << 15),
+/**
+ * Indicates that the filesystem supports asynchronous direct I/O submission.
+ *
+ * If this capability is not requested/available, the kernel will ensure that
+ * there is at most one pending read and one pending write request per direct
+ * I/O file-handle at any time.
+ *
+ * This feature is enabled by default when supported by the kernel.
+ */
+#define FUSE_CAP_ASYNC_DIO (1 << 15)
 
-	/**
-	 * Indicates that writeback caching should be enabled. This means that
-	 * individual write request may be buffered and merged in the kernel
-	 * before they are send to the filesystem.
-	 *
-	 * This feature is disabled by default.
-	 */
-	FUSE_CAP_WRITEBACK_CACHE = (1 << 16),
+/**
+ * Indicates that writeback caching should be enabled. This means that
+ * individual write request may be buffered and merged in the kernel
+ * before they are send to the filesystem.
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_WRITEBACK_CACHE (1 << 16)
 
-	/**
-	 * Indicates support for zero-message opens. If this flag is set in
-	 * the `capable` field of the `fuse_conn_info` structure, then the
-	 * filesystem may return `ENOSYS` from the open() handler to indicate
-	 * success. Further attempts to open files will be handled in the
-	 * kernel. (If this flag is not set, returning ENOSYS will be treated
-	 * as an error and signaled to the caller).
-	 *
-	 * Setting this flag in the `want` field enables this behavior automatically
-	 * within libfuse for low level API users. If non-low level users wish to have
-	 * this behavior you must return `ENOSYS` from the open() handler on supporting
-	 * kernels.
-	 */
-	FUSE_CAP_NO_OPEN_SUPPORT = (1 << 17),
+/**
+ * Indicates support for zero-message opens. If this flag is set in
+ * the `capable` field of the `fuse_conn_info` structure, then the
+ * filesystem may return `ENOSYS` from the open() handler to indicate
+ * success. Further attempts to open files will be handled in the
+ * kernel. (If this flag is not set, returning ENOSYS will be treated
+ * as an error and signaled to the caller).
+ *
+ * Setting this flag in the `want` field enables this behavior automatically
+ * within libfuse for low level API users. If non-low level users wish to have
+ * this behavior you must return `ENOSYS` from the open() handler on supporting
+ * kernels.
+ */
+#define FUSE_CAP_NO_OPEN_SUPPORT (1 << 17)
 
-	/**
-	 * Indicates support for parallel directory operations. If this flag
-	 * is unset, the FUSE kernel module will ensure that lookup() and
-	 * readdir() requests are never issued concurrently for the same
-	 * directory.
-	 */
-	FUSE_CAP_PARALLEL_DIROPS = (1 << 18),
+/**
+ * Indicates support for parallel directory operations. If this flag
+ * is unset, the FUSE kernel module will ensure that lookup() and
+ * readdir() requests are never issued concurrently for the same
+ * directory.
+ */
+#define FUSE_CAP_PARALLEL_DIROPS (1 << 18)
 
-	/**
-	 * Indicates support for POSIX ACLs.
-	 *
-	 * If this feature is enabled, the kernel will cache and have
-	 * responsibility for enforcing ACLs. ACL will be stored as xattrs and
-	 * passed to userspace, which is responsible for updating the ACLs in
-	 * the filesystem, keeping the file mode in sync with the ACL, and
-	 * ensuring inheritance of default ACLs when new filesystem nodes are
-	 * created. Note that this requires that the file system is able to
-	 * parse and interpret the xattr representation of ACLs.
-	 *
-	 * Enabling this feature implicitly turns on the
-	 * ``default_permissions`` mount option (even if it was not passed to
-	 * mount(2)).
-	 *
-	 * This feature is disabled by default.
-	 */
-	FUSE_CAP_POSIX_ACL = (1 << 19),
+/**
+ * Indicates support for POSIX ACLs.
+ *
+ * If this feature is enabled, the kernel will cache and have
+ * responsibility for enforcing ACLs. ACL will be stored as xattrs and
+ * passed to userspace, which is responsible for updating the ACLs in
+ * the filesystem, keeping the file mode in sync with the ACL, and
+ * ensuring inheritance of default ACLs when new filesystem nodes are
+ * created. Note that this requires that the file system is able to
+ * parse and interpret the xattr representation of ACLs.
+ *
+ * Enabling this feature implicitly turns on the
+ * ``default_permissions`` mount option (even if it was not passed to
+ * mount(2)).
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_POSIX_ACL (1 << 19)
 
-	/**
-	 * Indicates that the filesystem is responsible for unsetting
-	 * setuid and setgid bits when a file is written, truncated, or
-	 * its owner is changed.
-	 *
-	 * This feature is disabled by default.
-	 */
-	FUSE_CAP_HANDLE_KILLPRIV = (1 << 20),
+/**
+ * Indicates that the filesystem is responsible for unsetting
+ * setuid and setgid bits when a file is written, truncated, or
+ * its owner is changed.
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_HANDLE_KILLPRIV (1 << 20)
 
-	/**
-	 * Indicates that the filesystem is responsible for unsetting
-	 * setuid and setgid bit and additionally cap (stored as xattr) when a
-	 * file is written, truncated, or its owner is changed.
-	 * Upon write/truncate suid/sgid is only killed if caller
-	 * does not have CAP_FSETID. Additionally upon
-	 * write/truncate sgid is killed only if file has group
-	 * execute permission. (Same as Linux VFS behavior).
-	 * KILLPRIV_V2 requires handling of
-	 *   - FUSE_OPEN_KILL_SUIDGID (set in struct fuse_create_in::open_flags)
-	 *   - FATTR_KILL_SUIDGID (set in struct fuse_setattr_in::valid)
-	 *   - FUSE_WRITE_KILL_SUIDGID (set in struct fuse_write_in::write_flags)
-	 *
-	 * This feature is disabled by default.
-	 */
-	FUSE_CAP_HANDLE_KILLPRIV_V2 = (1 << 21),
+/**
+ * Indicates that the filesystem is responsible for unsetting
+ * setuid and setgid bit and additionally cap (stored as xattr) when a
+ * file is written, truncated, or its owner is changed.
+ * Upon write/truncate suid/sgid is only killed if caller
+ * does not have CAP_FSETID. Additionally upon
+ * write/truncate sgid is killed only if file has group
+ * execute permission. (Same as Linux VFS behavior).
+ * KILLPRIV_V2 requires handling of
+ *   - FUSE_OPEN_KILL_SUIDGID (set in struct fuse_create_in::open_flags)
+ *   - FATTR_KILL_SUIDGID (set in struct fuse_setattr_in::valid)
+ *   - FUSE_WRITE_KILL_SUIDGID (set in struct fuse_write_in::write_flags)
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_HANDLE_KILLPRIV_V2 (1 << 21)
 
-	/**
-	 * Indicates that the kernel supports caching symlinks in its page cache.
-	 *
-	 * When this feature is enabled, symlink targets are saved in the page cache.
-	 * You can invalidate a cached link by calling:
-	 * `fuse_lowlevel_notify_inval_inode(se, ino, 0, 0);`
-	 *
-	 * This feature is disabled by default.
-	 * If the kernel supports it (>= 4.20), you can enable this feature by
-	 * setting this flag in the `want` field of the `fuse_conn_info` structure.
-	 */
-	FUSE_CAP_CACHE_SYMLINKS = (1 << 23),
+/**
+ * Indicates that the kernel supports caching symlinks in its page cache.
+ *
+ * When this feature is enabled, symlink targets are saved in the page cache.
+ * You can invalidate a cached link by calling:
+ * `fuse_lowlevel_notify_inval_inode(se, ino, 0, 0);`
+ *
+ * This feature is disabled by default.
+ * If the kernel supports it (>= 4.20), you can enable this feature by
+ * setting this flag in the `want` field of the `fuse_conn_info` structure.
+ */
+#define FUSE_CAP_CACHE_SYMLINKS (1 << 23)
 
-	/**
-	 * Indicates support for zero-message opendirs. If this flag is set in
-	 * the `capable` field of the `fuse_conn_info` structure, then the filesystem
-	 * may return `ENOSYS` from the opendir() handler to indicate success. Further
-	 * opendir and releasedir messages will be handled in the kernel. (If this
-	 * flag is not set, returning ENOSYS will be treated as an error and signalled
-	 * to the caller.)
-	 *
-	 * Setting this flag in the `want` field enables this behavior automatically
-	 * within libfuse for low level API users.  If non-low level users with to have
-	 * this behavior you must return `ENOSYS` from the opendir() handler on
-	 * supporting kernels.
-	 */
-	FUSE_CAP_NO_OPENDIR_SUPPORT = (1 << 24),
+/**
+ * Indicates support for zero-message opendirs. If this flag is set in
+ * the `capable` field of the `fuse_conn_info` structure, then the filesystem
+ * may return `ENOSYS` from the opendir() handler to indicate success. Further
+ * opendir and releasedir messages will be handled in the kernel. (If this
+ * flag is not set, returning ENOSYS will be treated as an error and signalled
+ * to the caller.)
+ *
+ * Setting this flag in the `want` field enables this behavior automatically
+ * within libfuse for low level API users.  If non-low level users with to have
+ * this behavior you must return `ENOSYS` from the opendir() handler on
+ * supporting kernels.
+ */
+#define FUSE_CAP_NO_OPENDIR_SUPPORT (1 << 24)
 
-	/**
-	 * Indicates support for invalidating cached pages only on explicit request.
-	 *
-	 * If this flag is set in the `capable` field of the `fuse_conn_info` structure,
-	 * then the FUSE kernel module supports invalidating cached pages only on
-	 * explicit request by the filesystem through fuse_lowlevel_notify_inval_inode()
-	 * or fuse_invalidate_path().
-	 *
-	 * By setting this flag in the `want` field of the `fuse_conn_info` structure,
-	 * the filesystem is responsible for invalidating cached pages through explicit
-	 * requests to the kernel.
-	 *
-	 * Note that setting this flag does not prevent the cached pages from being
-	 * flushed by OS itself and/or through user actions.
-	 *
-	 * Note that if both FUSE_CAP_EXPLICIT_INVAL_DATA and FUSE_CAP_AUTO_INVAL_DATA
-	 * are set in the `capable` field of the `fuse_conn_info` structure then
-	 * FUSE_CAP_AUTO_INVAL_DATA takes precedence.
-	 *
-	 * This feature is disabled by default.
-	 */
-	FUSE_CAP_EXPLICIT_INVAL_DATA = (1 << 25),
+/**
+ * Indicates support for invalidating cached pages only on explicit request.
+ *
+ * If this flag is set in the `capable` field of the `fuse_conn_info` structure,
+ * then the FUSE kernel module supports invalidating cached pages only on
+ * explicit request by the filesystem through fuse_lowlevel_notify_inval_inode()
+ * or fuse_invalidate_path().
+ *
+ * By setting this flag in the `want` field of the `fuse_conn_info` structure,
+ * the filesystem is responsible for invalidating cached pages through explicit
+ * requests to the kernel.
+ *
+ * Note that setting this flag does not prevent the cached pages from being
+ * flushed by OS itself and/or through user actions.
+ *
+ * Note that if both FUSE_CAP_EXPLICIT_INVAL_DATA and FUSE_CAP_AUTO_INVAL_DATA
+ * are set in the `capable` field of the `fuse_conn_info` structure then
+ * FUSE_CAP_AUTO_INVAL_DATA takes precedence.
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_EXPLICIT_INVAL_DATA (1 << 25)
 
-	/**
-	 * Indicates support that dentries can be expired.
-	 *
-	 * Expiring dentries, instead of invalidating them, makes a difference for
-	 * overmounted dentries, where plain invalidation would detach all submounts
-	 * before dropping the dentry from the cache. If only expiry is set on the
-	 * dentry, then any overmounts are left alone and until ->d_revalidate()
-	 * is called.
-	 *
-	 * Note: ->d_revalidate() is not called for the case of following a submount,
-	 * so invalidation will only be triggered for the non-overmounted case.
-	 * The dentry could also be mounted in a different mount instance, in which case
-	 * any submounts will still be detached.
-	*/
-	FUSE_CAP_EXPIRE_ONLY = (1 << 26),
+/**
+ * Indicates support that dentries can be expired.
+ *
+ * Expiring dentries, instead of invalidating them, makes a difference for
+ * overmounted dentries, where plain invalidation would detach all submounts
+ * before dropping the dentry from the cache. If only expiry is set on the
+ * dentry, then any overmounts are left alone and until ->d_revalidate()
+ * is called.
+ *
+ * Note: ->d_revalidate() is not called for the case of following a submount,
+ * so invalidation will only be triggered for the non-overmounted case.
+ * The dentry could also be mounted in a different mount instance, in which case
+ * any submounts will still be detached.
+ */
+#define FUSE_CAP_EXPIRE_ONLY (1 << 26)
 
-	/**
-	 * Indicates that an extended 'struct fuse_setxattr' is used by the kernel
-	 * side - extra_flags are passed, which are used (as of now by acl) processing.
-	 * For example FUSE_SETXATTR_ACL_KILL_SGID might be set.
-	 */
-	FUSE_CAP_SETXATTR_EXT = (1 << 27),
+/**
+ * Indicates that an extended 'struct fuse_setxattr' is used by the kernel
+ * side - extra_flags are passed, which are used (as of now by acl) processing.
+ * For example FUSE_SETXATTR_ACL_KILL_SGID might be set.
+ */
+#define FUSE_CAP_SETXATTR_EXT (1 << 27)
 
-	/**
-	 * Files opened with FUSE_DIRECT_IO do not support MAP_SHARED mmap. This restriction
-	 * is relaxed through FUSE_CAP_DIRECT_IO_RELAX (kernel flag: FUSE_DIRECT_IO_RELAX).
-	 * MAP_SHARED is disabled by default for FUSE_DIRECT_IO, as this flag can be used to
-	 * ensure coherency between mount points (or network clients) and with kernel page
-	 * cache as enforced by mmap that cannot be guaranteed anymore.
-	 */
-	FUSE_CAP_DIRECT_IO_ALLOW_MMAP = (1 << 28),
+/**
+ * Files opened with FUSE_DIRECT_IO do not support MAP_SHARED mmap. This restriction
+ * is relaxed through FUSE_CAP_DIRECT_IO_RELAX (kernel flag: FUSE_DIRECT_IO_RELAX).
+ * MAP_SHARED is disabled by default for FUSE_DIRECT_IO, as this flag can be used to
+ * ensure coherency between mount points (or network clients) and with kernel page
+ * cache as enforced by mmap that cannot be guaranteed anymore.
+ */
+#define FUSE_CAP_DIRECT_IO_ALLOW_MMAP (1 << 28)
 
-	/**
-	 * Indicates support for passthrough mode access for read/write operations.
-	 *
-	 * If this flag is set in the `capable` field of the `fuse_conn_info`
-	 * structure, then the FUSE kernel module supports redirecting read/write
-	 * operations to the backing file instead of letting them to be handled
-	 * by the FUSE daemon.
-	 *
-	 * This feature is disabled by default.
-	 */
-	FUSE_CAP_PASSTHROUGH = (1 << 29),
+/**
+ * Indicates support for passthrough mode access for read/write operations.
+ *
+ * If this flag is set in the `capable` field of the `fuse_conn_info`
+ * structure, then the FUSE kernel module supports redirecting read/write
+ * operations to the backing file instead of letting them to be handled
+ * by the FUSE daemon.
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_PASSTHROUGH (1 << 29)
 
-	/**
-	 * Indicates that the file system cannot handle NFS export
-	 *
-	 * If this flag is set NFS export and name_to_handle_at
-	 * is not going to work at all and will fail with EOPNOTSUPP.
-	 */
-	FUSE_CAP_NO_EXPORT_SUPPORT = (1 << 30),
-
-	/**
-	 * Current maximum capability value.
-	 */
-	FUSE_CAP_CURRENT_MAX
-};
+/**
+ * Indicates that the file system cannot handle NFS export
+ *
+ * If this flag is set NFS export and name_to_handle_at
+ * is not going to work at all and will fail with EOPNOTSUPP.
+ */
+#define FUSE_CAP_NO_EXPORT_SUPPORT (1 << 30)
 
 /**
  * Ioctl flags


### PR DESCRIPTION
Some applications use that for detection of features between distributions/libfuse version.

Fixes: https://github.com/libfuse/libfuse/issues/1163