### PR TITLE
meson: add option for enabling usdt

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -98,6 +98,8 @@ private_cfg.set('HAVE_STRUCT_STAT_ST_ATIMESPEC',
                        prefix: include_default,
                        args: args_default))
 
+private_cfg.set('USDT_ENABLED', get_option('enable-usdt'))
+
 #
 # Compiler configuration
 #

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,3 +22,5 @@ option('tests', type : 'boolean', value : true,
 option('disable-libc-symbol-version', type : 'boolean', value : false,
        description: 'Disable versioned symbols through libc')
 
+option('enable-usdt', type : 'boolean', value : false,
+       description: 'Enable user statically defined tracepoints for extra observability')


### PR DESCRIPTION
Default is having usdt disabled.