### PR TITLE
Fix static_assert build failure with C++ version < 11

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -30,9 +30,7 @@
 #define FUSE_MAKE_VERSION(maj, min)  ((maj) * 100 + (min))
 #define FUSE_VERSION FUSE_MAKE_VERSION(FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION)
 
-#if (defined(__cplusplus) && __cplusplus >= 201103L) ||        \
-	(!defined(__cplusplus) && defined(__STDC_VERSION__) && \
-	 __STDC_VERSION__ >= 201112L)
+#ifdef HAVE_STATIC_ASSERT
 #define fuse_static_assert(condition, message) static_assert(condition, message)
 #else
 #define fuse_static_assert(condition, message)

--- a/meson.build
+++ b/meson.build
@@ -72,7 +72,7 @@ private_cfg.set_quoted('PACKAGE_VERSION', meson.project_version())
 # Test for presence of some functions
 test_funcs = [ 'fork', 'fstatat', 'openat', 'readlinkat', 'pipe2',
                'splice', 'vmsplice', 'posix_fallocate', 'fdatasync',
-               'utimensat', 'copy_file_range', 'fallocate' ]
+               'utimensat', 'copy_file_range', 'fallocate', 'static_assert' ]
 foreach func : test_funcs
     private_cfg.set('HAVE_' + func.to_upper(),
         cc.has_function(func, prefix: include_default, args: args_default))


### PR DESCRIPTION
At the moment build fails due to lack of static_assert: https://gitlab.com/jolivain/buildroot/-/jobs/9606292537 this means that the check per date is not enough, so let's use meson to check if static_assert() is present or not and simplify fuse_static_assert() definition by only checking HAVE_STATIC_ASSERT.