### PR TITLE
help: Remove duplicate io_uring options from fuse_cmdline_help

### DIFF
--- a/lib/helper.c
+++ b/lib/helper.c
@@ -139,11 +139,7 @@ void fuse_cmdline_help(void)
 	       "    -o max_idle_threads    the maximum number of idle worker threads\n"
 	       "                           allowed (default: -1)\n"
 	       "    -o max_threads         the maximum number of worker threads\n"
-	       "                           allowed (default: 10)\n"
-	       /* fuse_ll_opts in fuse_lowlevel.c, FIXME, call into that file */
-	       "    -o io_uring            enable io-uring\n"
-	       "    -o io_uring_q_depth=<n> io-uring queue depth\n"
-);
+	       "                           allowed (default: 10)\n");
 }
 
 static int fuse_helper_opt_proc(void *data, const char *arg, int key,


### PR DESCRIPTION
The io_uring options are currently shown in both fuse_cmdline_help() and fuse_lowlevel_help(), which creates unnecessary duplication. Since io_uring is a low-level I/O feature, it makes more sense to only show these options in fuse_lowlevel_help().

This change:
- Removes io_uring options from fuse_cmdline_help()
- Keeps them in fuse_lowlevel_help() where they belong
- Removes the FIXME comment that is no longer needed

This is purely a documentation improvement and does not affect any functionality. Users will still see all available options when using --help, just organized in a more logical way.