### PR TITLE
fuse: Fix want flag conversion

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -30,7 +30,7 @@ jobs:
         git rev-list --reverse $base_commit..HEAD | while read commit; do
           subject=$(git log -1 --format=%s $commit)
           echo "Checking commit: $commit - $subject"
-          if ! ./checkpatch.pl --max-line-length=100 --no-tree --ignore MAINTAINERS,SPDX_LICENSE_TAG,COMMIT_MESSAGE,FILE_PATH_CHANGES,EMAIL_SUBJECT,AVOID_EXTERNS,GIT_COMMIT_ID,ENOSYS_SYSCALL,ENOSYS,FROM_SIGN_OFF_MISMATCH,QUOTED_COMMIT_ID -g $commit; then
+          if ! ./checkpatch.pl --max-line-length=100 --no-tree --ignore MAINTAINERS,SPDX_LICENSE_TAG,COMMIT_MESSAGE,FILE_PATH_CHANGES,EMAIL_SUBJECT,AVOID_EXTERNS,GIT_COMMIT_ID,ENOSYS_SYSCALL,ENOSYS,FROM_SIGN_OFF_MISMATCH,QUOTED_COMMIT_ID,PREFER_ATTRIBUTE_ALWAYS_UNUSED,PREFER_DEFINED_ATTRIBUTE_MACRO  -g $commit; then
             echo "checkpatch.pl found issues in commit $commit - $subject"
             exit 1
           fi

--- a/example/hello.c
+++ b/example/hello.c
@@ -57,6 +57,11 @@ static void *hello_init(struct fuse_conn_info *conn,
 {
 	(void) conn;
 	cfg->kernel_cache = 1;
+
+	/* Test setting flags the old way */
+	conn->want = FUSE_CAP_ASYNC_READ;
+	conn->want &= ~FUSE_CAP_ASYNC_READ;
+
 	return NULL;
 }
 

--- a/example/hello_ll.c
+++ b/example/hello_ll.c
@@ -59,6 +59,10 @@ static void hello_ll_init(void *userdata, struct fuse_conn_info *conn)
 
 	/* Disable the receiving and processing of FUSE_INTERRUPT requests */
 	conn->no_interrupt = 1;
+
+	/* Test setting flags the old way */
+	conn->want = FUSE_CAP_ASYNC_READ;
+	conn->want &= ~FUSE_CAP_ASYNC_READ;
 }
 
 static void hello_ll_getattr(fuse_req_t req, fuse_ino_t ino,

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -10,6 +10,8 @@
 */
 
 #define _GNU_SOURCE
+#include "fuse.h"
+#include <pthread.h>
 
 #include "fuse_config.h"
 #include "fuse_i.h"
@@ -17,7 +19,9 @@
 #include "fuse_opt.h"
 #include "fuse_misc.h"
 #include "fuse_kernel.h"
+#include "util.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -2606,13 +2610,34 @@ void fuse_fs_init(struct fuse_fs *fs, struct fuse_conn_info *conn,
 {
 	fuse_get_context()->private_data = fs->user_data;
 	if (!fs->op.write_buf)
-		conn->want &= ~FUSE_CAP_SPLICE_READ;
+		fuse_unset_feature_flag(conn, FUSE_CAP_SPLICE_READ);
 	if (!fs->op.lock)
-		conn->want &= ~FUSE_CAP_POSIX_LOCKS;
+		fuse_unset_feature_flag(conn, FUSE_CAP_POSIX_LOCKS);
 	if (!fs->op.flock)
-		conn->want &= ~FUSE_CAP_FLOCK_LOCKS;
-	if (fs->op.init)
+		fuse_unset_feature_flag(conn, FUSE_CAP_FLOCK_LOCKS);
+	if (fs->op.init) {
+		uint64_t want_ext_default = conn->want_ext;
+		uint32_t want_default = fuse_lower_32_bits(conn->want_ext);
+		int rc;
+
+		conn->want = want_default;
 		fs->user_data = fs->op.init(conn, cfg);
+
+		rc = convert_to_conn_want_ext(conn, want_ext_default,
+					      want_default);
+
+		if (rc != 0) {
+			/*
+			 * This is a grave developer error, but
+			 * we cannot return an error here, as the function
+			 * signature does not allow it.
+			 */
+			fuse_log(
+				FUSE_LOG_ERR,
+				"fuse: Aborting due to invalid conn want flags.\n");
+			_exit(EXIT_FAILURE);
+		}
+	}
 }
 
 static int fuse_init_intr_signal(int signum, int *installed);

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -8,8 +8,11 @@
 
 #include "fuse.h"
 #include "fuse_lowlevel.h"
+#include "util.h"
 
+#include <stdint.h>
 #include <stdbool.h>
+#include <errno.h>
 
 #define MIN(a, b) \
 ({									\
@@ -224,3 +227,34 @@ int fuse_loop_cfg_verify(struct fuse_loop_config *config);
 /* room needed in buffer to accommodate header */
 #define FUSE_BUFFER_HEADER_SIZE 0x1000
 
+/**
+ * Get the wanted capability flags, converting from old format if necessary
+ */
+static inline int convert_to_conn_want_ext(struct fuse_conn_info *conn,
+					   uint64_t want_ext_default,
+					   uint32_t want_default)
+{
+	/*
+	 * Convert want to want_ext if necessary.
+	 * For the high level interface this function might be called
+	 * twice, once from the high level interface and once from the
+	 * low level interface. Both, with different want_ext_default and
+	 * want_default values. In order to suppress a failure for the
+	 * second call, we check if the lower 32 bits of want_ext are
+	 * already set to the value of want.
+	 */
+	if (conn->want != want_default &&
+	    fuse_lower_32_bits(conn->want_ext) != conn->want) {
+		if (conn->want_ext != want_ext_default) {
+			fuse_log(FUSE_LOG_ERR,
+				 "fuse: both 'want' and 'want_ext' are set\n");
+			return -EINVAL;
+		}
+
+		/* high bits from want_ext, low bits from want */
+		conn->want_ext = fuse_higher_32_bits(conn->want_ext) |
+				 conn->want;
+	}
+
+	return 0;
+}

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -423,10 +423,17 @@ void fuse_apply_conn_info_opts(struct fuse_conn_info_opts *opts,
 	if(opts->set_max_readahead)
 		conn->max_readahead = opts->max_readahead;
 
-#define LL_ENABLE(cond,cap) \
-	if (cond) conn->want |= (cap)
-#define LL_DISABLE(cond,cap) \
-	if (cond) conn->want &= ~(cap)
+#define LL_ENABLE(cond, cap)                     \
+	do {                                     \
+		if (cond)                        \
+			conn->want |= (cap); \
+	} while (0)
+
+#define LL_DISABLE(cond, cap)                     \
+	do {                                      \
+		if (cond)                         \
+			conn->want &= ~(cap); \
+	} while (0)
 
 	LL_ENABLE(opts->splice_read, FUSE_CAP_SPLICE_READ);
 	LL_DISABLE(opts->no_splice_read, FUSE_CAP_SPLICE_READ);

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -426,13 +426,13 @@ void fuse_apply_conn_info_opts(struct fuse_conn_info_opts *opts,
 #define LL_ENABLE(cond, cap)                     \
 	do {                                     \
 		if (cond)                        \
-			conn->want |= (cap); \
+			conn->want_ext |= (cap); \
 	} while (0)
 
 #define LL_DISABLE(cond, cap)                     \
 	do {                                      \
 		if (cond)                         \
-			conn->want &= ~(cap); \
+			conn->want_ext &= ~(cap); \
 	} while (0)
 
 	LL_ENABLE(opts->splice_read, FUSE_CAP_SPLICE_READ);

--- a/lib/util.h
+++ b/lib/util.h
@@ -1,6 +1,33 @@
+#ifndef FUSE_UTIL_H_
+#define FUSE_UTIL_H_
+
+#include <stdint.h>
+
 #define ROUND_UP(val, round_to) (((val) + (round_to - 1)) & ~(round_to - 1))
 
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
 
 int libfuse_strtol(const char *str, long *res);
+
+/**
+ * Return the low bits of a number
+ */
+static inline uint32_t fuse_lower_32_bits(uint64_t nr)
+{
+	return (uint32_t)(nr & 0xffffffff);
+}
+
+/**
+ * Return the high bits of a number
+ */
+static inline uint64_t fuse_higher_32_bits(uint64_t nr)
+{
+	return nr & ~0xffffffffULL;
+}
+
+#ifndef FUSE_VAR_UNUSED
+#define FUSE_VAR_UNUSED(var) (__attribute__((unused)) var)
+#endif
+
+#endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,6 +16,9 @@ td += executable('readdir_inode', 'readdir_inode.c',
 td += executable('release_unlink_race', 'release_unlink_race.c',
                  dependencies: [ libfuse_dep ],
                  install: false)
+td += executable('test_want_conversion', 'test_want_conversion.c',
+                 dependencies: [ libfuse_dep ],
+                 install: false)
 
 test_scripts = [ 'conftest.py', 'pytest.ini', 'test_examples.py',
                  'util.py', 'test_ctests.py', 'test_custom_io.py' ]

--- a/test/test_want_conversion.c
+++ b/test/test_want_conversion.c
@@ -1,0 +1,152 @@
+#include "util.h"
+#include <string.h>
+#define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 17)
+
+#include "fuse_i.h"
+#include <stdio.h>
+#include <assert.h>
+#include <inttypes.h>
+
+static void print_conn_info(const char *prefix, struct fuse_conn_info *conn)
+{
+	printf("%s: want=0x%" PRIx32 " want_ext=0x%" PRIx64 "\n", prefix,
+	       conn->want, conn->want_ext);
+}
+
+static void application_init(struct fuse_conn_info *conn)
+{
+	/* Simulate application init */
+	conn->want |= FUSE_CAP_ASYNC_READ;
+	conn->want &= ~FUSE_CAP_SPLICE_READ;
+}
+
+static void test_fuse_fs_init(struct fuse_conn_info *conn)
+{
+	uint64_t want_ext_default = conn->want_ext;
+	uint32_t want_default = fuse_lower_32_bits(conn->want_ext);
+	int rc;
+
+	/* High-level init */
+	fuse_set_feature_flag(conn, FUSE_CAP_EXPORT_SUPPORT);
+
+	conn->want = want_default;
+
+	application_init(conn);
+
+	rc = convert_to_conn_want_ext(conn, want_ext_default, want_default);
+	assert(rc == 0);
+}
+
+static void test_do_init(struct fuse_conn_info *conn)
+{
+	/* Initial setup */
+	conn->capable_ext = FUSE_CAP_SPLICE_READ | FUSE_CAP_SPLICE_WRITE |
+			    FUSE_CAP_SPLICE_MOVE | FUSE_CAP_POSIX_LOCKS |
+			    FUSE_CAP_FLOCK_LOCKS | FUSE_CAP_EXPORT_SUPPORT;
+	conn->capable = fuse_lower_32_bits(conn->capable_ext);
+	conn->want_ext = conn->capable_ext;
+
+	print_conn_info("Initial state", conn);
+
+	uint64_t want_ext_default = conn->want_ext;
+	uint32_t want_default = fuse_lower_32_bits(conn->want_ext);
+	int rc;
+
+	conn->want = want_default;
+	conn->capable = fuse_lower_32_bits(conn->capable_ext);
+
+	test_fuse_fs_init(conn);
+
+	rc = convert_to_conn_want_ext(conn, want_ext_default, want_default);
+	assert(rc == 0);
+
+	/* Verify all expected flags are set */
+	assert(!(conn->want_ext & FUSE_CAP_SPLICE_READ));
+	assert(conn->want_ext & FUSE_CAP_SPLICE_WRITE);
+	assert(conn->want_ext & FUSE_CAP_SPLICE_MOVE);
+	assert(conn->want_ext & FUSE_CAP_POSIX_LOCKS);
+	assert(conn->want_ext & FUSE_CAP_FLOCK_LOCKS);
+	assert(conn->want_ext & FUSE_CAP_EXPORT_SUPPORT);
+	assert(conn->want_ext & FUSE_CAP_ASYNC_READ);
+	/* Verify no other flags are set */
+	assert(conn->want_ext ==
+	       (FUSE_CAP_SPLICE_WRITE | FUSE_CAP_SPLICE_MOVE |
+		FUSE_CAP_POSIX_LOCKS | FUSE_CAP_FLOCK_LOCKS |
+		FUSE_CAP_EXPORT_SUPPORT | FUSE_CAP_ASYNC_READ));
+
+	print_conn_info("After init", conn);
+}
+
+static void test_want_conversion_basic(void)
+{
+	struct fuse_conn_info conn = { 0 };
+
+	printf("\nTesting basic want conversion:\n");
+	test_do_init(&conn);
+	print_conn_info("After init", &conn);
+}
+
+static void test_want_conversion_conflict(void)
+{
+	struct fuse_conn_info conn = { 0 };
+	int rc;
+
+	printf("\nTesting want conversion conflict:\n");
+
+	/* Test conflicting values */
+	/* Initialize like fuse_lowlevel.c does */
+	conn.capable_ext = FUSE_CAP_SPLICE_READ | FUSE_CAP_SPLICE_WRITE |
+			   FUSE_CAP_SPLICE_MOVE | FUSE_CAP_POSIX_LOCKS |
+			   FUSE_CAP_FLOCK_LOCKS;
+	conn.capable = fuse_lower_32_bits(conn.capable_ext);
+	conn.want_ext = conn.capable_ext;
+	conn.want = fuse_lower_32_bits(conn.want_ext);
+	print_conn_info("Test conflict initial", &conn);
+
+	/* Initialize default values like in basic test */
+	uint64_t want_ext_default_ll = conn.want_ext;
+	uint32_t want_default_ll = fuse_lower_32_bits(want_ext_default_ll);
+
+	/* Simulate application init modifying capabilities */
+	conn.want_ext |= FUSE_CAP_ATOMIC_O_TRUNC; /* Add new capability */
+	conn.want &= ~FUSE_CAP_SPLICE_READ; /* Remove a capability */
+
+	rc = convert_to_conn_want_ext(&conn, want_ext_default_ll,
+				      want_default_ll);
+	assert(rc == -EINVAL);
+	print_conn_info("Test conflict after", &conn);
+
+	printf("Want conversion conflict test passed\n");
+}
+
+static void test_want_conversion_high_bits(void)
+{
+	struct fuse_conn_info conn = { 0 };
+	int rc;
+
+	printf("\nTesting want conversion high bits preservation:\n");
+
+	/* Test high bits preservation */
+	conn.want_ext = (1ULL << 33) | FUSE_CAP_ASYNC_READ;
+	conn.want = fuse_lower_32_bits(conn.want_ext);
+	print_conn_info("Test high bits initial", &conn);
+
+	uint64_t want_ext_default_ll = conn.want_ext;
+	uint32_t want_default_ll = fuse_lower_32_bits(want_ext_default_ll);
+
+	rc = convert_to_conn_want_ext(&conn, want_ext_default_ll,
+				      want_default_ll);
+	assert(rc == 0);
+	assert(conn.want_ext == ((1ULL << 33) | FUSE_CAP_ASYNC_READ));
+	print_conn_info("Test high bits after", &conn);
+
+	printf("Want conversion high bits test passed\n");
+}
+
+int main(void)
+{
+	test_want_conversion_basic();
+	test_want_conversion_conflict();
+	test_want_conversion_high_bits();
+	return 0;
+}

--- a/test/test_write_cache.c
+++ b/test/test_write_cache.c
@@ -66,7 +66,7 @@ static void tfs_init(void *userdata, struct fuse_conn_info *conn)
 
 	if (options.writeback) {
 		assert(fuse_get_feature_flag(conn, FUSE_CAP_WRITEBACK_CACHE));
-		conn->want |= FUSE_CAP_WRITEBACK_CACHE;
+		fuse_set_feature_flag(conn, FUSE_CAP_WRITEBACK_CACHE);
 	}
 }
 

--- a/test/test_write_cache.c
+++ b/test/test_write_cache.c
@@ -6,7 +6,6 @@
   See the file COPYING.
 */
 
-
 #define FUSE_USE_VERSION 30
 
 /* Not really needed - just to test build with FUSE_USE_VERSION == 30 */
@@ -37,24 +36,22 @@
 
 /* Command line parsing */
 struct options {
-    int writeback;
-    int data_size;
-    int delay_ms;
+	int writeback;
+	int data_size;
+	int delay_ms;
 } options = {
-    .writeback = 0,
-    .data_size = 2048,
-    .delay_ms = 0,
+	.writeback = 0,
+	.data_size = 2048,
+	.delay_ms = 0,
 };
 
 #define WRITE_SYSCALLS 64
 
-#define OPTION(t, p)                           \
-    { t, offsetof(struct options, p), 1 }
+#define OPTION(t, p) { t, offsetof(struct options, p), 1 }
 static const struct fuse_opt option_spec[] = {
-    OPTION("writeback_cache", writeback),
-    OPTION("--data-size=%d", data_size),
-    OPTION("--delay_ms=%d", delay_ms),
-    FUSE_OPT_END
+	OPTION("writeback_cache", writeback),
+	OPTION("--data-size=%d", data_size), OPTION("--delay_ms=%d", delay_ms),
+	FUSE_OPT_END
 };
 static int got_write;
 static atomic_int write_cnt;
@@ -63,229 +60,241 @@ pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static int write_start, write_done;
 
-static void tfs_init (void *userdata, struct fuse_conn_info *conn)
+static void tfs_init(void *userdata, struct fuse_conn_info *conn)
 {
-    (void) userdata;
+	(void)userdata;
 
-    if(options.writeback) {
-        assert(fuse_get_feature_flag(conn, FUSE_CAP_WRITEBACK_CACHE));
-        conn->want |= FUSE_CAP_WRITEBACK_CACHE;
-    }
+	if (options.writeback) {
+		assert(fuse_get_feature_flag(conn, FUSE_CAP_WRITEBACK_CACHE));
+		conn->want |= FUSE_CAP_WRITEBACK_CACHE;
+	}
 }
 
-static int tfs_stat(fuse_ino_t ino, struct stat *stbuf) {
-    stbuf->st_ino = ino;
-    if (ino == FUSE_ROOT_ID) {
-        stbuf->st_mode = S_IFDIR | 0755;
-        stbuf->st_nlink = 1;
-    }
+static int tfs_stat(fuse_ino_t ino, struct stat *stbuf)
+{
+	stbuf->st_ino = ino;
+	if (ino == FUSE_ROOT_ID) {
+		stbuf->st_mode = S_IFDIR | 0755;
+		stbuf->st_nlink = 1;
+	}
 
-    else if (ino == FILE_INO) {
-        stbuf->st_mode = S_IFREG | 0222;
-        stbuf->st_nlink = 1;
-        stbuf->st_size = 0;
-    }
+	else if (ino == FILE_INO) {
+		stbuf->st_mode = S_IFREG | 0222;
+		stbuf->st_nlink = 1;
+		stbuf->st_size = 0;
+	}
 
-    else
-        return -1;
+	else
+		return -1;
 
-    return 0;
+	return 0;
 }
 
-static void tfs_lookup(fuse_req_t req, fuse_ino_t parent,
-                       const char *name) {
-    struct fuse_entry_param e;
-    memset(&e, 0, sizeof(e));
+static void tfs_lookup(fuse_req_t req, fuse_ino_t parent, const char *name)
+{
+	struct fuse_entry_param e;
 
-    if (parent != FUSE_ROOT_ID)
-        goto err_out;
-    else if (strcmp(name, FILE_NAME) == 0)
-        e.ino = FILE_INO;
-    else
-        goto err_out;
+	memset(&e, 0, sizeof(e));
 
-    if (tfs_stat(e.ino, &e.attr) != 0)
-        goto err_out;
-    fuse_reply_entry(req, &e);
-    return;
+	if (parent != FUSE_ROOT_ID)
+		goto err_out;
+	else if (strcmp(name, FILE_NAME) == 0)
+		e.ino = FILE_INO;
+	else
+		goto err_out;
+
+	if (tfs_stat(e.ino, &e.attr) != 0)
+		goto err_out;
+	fuse_reply_entry(req, &e);
+	return;
 
 err_out:
-    fuse_reply_err(req, ENOENT);
+	fuse_reply_err(req, ENOENT);
 }
 
 static void tfs_getattr(fuse_req_t req, fuse_ino_t ino,
-                        struct fuse_file_info *fi) {
-    struct stat stbuf;
+			struct fuse_file_info *fi)
+{
+	struct stat stbuf;
 
-    (void) fi;
+	(void)fi;
 
-    memset(&stbuf, 0, sizeof(stbuf));
-    if (tfs_stat(ino, &stbuf) != 0)
-        fuse_reply_err(req, ENOENT);
-    else
-        fuse_reply_attr(req, &stbuf, 5);
+	memset(&stbuf, 0, sizeof(stbuf));
+	if (tfs_stat(ino, &stbuf) != 0)
+		fuse_reply_err(req, ENOENT);
+	else
+		fuse_reply_attr(req, &stbuf, 5);
 }
 
-static void tfs_open(fuse_req_t req, fuse_ino_t ino,
-                     struct fuse_file_info *fi) {
-    if (ino == FUSE_ROOT_ID)
-        fuse_reply_err(req, EISDIR);
-    else {
-        assert(ino == FILE_INO);
-        /* Test close(rofd) does not block waiting for pending writes */
-        fi->noflush = !options.writeback && options.delay_ms &&
-                      (fi->flags & O_ACCMODE) == O_RDONLY;
-        fuse_reply_open(req, fi);
-    }
+static void tfs_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
+{
+	if (ino == FUSE_ROOT_ID)
+		fuse_reply_err(req, EISDIR);
+	else {
+		assert(ino == FILE_INO);
+		/* Test close(rofd) does not block waiting for pending writes */
+		fi->noflush = !options.writeback && options.delay_ms &&
+			      (fi->flags & O_ACCMODE) == O_RDONLY;
+		fuse_reply_open(req, fi);
+	}
 }
 
 static void tfs_write(fuse_req_t req, fuse_ino_t ino, const char *buf,
-                      size_t size, off_t off, struct fuse_file_info *fi) {
-    (void) fi; (void) buf; (void) off;
-    size_t expected;
+		      size_t size, off_t off, struct fuse_file_info *fi)
+{
+	(void)fi;
+	(void)buf;
+	(void)off;
+	size_t expected;
 
-    assert(ino == FILE_INO);
-    expected = options.data_size;
-    if(options.writeback)
-        expected *= 2;
+	assert(ino == FILE_INO);
+	expected = options.data_size;
+	if (options.writeback)
+		expected *= 2;
 
-    write_cnt++;
+	write_cnt++;
 
-   if(size != expected && !options.writeback)
-       fprintf(stderr, "ERROR: Expected %zd bytes, got %zd\n!",
-               expected, size);
-   else
-      got_write = 1;
+	if (size != expected && !options.writeback)
+		fprintf(stderr, "ERROR: Expected %zd bytes, got %zd\n!",
+			expected, size);
+	else
+		got_write = 1;
 
-    /* Simulate waiting for pending writes */
-    if (options.delay_ms) {
-        pthread_mutex_lock(&lock);
-        write_start = 1;
-        pthread_cond_signal(&cond);
-        pthread_mutex_unlock(&lock);
+	/* Simulate waiting for pending writes */
+	if (options.delay_ms) {
+		pthread_mutex_lock(&lock);
+		write_start = 1;
+		pthread_cond_signal(&cond);
+		pthread_mutex_unlock(&lock);
 
-        usleep(options.delay_ms * 1000);
+		usleep(options.delay_ms * 1000);
 
-        pthread_mutex_lock(&lock);
-        write_done = 1;
-        pthread_cond_signal(&cond);
-        pthread_mutex_unlock(&lock);
-    }
+		pthread_mutex_lock(&lock);
+		write_done = 1;
+		pthread_cond_signal(&cond);
+		pthread_mutex_unlock(&lock);
+	}
 
-    fuse_reply_write(req, size);
+	fuse_reply_write(req, size);
 }
 
 static struct fuse_lowlevel_ops tfs_oper = {
-    .init       = tfs_init,
-    .lookup	= tfs_lookup,
-    .getattr	= tfs_getattr,
-    .open	= tfs_open,
-    .write	= tfs_write,
+	.init = tfs_init,
+	.lookup = tfs_lookup,
+	.getattr = tfs_getattr,
+	.open = tfs_open,
+	.write = tfs_write,
 };
 
-static void* close_rofd(void *data) {
-    int rofd = (int)(long) data;
+static void *close_rofd(void *data)
+{
+	int rofd = (int)(long)data;
 
-    /* Wait for first write to start */
-    pthread_mutex_lock(&lock);
-    while (!write_start && !write_done)
-        pthread_cond_wait(&cond, &lock);
-    pthread_mutex_unlock(&lock);
+	/* Wait for first write to start */
+	pthread_mutex_lock(&lock);
+	while (!write_start && !write_done)
+		pthread_cond_wait(&cond, &lock);
+	pthread_mutex_unlock(&lock);
 
-    close(rofd);
-    printf("rofd closed. write_start: %d write_done: %d\n", write_start, write_done);
+	close(rofd);
+	printf("rofd closed. write_start: %d write_done: %d\n", write_start,
+	       write_done);
 
-    /* First write should not have been completed */
-    if (write_done)
-        fprintf(stderr, "ERROR: close(rofd) blocked on write!\n");
+	/* First write should not have been completed */
+	if (write_done)
+		fprintf(stderr, "ERROR: close(rofd) blocked on write!\n");
 
-    return NULL;
+	return NULL;
 }
 
-static void* run_fs(void *data) {
-    struct fuse_session *se = (struct fuse_session*) data;
-    assert(fuse_session_loop(se) == 0);
-    return NULL;
+static void *run_fs(void *data)
+{
+	struct fuse_session *se = (struct fuse_session *)data;
+
+	assert(fuse_session_loop(se) == 0);
+	return NULL;
 }
 
-static void test_fs(char *mountpoint) {
-    char fname[PATH_MAX];
-    char *buf;
-    const size_t iosize = options.data_size;
-    const size_t dsize = options.data_size * WRITE_SYSCALLS;
-    int fd, rofd;
-    pthread_t rofd_thread;
-    off_t off = 0;
+static void test_fs(char *mountpoint)
+{
+	char fname[PATH_MAX];
+	char *buf;
+	const size_t iosize = options.data_size;
+	const size_t dsize = options.data_size * WRITE_SYSCALLS;
+	int fd, rofd;
+	pthread_t rofd_thread;
+	off_t off = 0;
 
-    buf = malloc(dsize);
-    assert(buf != NULL);
-    assert((fd = open("/dev/urandom", O_RDONLY)) != -1);
-    assert(read(fd, buf, dsize) == dsize);
-    close(fd);
+	buf = malloc(dsize);
+	assert(buf != NULL);
+	assert((fd = open("/dev/urandom", O_RDONLY)) != -1);
+	assert(read(fd, buf, dsize) == dsize);
+	close(fd);
 
-    assert(snprintf(fname, PATH_MAX, "%s/" FILE_NAME,
-                     mountpoint) > 0);
-    fd = open(fname, O_WRONLY);
-    if (fd == -1) {
-        perror(fname);
-        assert(0);
-    }
+	assert(snprintf(fname, PATH_MAX, "%s/" FILE_NAME, mountpoint) > 0);
+	fd = open(fname, O_WRONLY);
+	if (fd == -1) {
+		perror(fname);
+		assert(0);
+	}
 
-    if (options.delay_ms) {
-        /* Verify that close(rofd) does not block waiting for pending writes */
-        rofd = open(fname, O_RDONLY);
-        assert(pthread_create(&rofd_thread, NULL, close_rofd, (void *)(long)rofd) == 0);
-        /* Give close_rofd time to start */
-        usleep(options.delay_ms * 1000);
-    }
+	if (options.delay_ms) {
+		/* Verify that close(rofd) does not block waiting for pending writes */
+		rofd = open(fname, O_RDONLY);
+		assert(pthread_create(&rofd_thread, NULL, close_rofd,
+				      (void *)(long)rofd) == 0);
+		/* Give close_rofd time to start */
+		usleep(options.delay_ms * 1000);
+	}
 
-    for (int cnt = 0; cnt < WRITE_SYSCALLS; cnt++) {
-        assert(pwrite(fd, buf + off, iosize, off) == iosize);
-        off += iosize;
-        assert(off <= dsize);
-    }
-    free(buf);
-    close(fd);
+	for (int cnt = 0; cnt < WRITE_SYSCALLS; cnt++) {
+		assert(pwrite(fd, buf + off, iosize, off) == iosize);
+		off += iosize;
+		assert(off <= dsize);
+	}
+	free(buf);
+	close(fd);
 
-    if (options.delay_ms) {
-        printf("rwfd closed. write_start: %d write_done: %d\n", write_start, write_done);
-        assert(pthread_join(rofd_thread, NULL) == 0);
-    }
+	if (options.delay_ms) {
+		printf("rwfd closed. write_start: %d write_done: %d\n",
+		       write_start, write_done);
+		assert(pthread_join(rofd_thread, NULL) == 0);
+	}
 }
 
-int main(int argc, char *argv[]) {
-    struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
-    struct fuse_session *se;
-    struct fuse_cmdline_opts fuse_opts;
-    pthread_t fs_thread;
+int main(int argc, char *argv[])
+{
+	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
+	struct fuse_session *se;
+	struct fuse_cmdline_opts fuse_opts;
+	pthread_t fs_thread;
 
-    assert(fuse_opt_parse(&args, &options, option_spec, NULL) == 0);
-    assert(fuse_parse_cmdline(&args, &fuse_opts) == 0);
-#ifndef __FreeBSD__    
-    assert(fuse_opt_add_arg(&args, "-oauto_unmount") == 0);
+	assert(fuse_opt_parse(&args, &options, option_spec, NULL) == 0);
+	assert(fuse_parse_cmdline(&args, &fuse_opts) == 0);
+#ifndef __FreeBSD__
+	assert(fuse_opt_add_arg(&args, "-oauto_unmount") == 0);
 #endif
-    se = fuse_session_new(&args, &tfs_oper,
-                          sizeof(tfs_oper), NULL);
-    fuse_opt_free_args(&args);
-    assert (se != NULL);
-    assert(fuse_set_signal_handlers(se) == 0);
-    assert(fuse_session_mount(se, fuse_opts.mountpoint) == 0);
+	se = fuse_session_new(&args, &tfs_oper, sizeof(tfs_oper), NULL);
+	fuse_opt_free_args(&args);
+	assert(se != NULL);
+	assert(fuse_set_signal_handlers(se) == 0);
+	assert(fuse_session_mount(se, fuse_opts.mountpoint) == 0);
 
-    /* Start file-system thread */
-    assert(pthread_create(&fs_thread, NULL, run_fs, (void *)se) == 0);
+	/* Start file-system thread */
+	assert(pthread_create(&fs_thread, NULL, run_fs, (void *)se) == 0);
 
-    /* Write test data */
-    test_fs(fuse_opts.mountpoint);
-    free(fuse_opts.mountpoint);
+	/* Write test data */
+	test_fs(fuse_opts.mountpoint);
+	free(fuse_opts.mountpoint);
 
-    /* Stop file system */
-    fuse_session_exit(se);
-    fuse_session_unmount(se);
-    assert(pthread_join(fs_thread, NULL) == 0);
+	/* Stop file system */
+	fuse_session_exit(se);
+	fuse_session_unmount(se);
+	assert(pthread_join(fs_thread, NULL) == 0);
 
-    assert(got_write == 1);
+	assert(got_write == 1);
 
-    /*
+	/*
      * when writeback cache is enabled, kernel side can merge requests, but
      * memory pressure, system 'sync' might trigger data flushes before - flush
      * might happen in between write syscalls - merging subpage writes into
@@ -293,18 +302,17 @@ int main(int argc, char *argv[]) {
      * Though we can expect that that at least some (but maybe all) write
      * system calls can be merged.
      */
-    if (options.writeback)
-        assert(write_cnt < WRITE_SYSCALLS);
-    else
-        assert(write_cnt == WRITE_SYSCALLS);
+	if (options.writeback)
+		assert(write_cnt < WRITE_SYSCALLS);
+	else
+		assert(write_cnt == WRITE_SYSCALLS);
 
-    fuse_remove_signal_handlers(se);
-    fuse_session_destroy(se);
+	fuse_remove_signal_handlers(se);
+	fuse_session_destroy(se);
 
-    printf("Test completed successfully.\n");
-    return 0;
+	printf("Test completed successfully.\n");
+	return 0;
 }
-
 
 /**
  * Local Variables:


### PR DESCRIPTION
32-bit conn->want flags been left to be ABI compatible to 3.10, even though the so version was changed.
The more recent way is to use fuse_set_feature_flag(), which will use conn->want_ext.

Given that we now have two flags (want and want_ext), we need to convert and that brought several issues
- If the application sets conn->want, that needs to be set into the lower 32 bit of  conn->want_ext. As the application might actually unset values, it really has to be a copy and not just 'or' - fixed now.
- convert_to_conn_want_ext() actually needs to check for _modified_ conn->want and conn->want_ext
- convert_to_conn_want_ext() must consider being called from high and lowlevel interfact, with different want_ext_default and want_default values. It is only a failure, if the application changed both, conn->want and conn->want_ext. This function was failing in issue #1171, because high level fuse_fs_init() was changing values and then lowlevel do_init() was incorrectly failing on that.

This also adds a new test (test_want_conversion) and sets values into example/{hello.c,hello_ll.c}

Also some more internal users of conn->want are converted to fuse_{set,unset}_feature_flag().

closes: https://github.com/libfuse/libfuse/issues/1171