### PR TITLE
fusermount: Fix the close_range ifdef

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -98,7 +98,9 @@ special_funcs = {
     'close_range': '''
         #include <unistd.h>
         #include <fcntl.h>
+        #ifdef linux
         #include <linux/close_range.h>
+        #endif
         int main(void) {
             unsigned int flags = CLOSE_RANGE_UNSHARE;
             return close_range(3, ~0U, flags);

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 #include <sys/vfs.h>
 
-#ifdef HAVE_LINUX_CLOSE_RANGE_H
+#ifdef HAVE_CLOSE_RANGE
 #include <linux/close_range.h>
 #endif
 
@@ -1451,7 +1451,7 @@ static int close_inherited_fds(int cfd)
 	if (cfd <= STDERR_FILENO)
 		return -EINVAL;
 
-#ifdef HAVE_LINUX_CLOSE_RANGE_H
+#ifdef HAVE_CLOSE_RANGE
 	if (cfd < STDERR_FILENO + 2) {
 		close_range_loop(STDERR_FILENO + 1, cfd - 1, cfd);
 	} else {

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 #include <sys/vfs.h>
 
-#ifdef HAVE_CLOSE_RANGE
+#if defined HAVE_CLOSE_RANGE && defined linux
 #include <linux/close_range.h>
 #endif
 


### PR DESCRIPTION
This fixes commit 82bcd818
That commit had removed HAVE_LINUX_CLOSE_RANGE in meson generation, but didn't remove the usage in fusermount.c - fusermount was then not using the close_range syscall.

Closes: https://github.com/libfuse/libfuse/issues/1284