### PR TITLE
fuse_signals.c: fix build warning when HAVE_BACKTRACE is undefined

### DIFF
--- a/lib/fuse_signals.c
+++ b/lib/fuse_signals.c
@@ -32,8 +32,10 @@ static int ignore_sigs[] = { SIGPIPE};
 static int fail_sigs[] = { SIGILL, SIGTRAP, SIGABRT, SIGBUS, SIGFPE, SIGSEGV };
 static struct fuse_session *fuse_instance;
 
+#ifdef HAVE_BACKTRACE
 #define BT_STACK_SZ (1024 * 1024)
 static void *backtrace_buffer[BT_STACK_SZ];
+#endif
 
 static void dump_stack(void)
 {


### PR DESCRIPTION
`BT_STACK_SZ` and `backtrace_buffer` are not used when `HAVE_BACKTRACE` is undefined. Wrap them in `#ifdef`
to avoid a build warning:

``` C
../lib/fuse_signals.c:31:14: warning: 'backtrace_buffer' defined but not used [-Wunused-variable]
   31 | static void *backtrace_buffer[BT_STACK_SZ];
      |              ^~~~~~~~~~~~~~~~
```

@bsbernd @Nikratio 