### PR TITLE
signal handlers: Store fuse_session unconditionally

### DIFF
--- a/lib/fuse_signals.c
+++ b/lib/fuse_signals.c
@@ -150,8 +150,13 @@ int fuse_set_signal_handlers(struct fuse_session *se)
 	if (rc < 0)
 		return rc;
 
-	if (fuse_instance == NULL)
-		fuse_instance = se;
+	/*
+	 * needs to be set independently if already set, as some  applications
+	 * may have multiple sessions and might rely on traditional behavior
+	 * that the last session is used.
+	 */
+	fuse_instance = se;
+
 	return 0;
 }
 
@@ -164,8 +169,8 @@ int fuse_set_fail_signal_handlers(struct fuse_session *se)
 	if (rc < 0)
 		return rc;
 
-	if (fuse_instance == NULL)
-		fuse_instance = se;
+	/* See fuse_set_signal_handlers, why set unconditionally */
+	fuse_instance = se;
 
 	return 0;
 }


### PR DESCRIPTION
Commit dae1184 ("Add syslog and fatal signal handler feature") added fuse_set_fail_signal_handlers() which can store "se". But as fuse_set_signal_handlers() also stores the object storing it was made conditionally if not set already.

As per https://github.com/libfuse/libfuse/issues/1182 this breaks some applications like osspd, that have multiple sessions and rely on the right order and that the last call of fuse_set_signal_handlers() wins.

Special thanks to Sébastien Noel to debug this issue.

Closes: https://github.com/libfuse/libfuse/issues/1182