### PR TITLE
conn: prevent duplicate flag conversion in high-level interface

### DIFF
--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -256,5 +256,8 @@ static inline int convert_to_conn_want_ext(struct fuse_conn_info *conn,
 				 conn->want;
 	}
 
+	/* ensure there won't be a second conversion */
+	conn->want = fuse_lower_32_bits(conn->want_ext);
+
 	return 0;
 }

--- a/test/hello.c
+++ b/test/hello.c
@@ -1,10 +1,10 @@
 /*
-  FUSE: Filesystem in Userspace
-  Copyright (C) 2001-2007  Miklos Szeredi <miklos@szeredi.hu>
-
-  This program can be distributed under the terms of the GNU GPLv2.
-  See the file COPYING.
-*/
+ * FUSE: Filesystem in Userspace
+ * Copyright (C) 2001-2007  Miklos Szeredi <miklos@szeredi.hu>
+ *
+ * This program can be distributed under the terms of the GNU GPLv2.
+ * See the file COPYING.
+ */
 
 /** @file
  *
@@ -17,7 +17,6 @@
  * ## Source code ##
  * \include hello.c
  */
-
 
 #define FUSE_USE_VERSION 31
 
@@ -42,25 +41,20 @@ static struct options {
 	int show_help;
 } options;
 
-#define OPTION(t, p)                           \
-    { t, offsetof(struct options, p), 1 }
+#define OPTION(t, p) { t, offsetof(struct options, p), 1 }
 static const struct fuse_opt option_spec[] = {
-	OPTION("--name=%s", filename),
-	OPTION("--contents=%s", contents),
-	OPTION("-h", show_help),
-	OPTION("--help", show_help),
-	FUSE_OPT_END
+	OPTION("--name=%s", filename), OPTION("--contents=%s", contents),
+	OPTION("-h", show_help), OPTION("--help", show_help), FUSE_OPT_END
 };
 
-static void *hello_init(struct fuse_conn_info *conn,
-			struct fuse_config *cfg)
+static void *hello_init(struct fuse_conn_info *conn, struct fuse_config *cfg)
 {
-	(void) conn;
+	(void)conn;
 	cfg->kernel_cache = 1;
 
 	/* Test setting flags the old way */
-	fuse_set_feature_flag(conn, FUSE_CAP_ASYNC_READ);
-	fuse_unset_feature_flag(conn, FUSE_CAP_ASYNC_READ);
+	conn->want = FUSE_CAP_ASYNC_READ;
+	conn->want &= ~FUSE_CAP_ASYNC_READ;
 
 	return NULL;
 }
@@ -68,14 +62,14 @@ static void *hello_init(struct fuse_conn_info *conn,
 static int hello_getattr(const char *path, struct stat *stbuf,
 			 struct fuse_file_info *fi)
 {
-	(void) fi;
+	(void)fi;
 	int res = 0;
 
 	memset(stbuf, 0, sizeof(struct stat));
 	if (strcmp(path, "/") == 0) {
 		stbuf->st_mode = S_IFDIR | 0755;
 		stbuf->st_nlink = 2;
-	} else if (strcmp(path+1, options.filename) == 0) {
+	} else if (strcmp(path + 1, options.filename) == 0) {
 		stbuf->st_mode = S_IFREG | 0444;
 		stbuf->st_nlink = 1;
 		stbuf->st_size = strlen(options.contents);
@@ -89,9 +83,9 @@ static int hello_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 			 off_t offset, struct fuse_file_info *fi,
 			 enum fuse_readdir_flags flags)
 {
-	(void) offset;
-	(void) fi;
-	(void) flags;
+	(void)offset;
+	(void)fi;
+	(void)flags;
 
 	if (strcmp(path, "/") != 0)
 		return -ENOENT;
@@ -105,7 +99,7 @@ static int hello_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 
 static int hello_open(const char *path, struct fuse_file_info *fi)
 {
-	if (strcmp(path+1, options.filename) != 0)
+	if (strcmp(path + 1, options.filename) != 0)
 		return -ENOENT;
 
 	if ((fi->flags & O_ACCMODE) != O_RDONLY)
@@ -118,8 +112,8 @@ static int hello_read(const char *path, char *buf, size_t size, off_t offset,
 		      struct fuse_file_info *fi)
 {
 	size_t len;
-	(void) fi;
-	if(strcmp(path+1, options.filename) != 0)
+	(void)fi;
+	if (strcmp(path + 1, options.filename) != 0)
 		return -ENOENT;
 
 	len = strlen(options.contents);
@@ -134,11 +128,11 @@ static int hello_read(const char *path, char *buf, size_t size, off_t offset,
 }
 
 static const struct fuse_operations hello_oper = {
-	.init           = hello_init,
-	.getattr	= hello_getattr,
-	.readdir	= hello_readdir,
-	.open		= hello_open,
-	.read		= hello_read,
+	.init = hello_init,
+	.getattr = hello_getattr,
+	.readdir = hello_readdir,
+	.open = hello_open,
+	.read = hello_read,
 };
 
 static void show_help(const char *progname)
@@ -158,8 +152,9 @@ int main(int argc, char *argv[])
 	struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
 
 	/* Set defaults -- we have to use strdup so that
-	   fuse_opt_parse can free the defaults if other
-	   values are specified */
+	 *  fuse_opt_parse can free the defaults if other
+	 *  values are specified
+	 */
 	options.filename = strdup("hello");
 	options.contents = strdup("Hello World!\n");
 
@@ -168,10 +163,11 @@ int main(int argc, char *argv[])
 		return 1;
 
 	/* When --help is specified, first print our own file-system
-	   specific help text, then signal fuse_main to show
-	   additional help (by adding `--help` to the options again)
-	   without usage: line (by setting argv[0] to the empty
-	   string) */
+	 * specific help text, then signal fuse_main to show
+	 * additional help (by adding `--help` to the options again)
+	 * without usage: line (by setting argv[0] to the empty
+	 * string)
+	 */
 	if (options.show_help) {
 		show_help(argv[0]);
 		assert(fuse_opt_add_arg(&args, "--help") == 0);

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,6 +1,6 @@
 # Compile helper programs
 td = []
-foreach prog: [ 'test_write_cache', 'test_setattr' ]
+foreach prog: [ 'test_write_cache', 'test_setattr', 'hello' ]
     td += executable(prog, prog + '.c',
                      include_directories: include_dirs,
                      link_with: [ libfuse ],

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -44,8 +44,13 @@ if sys.platform == 'linux':
     options.append('clone_fd')
 
 def invoke_directly(mnt_dir, name, options):
-    cmdline = base_cmdline + [ pjoin(basename, 'example', name),
-                               '-f', mnt_dir, '-o', ','.join(options) ]
+    # Handle test/hello specially since it's not in example/
+    if name.startswith('test/'):
+        path = pjoin(basename, name)
+    else:
+        path = pjoin(basename, 'example', name)
+
+    cmdline = base_cmdline + [ path, '-f', mnt_dir, '-o', ','.join(options) ]
     if name == 'hello_ll':
         # supports single-threading only
         cmdline.append('-s')
@@ -88,7 +93,7 @@ def readdir_inode(dir):
 @pytest.mark.parametrize("cmdline_builder", (invoke_directly, invoke_mount_fuse,
                                              invoke_mount_fuse_drop_privileges))
 @pytest.mark.parametrize("options", powerset(options))
-@pytest.mark.parametrize("name", ('hello', 'hello_ll'))
+@pytest.mark.parametrize("name", ('hello', 'hello_ll', 'test/hello'))
 def test_hello(tmpdir, name, options, cmdline_builder, output_checker):
     logger = logging.getLogger(__name__)
     mnt_dir = str(tmpdir)


### PR DESCRIPTION
The high-level interface triggers flag conversion twice: once in the high-level init and once in the low-level init. This caused false "both 'want' and 'want_ext' are set" errors when using fuse_set_feature_flag() or fuse_unset_feature_flag().

The existing check for duplicate conversion only worked when 32-bit flags were set directly. When using the preferred flag manipulation functions, conn->want and the lower 32 bits of conn->want_ext would differ, triggering the error.

Fix this by synchronizing conn->want with the lower 32 bits of conn->want_ext after conversion, ensuring consistent state for subsequent calls.

Closes: https://github.com/libfuse/libfuse/issues/1171