### PR TITLE
Cherry-pick fixes for 3.17.4

### DIFF
--- a/lib/fuse_signals.c
+++ b/lib/fuse_signals.c
@@ -27,8 +27,10 @@ static int ignore_sigs[] = { SIGPIPE};
 static int fail_sigs[] = { SIGILL, SIGTRAP, SIGABRT, SIGBUS, SIGFPE, SIGSEGV };
 static struct fuse_session *fuse_instance;
 
+#ifdef HAVE_BACKTRACE
 #define BT_STACK_SZ (1024 * 1024)
 static void *backtrace_buffer[BT_STACK_SZ];
+#endif
 
 static void dump_stack(void)
 {

--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -75,6 +75,10 @@ static int mtab_needs_update(const char *mnt)
 
 		if (err == EROFS)
 			return 0;
+
+		res = access("/run/mount/utab", F_OK);
+		if (res == -1)
+			return 0;
 	}
 
 	return 1;


### PR DESCRIPTION
Cherry-pick the following fixes for 3.17.4
6787608e5655b3d833a541a9f0d5a3159ae51f0e fuse_signals.c: fix build warning when HAVE_BACKTRACE is undefined
3793b1748ad151c8043dee1db198fffa3dbb5a67 mount_util.c: check if utab exists before update
