### PR TITLE
example/hello_ll.c: Fix the failure of the pkg-config command on CentOS

### DIFF
--- a/example/hello_ll.c
+++ b/example/hello_ll.c
@@ -14,6 +14,11 @@
  *
  *     gcc -Wall hello_ll.c `pkg-config fuse3 --cflags --libs` -o hello_ll
  *
+ * Note: On CentOS, if the libfuse library is manually built and installed
+ *     using Meson, use the following compilation command:
+ *     gcc -Wall hello_ll.c `PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig \
+ *     pkg-config fuse3 --cflags --libs` -o hello_ll
+ *
  * ## Source code ##
  * \include hello_ll.c
  */


### PR DESCRIPTION
When building and installing FUSE3 using Meson on CentOS, the fuse3.pc file is installed in the /usr/local/lib64/pkgconfig directory. However, pkg-config does not search for fuse3.pc in this directory, leading to GCC compilation failures for related examples.

This patch adds a new GCC command for users that can be executed successfully on CentOS.