### PR TITLE
example/passthrough: support fspacectl()

### DIFF
--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -40,10 +40,6 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <errno.h>
-#ifdef __FreeBSD__
-#include <sys/socket.h>
-#include <sys/un.h>
-#endif
 #include <sys/time.h>
 #ifdef HAVE_SETXATTR
 #include <sys/xattr.h>

--- a/example/passthrough_helpers.h
+++ b/example/passthrough_helpers.h
@@ -23,6 +23,23 @@
  * SUCH DAMAGE
  */
 
+static inline int do_fallocate(int fd, int mode, off_t offset, off_t length)
+{
+#ifdef HAVE_FALLOCATE
+	if (fallocate(fd, mode, offset, length) == -1)
+		return -errno;
+	return 0;
+#else  // HAVE_FALLOCATE
+
+#ifdef HAVE_POSIX_FALLOCATE
+	if (mode == 0)
+		return -posix_fallocate(fd, offset, length);
+#endif
+
+	return -EOPNOTSUPP;
+#endif  // HAVE_FALLOCATE
+}
+
 /*
  * Creates files on the underlying file system in response to a FUSE_MKNOD
  * operation

--- a/example/passthrough_helpers.h
+++ b/example/passthrough_helpers.h
@@ -23,6 +23,20 @@
  * SUCH DAMAGE
  */
 
+#ifndef FUSE_EXAMPLE_PASSTHROUGH_HELPERS_H_
+#define FUSE_EXAMPLE_PASSTHROUGH_HELPERS_H_
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#include <sys/un.h>
+#endif
+
 static inline int do_fallocate(int fd, int mode, off_t offset, off_t length)
 {
 #ifdef HAVE_FALLOCATE
@@ -44,7 +58,7 @@ static inline int do_fallocate(int fd, int mode, off_t offset, off_t length)
  * Creates files on the underlying file system in response to a FUSE_MKNOD
  * operation
  */
-static int mknod_wrapper(int dirfd, const char *path, const char *link,
+static inline int mknod_wrapper(int dirfd, const char *path, const char *link,
 	int mode, dev_t rdev)
 {
 	int res;
@@ -91,3 +105,5 @@ static int mknod_wrapper(int dirfd, const char *path, const char *link,
 
 	return res;
 }
+
+#endif  // FUSE_PASSTHROUGH_HELPERS_H_

--- a/example/passthrough_helpers.h
+++ b/example/passthrough_helpers.h
@@ -50,6 +50,19 @@ static inline int do_fallocate(int fd, int mode, off_t offset, off_t length)
 		return -posix_fallocate(fd, offset, length);
 #endif
 
+#ifdef HAVE_FSPACECTL
+	// 0x3 == FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE
+	if (mode == 0x3) {
+		struct spacectl_range sr;
+
+		sr.r_offset = offset;
+		sr.r_len = length;
+		if (fspacectl(fd, SPACECTL_DEALLOC, &sr, 0, NULL) == -1)
+			return -errno;
+		return 0;
+	}
+#endif
+
 	return -EOPNOTSUPP;
 #endif  // HAVE_FALLOCATE
 }

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -1006,22 +1006,10 @@ static void lo_statfs(fuse_req_t req, fuse_ino_t ino)
 static void lo_fallocate(fuse_req_t req, fuse_ino_t ino, int mode,
 			 off_t offset, off_t length, struct fuse_file_info *fi)
 {
-	int err = EOPNOTSUPP;
+	int err;
 	(void) ino;
 
-#ifdef HAVE_FALLOCATE
-	err = fallocate(fi->fh, mode, offset, length);
-	if (err < 0)
-		err = errno;
-
-#elif defined(HAVE_POSIX_FALLOCATE)
-	if (mode) {
-		fuse_reply_err(req, EOPNOTSUPP);
-		return;
-	}
-
-	err = posix_fallocate(fi->fh, offset, length);
-#endif
+	err = -do_fallocate(fi->fh, mode, offset, length);
 
 	fuse_reply_err(req, err);
 }

--- a/meson.build
+++ b/meson.build
@@ -74,7 +74,7 @@ private_cfg.set_quoted('PACKAGE_VERSION', meson.project_version())
 # Test for presence of some functions
 test_funcs = [ 'fork', 'fstatat', 'openat', 'readlinkat', 'pipe2',
                'splice', 'vmsplice', 'posix_fallocate', 'fdatasync',
-               'utimensat', 'copy_file_range', 'fallocate' ]
+               'utimensat', 'copy_file_range', 'fallocate', 'fspacectl' ]
 foreach func : test_funcs
     private_cfg.set('HAVE_' + func.to_upper(),
         cc.has_function(func, prefix: include_default, args: args_default))


### PR DESCRIPTION
FreeBSD 14 introduced a new system call, [`fspacectl(2)`](https://man.freebsd.org/cgi/man.cgi?fspacectl(2)).

Currently, it supports one operation mode, `SPACECTL_DEALLOC`, which is functionally equivalent to Linux `fallocate()` with `FALLOC_FL_KEEP_SIZE|FALLOC_FL_PUNCH_HOLE` flags.

`fspacectl()` calls with `SPACECTL_DEALLOC` is supported on FUSE filesystems via `FUSE_FALLOCATE` with the aforementioned flags.

---

Followup: Ideally there should be tests for this patch, however, since fallocate is not tested at all, I think we could save that for later.

P.S. `fspacectl()` is available in FreeBSD userland via [`truncate(1)`](https://man.freebsd.org/cgi/man.cgi?truncate(1)) with `-d` option.