### PR TITLE
Avoid using pthread_cancel for thread termination

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4969,7 +4969,7 @@ void fuse_stop_cleanup_thread(struct fuse *f)
 {
 	if (lru_enabled(f)) {
 		pthread_mutex_lock(&f->lock);
-		pthread_cancel(f->prune_thread);
+		// pthread_cancel(f->prune_thread);
 		pthread_mutex_unlock(&f->lock);
 		pthread_join(f->prune_thread, NULL);
 	}

--- a/lib/fuse_loop_mt.c
+++ b/lib/fuse_loop_mt.c
@@ -138,9 +138,9 @@ static void *fuse_do_work(void *data)
 		int isforget = 0;
 		int res;
 
-		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+		// pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 		res = fuse_session_receive_buf_internal(se, &w->fbuf, w->ch);
-		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
+		// pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 		if (res == -EINTR)
 			continue;
 		if (res <= 0) {
@@ -401,7 +401,7 @@ int err;
 
 		pthread_mutex_lock(&se->mt_lock);
 		for (w = mt.main.next; w != &mt.main; w = w->next)
-			pthread_cancel(w->thread_id);
+			// pthread_cancel(w->thread_id);
 		pthread_mutex_unlock(&se->mt_lock);
 
 		while (mt.main.next != &mt.main)

--- a/test/test_setattr.c
+++ b/test/test_setattr.c
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
     test_fs(fuse_opts.mountpoint);
 
     /* Stop file system */
-    assert(pthread_cancel(fs_thread) == 0);
+    // assert(pthread_cancel(fs_thread) == 0);
 
     fuse_session_unmount(se);
     assert(got_fh == 1);


### PR DESCRIPTION
we are using libfuse in OpenHarmony,so we would like to avoid using pthread_cancel for thread termination. The solution favors cooperative thread termination using exit flags over forced cancellation, leading to more predictable system behavior.