### PR TITLE
meson.build: make special_funcs check more reliable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('libfuse3', ['c'],
         version: '3.18.0-rc0',  # Version with RC suffix
-        meson_version: '>= 0.51.0',
+        meson_version: '>= 0.60.0',
         default_options: [
             'buildtype=debugoptimized',
             'c_std=gnu11',
@@ -108,7 +108,7 @@ special_funcs = {
 
 foreach name, code : special_funcs
     private_cfg.set('HAVE_' + name.to_upper(),
-        cc.compiles(code, args: ['-Werror'] + args_default,
+        cc.links(code, args: args_default,
                  name: name + ' check'))
 endforeach
 


### PR DESCRIPTION
Unfortunately while cross-compiling with build tools like Buildroot it happens to have repeated flags or anything that could lead to a warning. This way the check fails because of a warning not related to the special function. So let's use cc.links() and increase minimum meson_version to 0.60 since cc.links() has been added during that version.

--
Pardon @bsbernd!