### PR TITLE
Famfs changes to libfuse

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -516,6 +516,11 @@ struct fuse_loop_config_v1 {
 #define FUSE_CAP_NO_EXPORT_SUPPORT (1 << 30)
 
 /**
+ * handle files that use famfs dax fmaps
+ */
+#define FUSE_CAP_DAX_FMAP (1<<30)
+
+/**
  * Ioctl flags
  *
  * FUSE_IOCTL_COMPAT: 32bit compat ioctl on 64bit machine

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -2150,6 +2150,16 @@ static inline int fuse_session_custom_io(struct fuse_session *se,
 #endif
 
 /**
+ * Allow a libfuse caller to directly add kernel mount opts
+ *
+ * @param se session object
+ * @param mount_opt the option to add
+ *
+ * @return 0 on success, -1 on failure
+ */
+int fuse_add_kernel_mount_opt(struct fuse_session *se, const char *mount_opt);
+
+/**
  * Mount a FUSE file system.
  *
  * @param mountpoint the mount point path

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1303,7 +1303,6 @@ struct fuse_lowlevel_ops {
 	void (*lseek) (fuse_req_t req, fuse_ino_t ino, off_t off, int whence,
 		       struct fuse_file_info *fi);
 
-
 	/**
 	 * Create a tempfile
 	 * 
@@ -1325,6 +1324,15 @@ struct fuse_lowlevel_ops {
 	void (*tmpfile) (fuse_req_t req, fuse_ino_t parent,
 			mode_t mode, struct fuse_file_info *fi);
 
+	/**
+	 * Get a famfs/devdax/fsdax fmap
+	 */
+	void (*get_fmap) (fuse_req_t req, fuse_ino_t ino);
+
+	/**
+	 * Get a daxdev by index
+	 */
+	void (*get_daxdev) (fuse_req_t req, int daxdev_index);
 };
 
 /**

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -183,6 +183,7 @@ void destroy_mount_opts(struct mount_opts *mo);
 void fuse_mount_version(void);
 unsigned get_max_read(struct mount_opts *o);
 void fuse_kern_unmount(const char *mountpoint, int fd);
+int __fuse_add_kernel_mount_opt(struct fuse_session *se, const char *mount_opt);
 int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo);
 
 int fuse_send_reply_iov_nofree(fuse_req_t req, int error, struct iovec *iov,

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3459,6 +3459,11 @@ int fuse_session_custom_io_30(struct fuse_session *se,
 			offsetof(struct fuse_custom_io, clone_fd), fd);
 }
 
+int fuse_add_kernel_mount_opt(struct fuse_session *se, const char *mount_opt)
+{
+	return __fuse_add_kernel_mount_opt(se, mount_opt);
+}
+
 int fuse_session_mount(struct fuse_session *se, const char *mountpoint)
 {
 	int fd;

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -200,6 +200,7 @@ FUSE_3.17 {
 		fuse_set_fail_signal_handlers;
 		fuse_log_enable_syslog;
 		fuse_log_close_syslog;
+		fuse_add_kernel_mount_opt;
 } FUSE_3.12;
 
 # Local Variables:

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -675,6 +675,14 @@ void destroy_mount_opts(struct mount_opts *mo)
 	free(mo);
 }
 
+int __fuse_add_kernel_mount_opt(struct fuse_session *se, const char *mount_opt)
+{
+	if (!se->mo)
+		return -1;
+	if (!mount_opt)
+		return -1;
+	return fuse_opt_add_opt(&se->mo->kernel_opts, mount_opt);
+}
 
 int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo)
 {


### PR DESCRIPTION
These libfuse changes go with the famfs patch that I expect to send out later this evening. I will edit this PR to point to the famfs/fuse kernel patch set on lore, once it's been posted.

Two new low-level fuse messages/responses are added: GET_FMAP and GET_DAXDEV. Both are documented to a reasonable extent in the kernel patch set.

In addition, famfs needs to set some additional kernel mount options, and this enables that.

The famfs fuse kernel patchset and documentation can be viewed here: https://lore.kernel.org/linux-fsdevel/20250421013346.32530-1-john@groves.net/T/#t

Cheers,
John