### PR TITLE
fuse: add support to FUSE_NOTIFY_INC_EPOCH

### DIFF
--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -232,6 +232,9 @@
  *
  *  7.43
  *  - add FUSE_REQUEST_TIMEOUT
+ *
+ *  7.44
+ *  - add FUSE_NOTIFY_INC_EPOCH
  */
 
 #ifndef _LINUX_FUSE_H
@@ -267,7 +270,7 @@
 #define FUSE_KERNEL_VERSION 7
 
 /** Minor version number of this interface */
-#define FUSE_KERNEL_MINOR_VERSION 42
+#define FUSE_KERNEL_MINOR_VERSION 44
 
 /** The node ID of the root inode */
 #define FUSE_ROOT_ID 1
@@ -671,6 +674,7 @@ enum fuse_notify_code {
 	FUSE_NOTIFY_RETRIEVE = 5,
 	FUSE_NOTIFY_DELETE = 6,
 	FUSE_NOTIFY_RESEND = 7,
+	FUSE_NOTIFY_INC_EPOCH = 8,
 	FUSE_NOTIFY_CODE_MAX,
 };
 

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1745,6 +1745,20 @@ int fuse_lowlevel_notify_inval_inode(struct fuse_session *se, fuse_ino_t ino,
 				     off_t off, off_t len);
 
 /**
+ * Notify to increment the epoch for the current
+ *
+ * Each fuse connection has an 'epoch', which is initialized during INIT.
+ * Caching will then be validated against the epoch value: if the current epoch
+ * is higher than an object being revalidated, the object is invalid.
+ *
+ * This function simply increment the current epoch value.
+ *
+ * @param se the session object
+ * @return zero for success, -errno for failure
+ */
+int fuse_lowlevel_notify_increment_epoch(struct fuse_session *se);
+
+/**
  * Notify to invalidate parent attributes and the dentry matching parent/name
  *
  * To avoid a deadlock this function must not be called in the

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2973,6 +2973,19 @@ int fuse_lowlevel_notify_inval_inode(struct fuse_session *se, fuse_ino_t ino,
 	return send_notify_iov(se, FUSE_NOTIFY_INVAL_INODE, iov, 2);
 }
 
+int fuse_lowlevel_notify_increment_epoch(struct fuse_session *se)
+{
+	struct iovec iov[1];
+
+	if (!se)
+		return -EINVAL;
+
+	if (se->conn.proto_minor < 44)
+		return -ENOSYS;
+
+	return send_notify_iov(se, FUSE_NOTIFY_INC_EPOCH, iov, 1);
+}
+
 /**
  * Notify parent attributes and the dentry matching parent/name
  *

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -208,6 +208,7 @@ FUSE_3.18 {
 		fuse_set_feature_flag;
 		fuse_unset_feature_flag;
 		fuse_get_feature_flag;
+		fuse_lowlevel_notify_increment_epoch;
 
 		# Not part of public API, for internal test use only
 		fuse_convert_to_conn_want_ext;

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -376,7 +376,8 @@ def test_null(tmpdir, output_checker):
 
 @pytest.mark.skipif(fuse_proto < (7,12),
                     reason='not supported by running kernel')
-@pytest.mark.parametrize("only_expire", ("invalidate_entries", "expire_entries"))
+@pytest.mark.parametrize("only_expire", ("invalidate_entries",
+                                         "expire_entries", "inc_epoch"))
 @pytest.mark.parametrize("notify", (True, False))
 def test_notify_inval_entry(tmpdir, only_expire, notify, output_checker):
     mnt_dir = str(tmpdir)
@@ -390,6 +391,10 @@ def test_notify_inval_entry(tmpdir, only_expire, notify, output_checker):
         cmdline.append('--only-expire')
         if "FUSE_CAP_EXPIRE_ONLY" not in fuse_caps:
             pytest.skip('only-expire not supported by running kernel')
+    elif only_expire == "inc_epoch":
+        cmdline.append('--inc-epoch')
+        if fuse_proto < (7,44):
+            pytest.skip('inc-epoch not supported by running kernel')
     mount_process = subprocess.Popen(cmdline, stdout=output_checker.fd,
                                      stderr=output_checker.fd)
     try:


### PR DESCRIPTION
This patch adds support for the FUSE INC_EPOCH notify.  This new operation simply increments the FUSE connection epoch value, allowing to invalidate all the dentries next time they are revalidated.