### PR TITLE
gitignore: add *.patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.gz
 \#*#
 *.orig
+*.patch
 *~
 .DS_Store
 Makefile.in


### PR DESCRIPTION
When working with patches, git shows them as uncommitted changes.
Ignore `*.patch` to keep the list of changes tidy.

@bsbernd @Nikratio
