### PR TITLE
Fix test/test_examples.py::test_passthrough

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -157,10 +157,20 @@ def test_passthrough(short_tmpdir, name, debug, output_checker, writeback):
         cmdline = base_cmdline + \
                   [ pjoin(basename, 'example', 'passthrough'),
                     '--plus', '-f', mnt_dir ]
-    else:
+    elif name == 'passthrough_ll':
+        cmdline = base_cmdline + \
+                  [ pjoin(basename, 'example', name),
+                    '-f', mnt_dir, '-o', 'timeout=0' ]
+    else:  # passthrough and passthrough_fh
         cmdline = base_cmdline + \
                   [ pjoin(basename, 'example', name),
                     '-f', mnt_dir ]
+
+    # Set all timeouts to 0 for everything except passthrough_ll
+    # (this includes passthrough, passthrough_plus, and passthrough_fh)
+    if name != 'passthrough_ll':
+        cmdline.extend(['-o', 'entry_timeout=0,negative_timeout=0,attr_timeout=0,ac_attr_timeout=0'])
+
     if debug:
         cmdline.append('-d')
 
@@ -169,7 +179,9 @@ def test_passthrough(short_tmpdir, name, debug, output_checker, writeback):
             pytest.skip('example does not support writeback caching')
         cmdline.append('-o')
         cmdline.append('writeback')
-        
+
+    print(f"\nDebug: Command line: {' '.join(cmdline)}")
+
     mount_process = subprocess.Popen(cmdline, stdout=output_checker.fd,
                                      stderr=output_checker.fd)
     try:
@@ -871,25 +883,58 @@ def tst_utimens(mnt_dir, ns_tol=0):
 def tst_passthrough(src_dir, mnt_dir):
     name = name_generator()
     src_name = pjoin(src_dir, name)
-    mnt_name = pjoin(src_dir, name)
+    mnt_name = pjoin(mnt_dir, name)
+
+    print(f"\nDebug: Creating file {name}")
+    print(f"Debug: src_name={src_name}")
+    print(f"Debug: mnt_name={mnt_name}")
+
+    # First test: write to source directory
     assert name not in os.listdir(src_dir)
     assert name not in os.listdir(mnt_dir)
     with open(src_name, 'w') as fh:
         fh.write('Hello, world')
+
+    print(f"Debug: File written to src_name")
+
+    start_time = time.time()
+    while time.time() - start_time < 10:  # 10 second timeout
+        if name in os.listdir(mnt_dir):
+            break
+        print(f"Debug: Waiting for file to appear... ({time.time() - start_time:.1f}s)")
+        time.sleep(0.1)
+    else:
+        pytest.fail("File did not appear in mount directory within 10 seconds")
+
     assert name in os.listdir(src_dir)
     assert name in os.listdir(mnt_dir)
-    assert os.stat(src_name) == os.stat(mnt_name)
 
+    # Compare relevant stat attributes
+    src_stat = os.stat(src_name)
+    mnt_stat = os.stat(mnt_name)
+    assert src_stat.st_mode == mnt_stat.st_mode
+    assert src_stat.st_ino == mnt_stat.st_ino
+    assert src_stat.st_size == mnt_stat.st_size
+    assert src_stat.st_mtime == mnt_stat.st_mtime
+
+    # Second test: write to mount directory
     name = name_generator()
     src_name = pjoin(src_dir, name)
-    mnt_name = pjoin(src_dir, name)
+    mnt_name = pjoin(mnt_dir, name)
     assert name not in os.listdir(src_dir)
     assert name not in os.listdir(mnt_dir)
     with open(mnt_name, 'w') as fh:
         fh.write('Hello, world')
     assert name in os.listdir(src_dir)
     assert name in os.listdir(mnt_dir)
-    assert os.stat(src_name) == os.stat(mnt_name)
+
+    # Compare relevant stat attributes
+    src_stat = os.stat(src_name)
+    mnt_stat = os.stat(mnt_name)
+    assert src_stat.st_mode == mnt_stat.st_mode
+    assert src_stat.st_ino == mnt_stat.st_ino
+    assert src_stat.st_size == mnt_stat.st_size
+    assert abs(src_stat.st_mtime - mnt_stat.st_mtime) < 0.01
 
 
 def tst_xattr(path):


### PR DESCRIPTION
The test had multiple issues

- default passthrough_ll timeout was used - the created file was then not listed if timeout was not passed yet
- mnt_name was actually point to src_dir, file comparison of stat, etc succeeded, because the same file was compared. Switching to the right dir made stat to always fail, because st_dev is different for source and mount. I.e. the test must not compare all stat values.

Not sure how this test ever passed, but in a very slow debug VM with lots of kernel debug options enabled, the default passthrough_ll timeout it systematically failed.