### PR TITLE
fuse_lowlevel: Set bufsize if HAVE_SPLICE is not define and avoid race

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -228,6 +228,9 @@ static void sfs_init(void *userdata, fuse_conn_info *conn) {
 
     /* Disable the receiving and processing of FUSE_INTERRUPT requests */
     conn->no_interrupt = 1;
+
+    /* Try a large IO by default */
+    conn->max_write = 4 * 1024 * 1024;
 }
 
 


### PR DESCRIPTION
These are two buf size fixes

1) Set bufsize when HAVE_SPLICE is not defined. Addresses https://github.com/libfuse/libfuse/issues/1184

2) Check in the read retry condition for bufsize, i.e. the value passed to read and not for the buf->mem_size. Using buf->mem_size can be startup racy. Additionally we now also set bufsize on allocation to avoid these races.

This also tries to set large sizes in passthrough_hp, to catch issues in xfstests - though requires to set
/proc/sys/fs/fuse/max_pages_limit