### PR TITLE
Allow applications to retrieve the req payload (io-uring only)

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -254,19 +254,19 @@ static void sfs_getattr(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi)
 	fuse_reply_attr(req, &attr, fs.timeout);
 }
 
-static int with_fd_path(int fd, const std::function<int(const char*)>& f)
+static int with_fd_path(int fd, const std::function<int(const char *)> &f)
 {
 #ifdef __FreeBSD__
-    struct kinfo_file kf;
-    kf.kf_structsize = sizeof(kf);
-    int ret = fcntl(fd, F_KINFO, &kf);
-    if (ret == -1)
-        return ret;
-    return f (kf.kf_path);
+	struct kinfo_file kf;
+	kf.kf_structsize = sizeof(kf);
+	int ret = fcntl(fd, F_KINFO, &kf);
+	if (ret == -1)
+		return ret;
+	return f(kf.kf_path);
 #else // Linux
-    char procname[64];
-    sprintf(procname, "/proc/self/fd/%i", fd);
-    return f(procname);
+	char procname[64];
+	sprintf(procname, "/proc/self/fd/%i", fd);
+	return f(procname);
 #endif
 }
 static void do_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
@@ -280,7 +280,7 @@ static void do_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
 		if (fi) {
 			res = fchmod(fi->fh, attr->st_mode);
 		} else {
-			res = with_fd_path(ifd, [attr](const char* procname) {
+			res = with_fd_path(ifd, [attr](const char *procname) {
 				return chmod(procname, attr->st_mode);
 			});
 		}
@@ -304,7 +304,7 @@ static void do_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
 		if (fi) {
 			res = ftruncate(fi->fh, attr->st_size);
 		} else {
-			res = with_fd_path(ifd, [attr](const char* procname) {
+			res = with_fd_path(ifd, [attr](const char *procname) {
 				return truncate(procname, attr->st_size);
 			});
 		}
@@ -333,7 +333,7 @@ static void do_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
 			res = futimens(fi->fh, tv);
 		else {
 #ifdef HAVE_UTIMENSAT
-			res = with_fd_path(ifd, [&tv](const char* procname) {
+			res = with_fd_path(ifd, [&tv](const char *procname) {
 				return utimensat(AT_FDCWD, procname, tv, 0);
 			});
 #else
@@ -1089,7 +1089,7 @@ static void sfs_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi)
 
 	/* Unfortunately we cannot use inode.fd, because this was opened
        with O_PATH (so it doesn't allow read/write access). */
-	auto fd = with_fd_path(inode.fd, [fi](const char* buf) {
+	auto fd = with_fd_path(inode.fd, [fi](const char *buf) {
 		return open(buf, fi->flags & ~O_NOFOLLOW);
 	});
 	if (fd == -1) {

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -2367,6 +2367,24 @@ int fuse_session_receive_buf(struct fuse_session *se, struct fuse_buf *buf);
  */
 bool fuse_req_is_uring(fuse_req_t req);
 
+/**
+ * Get the payload of a request
+ * (for requests submitted through fuse-io-uring only)
+ *
+ * This is useful for a file system that wants to write data directly
+ * to the request buffer. With io-uring the req is the buffer owner
+ * and the file system can write directly to the buffer and avoid
+ * extra copying. For example useful for network file systems.
+ *
+ * @param req the request
+ * @param payload pointer to the payload
+ * @param payload_sz size of the payload
+ * @param mr  memory registration handle, currently unused
+ * @return 0 on success, -errno on failure
+ */
+int fuse_req_get_payload(fuse_req_t req, char **payload, size_t *payload_sz,
+			 void **mr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3317,6 +3317,18 @@ bool fuse_req_is_uring(fuse_req_t req)
 	return req->is_uring;
 }
 
+#ifndef HAVE_URING
+int fuse_req_get_payload(fuse_req_t req, char **payload, size_t *payload_sz,
+			 void **mr)
+{
+	(void)req;
+	(void)payload;
+	(void)payload_sz;
+	(void)mr;
+	return -ENOTSUP;
+}
+#endif
+
 static struct {
 	void (*func)(fuse_req_t req, const fuse_ino_t node, const void *arg);
 	const char *name;

--- a/lib/fuse_uring.c
+++ b/lib/fuse_uring.c
@@ -190,6 +190,30 @@ static int fuse_uring_commit_sqe(struct fuse_ring_pool *ring_pool,
 	return 0;
 }
 
+int fuse_req_get_payload(fuse_req_t req, char **payload, size_t *payload_sz,
+			 void **mr)
+{
+	struct fuse_ring_ent *ring_ent;
+
+	/* Not possible without io-uring interface */
+	if (!req->is_uring)
+		return -EINVAL;
+
+	ring_ent = container_of(req, struct fuse_ring_ent, req);
+
+	*payload = ring_ent->op_payload;
+	*payload_sz = ring_ent->req_payload_sz;
+
+	/*
+	 * For now unused, but will be used later when the application can
+	 * allocate the buffers itself and register them for rdma.
+	 */
+	if (mr)
+		*mr = NULL;
+
+	return 0;
+}
+
 int send_reply_uring(fuse_req_t req, int error, const void *arg, size_t argsize)
 {
 	int res;

--- a/lib/fuse_uring.c
+++ b/lib/fuse_uring.c
@@ -233,7 +233,8 @@ int send_reply_uring(fuse_req_t req, int error, const void *arg, size_t argsize)
 			 argsize, max_payload_sz);
 		error = -EINVAL;
 	} else if (argsize) {
-		memcpy(ring_ent->op_payload, arg, argsize);
+		if (arg != ring_ent->op_payload)
+			memcpy(ring_ent->op_payload, arg, argsize);
 	}
 	ent_in_out->payload_sz = argsize;
 

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -205,6 +205,7 @@ FUSE_3.17 {
 FUSE_3.18 {
 	global:
 		fuse_req_is_uring;
+		fuse_req_get_payload;
 		fuse_set_feature_flag;
 		fuse_unset_feature_flag;
 		fuse_get_feature_flag;


### PR DESCRIPTION
With io-uring the req owns the payload buffer, the application can directly access it and copy data into it.

fuse_buf_copy_one() already has a check for dstmem == srcmem and skips data copies.

fuse_reply_data
   fuse_reply_data_uring
       fuse_buf_copy
           fuse_buf_copy_one