### PR TITLE
mount: Add FUSE_KERN_DEVICE env variable to specify fuse kernel device

### DIFF
--- a/lib/mount.c
+++ b/lib/mount.c
@@ -49,6 +49,7 @@
 #define FUSERMOUNT_PROG		"fusermount3"
 #define FUSE_COMMFD_ENV		"_FUSE_COMMFD"
 #define FUSE_COMMFD2_ENV	"_FUSE_COMMFD2"
+#define FUSE_KERN_DEVICE_ENV	"FUSE_KERN_DEVICE"
 
 #ifndef MS_DIRSYNC
 #define MS_DIRSYNC 128
@@ -506,7 +507,7 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
 			  const char *mnt_opts)
 {
 	char tmp[128];
-	const char *devname = "/dev/fuse";
+	const char *devname = getenv(FUSE_KERN_DEVICE_ENV) ?: "/dev/fuse";
 	char *source = NULL;
 	char *type = NULL;
 	struct stat stbuf;
@@ -528,7 +529,9 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
 	fd = open(devname, O_RDWR | O_CLOEXEC);
 	if (fd == -1) {
 		if (errno == ENODEV || errno == ENOENT)
-			fuse_log(FUSE_LOG_ERR, "fuse: device not found, try 'modprobe fuse' first\n");
+			fuse_log(FUSE_LOG_ERR,
+				"fuse: device %s not found. Kernel module not loaded?\n",
+				devname);
 		else
 			fuse_log(FUSE_LOG_ERR, "fuse: failed to open %s: %s\n",
 				devname, strerror(errno));

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -41,6 +41,7 @@
 #endif
 
 #define FUSE_COMMFD_ENV		"_FUSE_COMMFD"
+#define FUSE_KERN_DEVICE_ENV	"FUSE_KERN_DEVICE"
 
 #define FUSE_DEV "/dev/fuse"
 
@@ -1163,56 +1164,30 @@ static int check_perm(const char **mntp, struct stat *stbuf, int *mountpoint_fd)
 	return -1;
 }
 
-static int try_open(const char *dev, char **devp, int silent)
-{
-	int fd = open(dev, O_RDWR);
-	if (fd != -1) {
-		*devp = strdup(dev);
-		if (*devp == NULL) {
-			fprintf(stderr, "%s: failed to allocate memory\n",
-				progname);
-			close(fd);
-			fd = -1;
-		}
-	} else if (errno == ENODEV ||
-		   errno == ENOENT)/* check for ENOENT too, for the udev case */
-		return -2;
-	else if (!silent) {
-		fprintf(stderr, "%s: failed to open %s: %s\n", progname, dev,
-			strerror(errno));
-	}
-	return fd;
-}
-
-static int try_open_fuse_device(char **devp)
+static int open_fuse_device(const char *dev)
 {
 	int fd;
 
 	drop_privs();
-	fd = try_open(FUSE_DEV, devp, 0);
+	fd = open(dev, O_RDWR);
+	if (fd == -1) {
+		if (errno == ENODEV || errno == ENOENT)/* check for ENOENT too, for the udev case */
+			fprintf(stderr,
+				"%s: fuse device %s not found. Kernel module not loaded?\n",
+				progname, dev);
+		else
+			fprintf(stderr,
+				"%s: failed to open %s: %s\n", progname, dev, strerror(errno));
+	}
 	restore_privs();
 	return fd;
 }
-
-static int open_fuse_device(char **devp)
-{
-	int fd = try_open_fuse_device(devp);
-	if (fd >= -1)
-		return fd;
-
-	fprintf(stderr,
-		"%s: fuse device not found, try 'modprobe fuse' first\n",
-		progname);
-
-	return -1;
-}
-
 
 static int mount_fuse(const char *mnt, const char *opts, const char **type)
 {
 	int res;
 	int fd;
-	char *dev;
+	const char *dev = getenv(FUSE_KERN_DEVICE_ENV) ?: FUSE_DEV;
 	struct stat stbuf;
 	char *source = NULL;
 	char *mnt_opts = NULL;
@@ -1221,7 +1196,7 @@ static int mount_fuse(const char *mnt, const char *opts, const char **type)
 	char *do_mount_opts = NULL;
 	char *x_opts = NULL;
 
-	fd = open_fuse_device(&dev);
+	fd = open_fuse_device(dev);
 	if (fd == -1)
 		return -1;
 
@@ -1292,7 +1267,6 @@ static int mount_fuse(const char *mnt, const char *opts, const char **type)
 out_free:
 	free(source);
 	free(mnt_opts);
-	free(dev);
 	free(x_opts);
 	free(do_mount_opts);
 


### PR DESCRIPTION
For kernel development it might be necessary to load a module with renamed symbols and renamed /dev/<devicenode>. Reason is that for example ubuntu kernels have fuse compiled in and it is not possible to replace it at run time. And fuse might also be used for other file systems - a different device node is then needed.