### PR TITLE
memfs_ll: fix deadlock in truncate operation

### DIFF
--- a/example/memfs_ll.cc
+++ b/example/memfs_ll.cc
@@ -199,7 +199,6 @@ class Inode {
 
 	void truncate(off_t size)
 	{
-		std::lock_guard<std::mutex> lock(mutex);
 		std::lock_guard<std::mutex> attr_lock(attr_mutex);
 		if (size < content.size()) {
 			content.resize(size);


### PR DESCRIPTION
Remove redundant mutex lock acquisition in the truncate() method to prevent deadlock. The issue occurs when memfs_setattr() already holds the mutex lock and then calls truncate(), which attempts to acquire the same lock again.