### PR TITLE
example/hello_ll.c: Improve the compilation comments

### DIFF
--- a/example/hello_ll.c
+++ b/example/hello_ll.c
@@ -14,6 +14,10 @@
  *
  *     gcc -Wall hello_ll.c `pkg-config fuse3 --cflags --libs` -o hello_ll
  *
+ * Note: If the pkg-config command fails due to the absence of the fuse3.pc
+ *     file, you should configure the path to the fuse3.pc file in the
+ *     PKG_CONFIG_PATH variable.
+ *
  * ## Source code ##
  * \include hello_ll.c
  */


### PR DESCRIPTION
When building and installing FUSE3 using Meson on CentOS8, the fuse3.pc
file is installed in the /usr/local/lib64/pkgconfig directory. However,
pkg-config does not search for fuse3.pc in this directory, leading to GCC
compilation failures.

This patch improves the compilation comments, helping users successfully
execute the GCC command.