### PR TITLE
Famfs patch update to libfuse (not ready to merge)

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -516,6 +516,11 @@ struct fuse_loop_config_v1 {
 #define FUSE_CAP_NO_EXPORT_SUPPORT (1 << 30)
 
 /**
+ * handle files that use famfs dax fmaps
+ */
+#define FUSE_CAP_DAX_FMAP (1<<30)
+
+/**
  * Ioctl flags
  *
  * FUSE_IOCTL_COMPAT: 32bit compat ioctl on 64bit machine

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -2150,6 +2150,16 @@ static inline int fuse_session_custom_io(struct fuse_session *se,
 #endif
 
 /**
+ * Allow a libfuse caller to directly add kernel mount opts
+ *
+ * @param se session object
+ * @param mount_opt the option to add
+ *
+ * @return 0 on success, -1 on failure
+ */
+int fuse_add_kernel_mount_opt(struct fuse_session *se, const char *mount_opt);
+
+/**
  * Mount a FUSE file system.
  *
  * @param mountpoint the mount point path

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1303,7 +1303,6 @@ struct fuse_lowlevel_ops {
 	void (*lseek) (fuse_req_t req, fuse_ino_t ino, off_t off, int whence,
 		       struct fuse_file_info *fi);
 
-
 	/**
 	 * Create a tempfile
 	 * 
@@ -1325,6 +1324,42 @@ struct fuse_lowlevel_ops {
 	void (*tmpfile) (fuse_req_t req, fuse_ino_t parent,
 			mode_t mode, struct fuse_file_info *fi);
 
+	/**
+	 * Get a famfs/devdax/fsdax fmap
+	 *
+	 * Retrieve a file map (aka fmap) for a previously looked-up file.
+	 * The fmap is serialized into the buffer, anchored by
+	 * struct fuse_famfs_fmap_header, followed by one or more
+	 * structs fuse_famfs_simple_ext, or fuse_famfs_iext (which itself
+	 * is followed by one or more fuse_famfs_simple_ext...
+	 *
+	 * Valid replies:
+	 *    fuse_reply_buf  (TODO: variable-size reply)
+	 *    fuse_reply_err
+	 *
+	 * @param req request handle
+	 * @param ino the inode number
+	 */
+	void (*get_fmap) (fuse_req_t req, fuse_ino_t ino, size_t size);
+
+	/**
+	 * Get a daxdev by index
+	 *
+	 * Retrieve info on a daxdev by index. This will be called any time
+	 * GET_FMAP has returned a file map that references a previously
+	 * unused daxdev. struct famfs_simple_ext, which is used for all
+	 * resolutions to daxdev offsets, references daxdevs by index.
+	 * In user space we maintain a master list of all referenced daxdevs
+	 * by index, which is queried by get_daxdev.
+	 *
+	 * Valid replies:
+	 *    fuse_reply_buf
+	 *    fuse_reply_err
+	 *
+	 * @param req request handle
+	 * @param ino the index of the daxdev
+	 */
+	void (*get_daxdev) (fuse_req_t req, int daxdev_index);
 };
 
 /**

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -183,6 +183,7 @@ void destroy_mount_opts(struct mount_opts *mo);
 void fuse_mount_version(void);
 unsigned get_max_read(struct mount_opts *o);
 void fuse_kern_unmount(const char *mountpoint, int fd);
+int __fuse_add_kernel_mount_opt(struct fuse_session *se, const char *mount_opt);
 int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo);
 
 int fuse_send_reply_iov_nofree(fuse_req_t req, int error, struct iovec *iov,

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2105,11 +2105,7 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		if (inargflags & FUSE_FLOCK_LOCKS)
 			se->conn.capable_ext |= FUSE_CAP_FLOCK_LOCKS;
 		if (inargflags & FUSE_AUTO_INVAL_DATA)
-			se->conn.capable_ext |= FUSE_CAP_AUTO_INVAL_DATA;
-		if (inargflags & FUSE_DO_READDIRPLUS)
-			se->conn.capable_ext |= FUSE_CAP_READDIRPLUS;
-		if (inargflags & FUSE_READDIRPLUS_AUTO)
-			se->conn.capable_ext |= FUSE_CAP_READDIRPLUS_AUTO;
+			se->conn.capable |= FUSE_CAP_AUTO_INVAL_DATA;
 		if (inargflags & FUSE_ASYNC_DIO)
 			se->conn.capable_ext |= FUSE_CAP_ASYNC_DIO;
 		if (inargflags & FUSE_WRITEBACK_CACHE)
@@ -2149,6 +2145,15 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 			se->conn.capable_ext |= FUSE_CAP_PASSTHROUGH;
 		if (inargflags & FUSE_NO_EXPORT_SUPPORT)
 			se->conn.capable_ext |= FUSE_CAP_NO_EXPORT_SUPPORT;
+		if (inargflags & FUSE_DAX_FMAP)
+			se->conn.capable_ext |= FUSE_CAP_DAX_FMAP;
+		else {
+			/* Avoid READDIRPLUS for famfs */
+			if (inargflags & FUSE_DO_READDIRPLUS)
+				se->conn.capable_ext |= FUSE_CAP_READDIRPLUS;
+			if (inargflags & FUSE_READDIRPLUS_AUTO)
+				se->conn.capable_ext |= FUSE_CAP_READDIRPLUS_AUTO;
+		}
 	} else {
 		se->conn.max_readahead = 0;
 	}
@@ -2314,6 +2319,8 @@ void do_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 	}
 	if (se->conn.want_ext & FUSE_CAP_NO_EXPORT_SUPPORT)
 		outargflags |= FUSE_NO_EXPORT_SUPPORT;
+	if (se->conn.want & FUSE_CAP_DAX_FMAP)
+		outargflags |= FUSE_DAX_FMAP;
 
 	if (inargflags & FUSE_INIT_EXT) {
 		outargflags |= FUSE_INIT_EXT;
@@ -2377,6 +2384,30 @@ static void do_destroy(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 		se->op.destroy(se->userdata);
 
 	send_reply_ok(req, NULL, 0);
+}
+
+static void
+do_get_fmap(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
+{
+	struct fuse_session *se = req->se;
+	struct fuse_getxattr_in *arg = (struct fuse_getxattr_in *) inarg;
+
+	if (se->op.get_fmap)
+		se->op.get_fmap(req, nodeid, arg->size);
+	else
+		fuse_reply_err(req, -EOPNOTSUPP);
+}
+
+static void
+do_get_daxdev(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
+{
+	struct fuse_session *se = req->se;
+	(void)inarg;
+
+	if (se->op.get_daxdev)
+		se->op.get_daxdev(req, nodeid); /* Use nodeid as daxdev_index */
+	else
+		fuse_reply_err(req, -EOPNOTSUPP);
 }
 
 static void list_del_nreq(struct fuse_notify_req *nreq)
@@ -2780,6 +2811,8 @@ static struct {
 	[FUSE_COPY_FILE_RANGE] = { do_copy_file_range, "COPY_FILE_RANGE" },
 	[FUSE_LSEEK]	   = { do_lseek,       "LSEEK"	     },
 	[CUSE_INIT]	   = { cuse_lowlevel_init, "CUSE_INIT"   },
+	[FUSE_GET_FMAP]    = { do_get_fmap, "GET_FMAP" },
+	[FUSE_GET_DAXDEV]  = { do_get_daxdev, "GET_DAXDEV" },
 };
 
 /*

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3459,6 +3459,11 @@ int fuse_session_custom_io_30(struct fuse_session *se,
 			offsetof(struct fuse_custom_io, clone_fd), fd);
 }
 
+int fuse_add_kernel_mount_opt(struct fuse_session *se, const char *mount_opt)
+{
+	return __fuse_add_kernel_mount_opt(se, mount_opt);
+}
+
 int fuse_session_mount(struct fuse_session *se, const char *mountpoint)
 {
 	int fd;

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -200,6 +200,7 @@ FUSE_3.17 {
 		fuse_set_fail_signal_handlers;
 		fuse_log_enable_syslog;
 		fuse_log_close_syslog;
+		fuse_add_kernel_mount_opt;
 } FUSE_3.12;
 
 # Local Variables:

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -675,6 +675,14 @@ void destroy_mount_opts(struct mount_opts *mo)
 	free(mo);
 }
 
+int __fuse_add_kernel_mount_opt(struct fuse_session *se, const char *mount_opt)
+{
+	if (!se->mo)
+		return -1;
+	if (!mount_opt)
+		return -1;
+	return fuse_opt_add_opt(&se->mo->kernel_opts, mount_opt);
+}
 
 int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo)
 {


### PR DESCRIPTION
[do not merge]

This is an update to the famfs patch for libfuse, to go with a V2 famfs/fuse kernel patch that will go out soon.

- This is for kernel (and fuse_kernel.h) 6.14, because my famfs/fuse kernel patch is currently stuck at kernel 6.14 due to some dax changes in 6.15 that will require some famfs work. The next kernel and libfuse patches from me should move forward to a current kernel.
- The impending V2 famfs/fuse kernel patch moves GET_FMAP from LOOKUP to OPEN. This should allow reverting the portion of this patch that allows famfs to opt out of READDIRPLUS. So I expect the next version of this series to revert that; it's still in right now because I haven't yet put READDIRPLUS back into the famfs fuse daemon.
- The most important functional change in this patch is that the GET_FMAP response is now variable-sized.

Regards,
John
