### PR TITLE
example: Add a compilation instruction in README.compile

### DIFF
--- a/example/README.compile
+++ b/example/README.compile
@@ -1,0 +1,4 @@
+Note:
+  * If the pkg-config command fails due to the absence of the fuse3.pc file,
+  you should configure the path to the fuse3.pc file in the PKG_CONFIG_PATH
+  variable.


### PR DESCRIPTION
When building FUSE3 with Meson on CentOS 8, the fuse3.pc file gets
installed in /usr/local/lib64/pkgconfig. Since pkg-config doesn't search
this path by default, GCC compilation fails due to missing FUSE3 flags.

This patch adds an instruction for setting PKG_CONFIG_PATH variable in 
README.compile to fix GCC compilation issues.