### PR TITLE
mount_bsd.c: Fix race between actual mounting and returning to the caller

### DIFF
--- a/lib/mount_bsd.c
+++ b/lib/mount_bsd.c
@@ -187,7 +187,7 @@ mount:
 		if (pid == 0) {
 			const char *argv[32];
 			int a = 0;
-			int ret = -1; 
+			int ret = -1;
 
 			if (! fdnam)
 			{
@@ -214,6 +214,7 @@ mount:
 			_exit(EXIT_FAILURE);
 		}
 
+		waitpid(pid, &status, 0);
 		_exit(EXIT_SUCCESS);
 	}
 


### PR DESCRIPTION
I was trying to debug an application that mounts a FUSE filesystem and then immediately tries to access it. I was constantly getting ENOENT after mounting despite `fuse_session_mount()` returning success.

It turned out that the code doesn't really wait for the actual mounting program to finish, which allows the caller to proceed with execution before the FS gets mounted.