### PR TITLE
Restore compile-time check for static_assert

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -30,7 +30,8 @@
 #define FUSE_MAKE_VERSION(maj, min)  ((maj) * 100 + (min))
 #define FUSE_VERSION FUSE_MAKE_VERSION(FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION)
 
-#ifdef HAVE_STATIC_ASSERT
+#if (defined(__cplusplus) && __cplusplus >= 201103L) || \
+	(defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
 #define fuse_static_assert(condition, message) static_assert(condition, message)
 #else
 #define fuse_static_assert(condition, message)

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,6 @@ include_default = '''
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <assert.h>     /* For static_assert */
 #include <pthread.h>    /* For pthread_setname_np */
 '''
 args_default = [ '-D_GNU_SOURCE' ]
@@ -82,11 +81,6 @@ endforeach
 
 # Special case checks that need custom code
 special_funcs = {
-    'static_assert': '''
-        #include <assert.h>
-        static_assert(1, "test");
-        int main(void) { return 0; }
-    ''',
     'pthread_setname_np': '''
         #include <pthread.h>
         int main(void) {


### PR DESCRIPTION
This reverts commit 197ea99fe4520b1ada8a4f2e3e1dcaf6de145002 (#1189), which replaced the compile-time check for "static_assert" with a meson check.

However, a simple check for `__STDC_VERSION__` is already sufficient to detect `static_assert` presence in ISO C.
The build failure referenced in the aforementioned commit was caused by a defect[^1] in legacy (<1.0.42) versions of uclibc-ng, which did not define `static_assert` to `_Static_assert` for C11 in `assert.h`.

To fix this, the downstream (buildroot) should either update the uclibc version in their prebuilt toolchain[^2], or apply workaround patches in their packaging script for libfuse (they've already done that for a couple of packages[^3][^4][^5]).

Another problem with the meson check is that `fuse_common.h` is a public header, which means libfuse users need to check and define `HAVE_STATIC_ASSERT` themselves for `fuse_static_assert` to work. This should be avoided.

[^1]: https://github.com/wbx-github/uclibc-ng/commit/03fbd941e943976bb92cb392882c2ff7ec218704
[^2]: https://gitlab.com/buildroot.org/buildroot/-/blob/master/support/config-fragments/autobuild/br-arm-basic.config
[^3]: https://gitlab.com/buildroot.org/buildroot/-/blob/2025.05/package/util-linux/util-linux.mk#L113
[^4]: https://gitlab.com/buildroot.org/buildroot/-/blob/2025.05/package/pulseaudio/0001-shm.c-use-_Static_assert-instead-of-static_assert-fo.patch
[^5]: https://gitlab.com/buildroot.org/buildroot/-/blob/2025.05/package/iproute2/iproute2.mk#L55