### PR TITLE
Fix build with kernel < 5.9

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -72,7 +72,7 @@ private_cfg.set_quoted('PACKAGE_VERSION', meson.project_version())
 # Test for presence of some functions
 test_funcs = [ 'fork', 'fstatat', 'openat', 'readlinkat', 'pipe2',
                'splice', 'vmsplice', 'posix_fallocate', 'fdatasync',
-               'utimensat', 'copy_file_range', 'fallocate', 'close_range' ]
+               'utimensat', 'copy_file_range', 'fallocate' ]
 foreach func : test_funcs
     private_cfg.set('HAVE_' + func.to_upper(),
         cc.has_function(func, prefix: include_default, args: args_default))
@@ -83,6 +83,10 @@ private_cfg.set('HAVE_ICONV',
         cc.has_function('iconv', prefix: '#include <iconv.h>'))
 private_cfg.set('HAVE_BACKTRACE',
         cc.has_function('backtrace', prefix: '#include <execinfo.h>'))
+
+# Test if headers exist
+private_cfg.set('HAVE_LINUX_CLOSE_RANGE_H',
+        cc.check_header('#include <linux/close_range.h>'))
 
 # Test if structs have specific member
 private_cfg.set('HAVE_STRUCT_STAT_ST_ATIM',

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 #include <sys/vfs.h>
 
-#ifdef HAVE_CLOSE_RANGE
+#ifdef HAVE_LINUX_CLOSE_RANGE_H
 #include <linux/close_range.h>
 #endif
 
@@ -1477,7 +1477,7 @@ static int close_inherited_fds(int cfd)
 	if (cfd <= STDERR_FILENO)
 		return -EINVAL;
 
-#ifdef HAVE_CLOSE_RANGE
+#ifdef HAVE_LINUX_CLOSE_RANGE_H
 	if (cfd < STDERR_FILENO + 2) {
 		close_range_loop(STDERR_FILENO + 1, cfd - 1, cfd);
 	} else {


### PR DESCRIPTION
linux/close_range.h is only available since kernel 5.9 and https://github.com/torvalds/linux/commit/60997c3d45d9a67daf01c56d805ae4fec37e0bd8 resulting in the following build failure:

../util/fusermount.c:40:10: fatal error: linux/close_range.h: No such file or directory

So let's check for header presence and emit HAVE_LINUX_CLOSE_RANGE_H accordingly and check for it when including <linux/close_range.h>.