### PR TITLE
mount_util.c: check if utab exists before update

### DIFF
--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -75,6 +75,10 @@ static int mtab_needs_update(const char *mnt)
 
 		if (err == EROFS)
 			return 0;
+
+		res = access("/run/mount/utab", F_OK);
+		if (res == -1)
+			return 0;
 	}
 
 	return 1;


### PR DESCRIPTION
Do not attempt to update `/run/mount/utab` if it doesn't exist.
Note: if this path ever changes, `utab` updates will break.

Fixes the following error when mounting iPhone documents and containers using `ifuse`:
``` bash
ifuse /mnt --container com.httpstorm.httpstorm
mount: mounting ifuse on /mnt failed: Invalid argument
```

On OpenWRT by default `mount-utils` is not installed and `utab` does not exist.
`/bin/mount` is a symlink to `/bin/busybox` and does not support updating of `utab`.
If `mount-utils` is installed `/run/mount/` exists, but does not contain `utab`.
The `mount-utils` instance is under `/usr/bin/mount`, so a hard-coded call to `/bin/mount` will still fail.
Using `/usr/bin/mount` succeeds but does not create `utab`.

I am not sure if this is the correct approach of solving the issue.
The regression was introduced in 74b1df2e84e836a1710561f52075d51f20cd5c78 which does not explain why the symlink check was removed.
The original symlink check was introduced in 7f571e320e39a5dd0bb7ab2c1b2a40b174879b18.

Build and run tested on OpenWRT main, using `ifuse` master, where `mtab` is indeed a symlink:
``` bash
ll /etc/mtab 
lrwxr-xr-x    1 root     root            12 Jun 12 03:58 /etc/mtab -> /proc/mounts
```

@bsbernd @Nikratio