### PR TITLE
Avoid double unmount on FUSE_DESTROY

### DIFF
--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <stdatomic.h>
 
 #define MIN(a, b) \
 ({									\
@@ -67,7 +68,7 @@ struct fuse_session_uring {
 };
 
 struct fuse_session {
-	char *mountpoint;
+	_Atomic(char *)mountpoint;
 	int fd;
 	struct fuse_custom_io *io;
 	struct mount_opts *mo;


### PR DESCRIPTION
This is a long standing issue, a system could have unmounted /path/to/mnt and then fuse-client/kernel would send FUSE_DESTROY, which would then again try a umount.

Given that FUSE_DESTROY is async, that umount might arrive any time later and might possibly unmount a wrong mount point. A warning as in issue #1286 is just minor to that.

Code wise this uses atomics to free the char *, as FUSE_DESTROY might race with a signal and a double free might be possible without proctection. A lock might run into the same issue, if the signal would arrive at the wrong time a double lock would be possible.

Additionally, fuse_session_mount() is updated, to first duplicatate the pointer and to then do the kernel mount - reverting the kernel mount in case of strdup() failure is much harder.

Closes: https://github.com/libfuse/libfuse/issues/1286