### PR TITLE
checkpatch: Ignore dependabot commits

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -28,6 +28,11 @@ jobs:
         echo "Base commit: $base_commit"
         echo "Running checkpatch.pl on all commits in the PR:"
         git rev-list --reverse $base_commit..HEAD | while read commit; do
+          # Skip dependabot commits - we do not have control over it
+          if git log -1 --format='%ae' $commit | grep -q "dependabot"; then
+            echo "Skipping dependabot commit: $commit"
+            continue
+          fi
           subject=$(git log -1 --format=%s $commit)
           echo "Checking commit: $commit - $subject"
           if ! ./checkpatch.pl --max-line-length=100 --no-tree --ignore MAINTAINERS,SPDX_LICENSE_TAG,COMMIT_MESSAGE,FILE_PATH_CHANGES,EMAIL_SUBJECT,AVOID_EXTERNS,GIT_COMMIT_ID,ENOSYS_SYSCALL,ENOSYS,FROM_SIGN_OFF_MISMATCH,QUOTED_COMMIT_ID,PREFER_ATTRIBUTE_ALWAYS_UNUSED,PREFER_DEFINED_ATTRIBUTE_MACRO  -g $commit; then


### PR DESCRIPTION
Thes commits have the habit to persistently fail, mostly with long lines. We don't have control over these commits, so let's ignore them.