### PR TITLE
Switch to c++20

### DIFF
--- a/example/meson.build
+++ b/example/meson.build
@@ -37,7 +37,7 @@ if platform != 'dragonfly' and add_languages('cpp', required : false)
                install: false)
     executable('memfs_ll', 'memfs_ll.cc',
                dependencies: [ thread_dep, libfuse_dep ],
-               cpp_args : '-std=c++17',
+               cpp_args : '-std=c++20',
                install: false)
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('libfuse3', ['c'],
         default_options: [
             'buildtype=debugoptimized',
             'c_std=gnu11',
-            'cpp_std=c++17',
+            'cpp_std=c++20',
             'warning_level=2',
         ])
 


### PR DESCRIPTION
This only effects example/{passthrough_hp.cc,memfs_ll.cc} and is mainly to avoid these warnings

2025-07-15T16:32:21.9595443Z ../example/memfs_ll.cc:1100:1: warning: missing field 'statx' initializer [-Wmissing-designated-field-initializers] 2025-07-15T16:32:21.9596168Z  1100 | };
2025-07-15T16:32:21.9596329Z       | ^
2025-07-15T16:32:21.9596492Z 1 warning generated.