### PR TITLE
fuse_lowlevel.c: Add FUSE_CAP_INVAL_INODE_ENTRY flag

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -521,6 +521,11 @@ struct fuse_loop_config_v1 {
 #define FUSE_CAP_OVER_IO_URING (1UL << 31)
 
 /**
+ * invalidate inode aliases when doing inode invalidation
+ */
+#define FUSE_CAP_INVAL_INODE_ENTRY (1ULL << 32)
+
+/**
  * Ioctl flags
  *
  * FUSE_IOCTL_COMPAT: 32bit compat ioctl on 64bit machine

--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -443,6 +443,7 @@ struct fuse_file_lock {
  * FUSE_OVER_IO_URING: Indicate that client supports io-uring
  * FUSE_REQUEST_TIMEOUT: kernel supports timing out requests.
  *			 init_out.request_timeout contains the timeout (in secs)
+ * FUSE_INVAL_INODE_ENTRY: invalidate inode aliases when doing inode invalidation
  */
 #define FUSE_ASYNC_READ		(1 << 0)
 #define FUSE_POSIX_LOCKS	(1 << 1)
@@ -490,6 +491,7 @@ struct fuse_file_lock {
 #define FUSE_ALLOW_IDMAP	(1ULL << 40)
 #define FUSE_OVER_IO_URING	(1ULL << 41)
 #define FUSE_REQUEST_TIMEOUT	(1ULL << 42)
+#define FUSE_INVAL_INODE_ENTRY  (1ULL << 43)
 
 /**
  * CUSE INIT request/reply flags

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2624,6 +2624,8 @@ _do_init(fuse_req_t req, const fuse_ino_t nodeid, const void *op_in,
 			se->conn.capable_ext |= FUSE_CAP_NO_EXPORT_SUPPORT;
 		if (inargflags & FUSE_OVER_IO_URING)
 			se->conn.capable_ext |= FUSE_CAP_OVER_IO_URING;
+		if (inargflags & FUSE_INVAL_INODE_ENTRY)
+			se->conn.capable_ext |= FUSE_CAP_INVAL_INODE_ENTRY;
 
 	} else {
 		se->conn.max_readahead = 0;
@@ -2783,6 +2785,9 @@ _do_init(fuse_req_t req, const fuse_ino_t nodeid, const void *op_in,
 		outargflags |= FUSE_OVER_IO_URING;
 		enable_io_uring = true;
 	}
+
+	if (se->conn.want_ext & FUSE_CAP_INVAL_INODE_ENTRY)
+		outargflags |= FUSE_INVAL_INODE_ENTRY;
 
 	if ((inargflags & FUSE_REQUEST_TIMEOUT) && se->conn.request_timeout) {
 		outargflags |= FUSE_REQUEST_TIMEOUT;


### PR DESCRIPTION
Add FUSE_CAP_INVAL_INODE_ENTRY flag, when this flag is enabled, FUSE kerenl will do inode dentry invalidation when invalidating an inode.