### PR TITLE
Check if pthread_setname_np() exists before use it

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4917,7 +4917,9 @@ static void *fuse_prune_nodes(void *fuse)
 	struct fuse *f = fuse;
 	int sleep_time;
 
+#ifdef HAVE_PTHREAD_SETNAME_NP
 	pthread_setname_np(pthread_self(), "fuse_prune_nodes");
+#endif
 
 	while(1) {
 		sleep_time = fuse_clean_cache(f);

--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -132,7 +132,9 @@ static void *fuse_do_work(void *data)
 	struct fuse_worker *w = (struct fuse_worker *) data;
 	struct fuse_mt *mt = w->mt;
 
+#ifdef HAVE_PTHREAD_SETNAME_NP
 	pthread_setname_np(pthread_self(), "fuse_worker");
+#endif
 
 	while (!fuse_session_exited(mt->se)) {
 		int isforget = 0;

--- a/meson.build
+++ b/meson.build
@@ -72,7 +72,8 @@ private_cfg.set_quoted('PACKAGE_VERSION', meson.project_version())
 # Test for presence of some functions
 test_funcs = [ 'fork', 'fstatat', 'openat', 'readlinkat', 'pipe2',
                'splice', 'vmsplice', 'posix_fallocate', 'fdatasync',
-               'utimensat', 'copy_file_range', 'fallocate', 'static_assert' ]
+               'utimensat', 'copy_file_range', 'fallocate', 'static_assert',
+               'pthread_setname_np' ]
 foreach func : test_funcs
     private_cfg.set('HAVE_' + func.to_upper(),
         cc.has_function(func, prefix: include_default, args: args_default))


### PR DESCRIPTION
Since pthread_setname_np() is the only pthread function that requires NPTL and it basically only set thread name, let's check if pthread_setname_np() does exist, otherwise let's not call pthread_setname_np() to shrink dependencies.