### PR TITLE
Fix build in musl libc

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4840,7 +4840,7 @@ static void *fuse_prune_nodes(void *fuse)
 	struct fuse *f = fuse;
 	int sleep_time;
 
-	fuse_set_thread_name(pthread_self(), "fuse_prune_nodes");
+	fuse_set_thread_name("fuse_prune_nodes");
 
 	while(1) {
 		sleep_time = fuse_clean_cache(f);

--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -132,7 +132,7 @@ static void *fuse_do_work(void *data)
 	struct fuse_mt *mt = w->mt;
 	struct fuse_session *se = mt->se;
 
-	fuse_set_thread_name(pthread_self(), "fuse_worker");
+	fuse_set_thread_name("fuse_worker");
 
 	while (!fuse_session_exited(se)) {
 		int isforget = 0;

--- a/lib/fuse_uring.c
+++ b/lib/fuse_uring.c
@@ -679,7 +679,7 @@ static void *fuse_uring_thread(void *arg)
 
 	snprintf(thread_name, 16, "fuse-ring-%d", queue->qid);
 	thread_name[15] = '\0';
-	fuse_set_thread_name(pthread_self(), thread_name);
+	fuse_set_thread_name(thread_name);
 
 	fuse_uring_set_thread_core(queue->qid);
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -42,12 +42,11 @@ int libfuse_strtol(const char *str, long *res)
 	return 0;
 }
 
-void fuse_set_thread_name(unsigned long tid, const char *name)
+void fuse_set_thread_name(const char *name)
 {
 #ifdef HAVE_PTHREAD_SETNAME_NP
-	pthread_setname_np(tid, name);
+	pthread_setname_np(pthread_self(), name);
 #else
-	(void)tid;
 	(void)name;
 #endif
 }

--- a/lib/util.h
+++ b/lib/util.h
@@ -12,7 +12,7 @@
 struct fuse_conn_info;
 
 int libfuse_strtol(const char *str, long *res);
-void fuse_set_thread_name(unsigned long tid, const char *name);
+void fuse_set_thread_name(const char *name);
 
 /**
  * Return the low bits of a number


### PR DESCRIPTION
Function fuse_set_thread_name() assumes that pthread_t is an unsigned long and fails to compile in musl libc with the following:

```
../lib/util.c: In function 'fuse_set_thread_name': ../lib/util.c:48:28: error: passing argument 1 of \
      'pthread_setname_np' makes pointer from integer without a cast [-Wint-conversion]
```
Fix fuse_set_thread_name() by using pthread_t type instead.