### PR TITLE
tests: Add an exception for output "error"

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -77,8 +77,11 @@ class OutputChecker:
             cp = re.compile(pattern, re.IGNORECASE | re.MULTILINE)
             hit = cp.search(buf)
             if hit:
-                raise AssertionError('Suspicious output to stderr (matched "%s")'
-                                     % hit.group(0))
+                # Skip FUSE error messages in the format "unique: X, error: -Y (...), outsize: Z"
+                # These are no errors, but just fuse debug messages with the return code
+                if re.search(r'unique: \d+, error: -\d+ \(.*\), outsize: \d+', hit.group(0)):
+                    continue
+                raise AssertionError(f'Suspicious output to stderr (matched "{hit.group(0)}")')
 
 @pytest.fixture()
 def output_checker(request):


### PR DESCRIPTION
The sigterm test triggers debug output like

dev unique: 6, opcode: STATFS (17), nodeid: 1, insize: 40, pid: 1808
   unique: 6, success, outsize: 96
dev unique: 8, opcode: GETATTR (3), nodeid: 1, insize: 56, pid: 1808 exit_handler called with sig 15
fuse: session exited, terminating workers
   unique: 8, error: -2 (No such file or directory), outsize: 16

Which then triggers test failures, because the test was acting on the word 'error'.