### PR TITLE
fuse_common.h: fix ISO C compliance

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -31,9 +31,9 @@
 #define FUSE_VERSION FUSE_MAKE_VERSION(FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION)
 
 #ifdef HAVE_STATIC_ASSERT
-#define fuse_static_assert(condition, message) static_assert(condition, message)
+#define FUSE_STATIC_ASSERT(condition, message) static_assert(condition, message);
 #else
-#define fuse_static_assert(condition, message)
+#define FUSE_STATIC_ASSERT(condition, message)
 #endif
 
 #ifdef __cplusplus
@@ -129,8 +129,8 @@ struct fuse_file_info {
 
 	uint64_t reserved[2];
 };
-fuse_static_assert(sizeof(struct fuse_file_info) == 64,
-		   "fuse_file_info size mismatch");
+FUSE_STATIC_ASSERT(sizeof(struct fuse_file_info) == 64,
+		   "fuse_file_info size mismatch")
 
 /**
  * Configuration parameters passed to fuse_session_loop_mt() and
@@ -719,8 +719,8 @@ struct fuse_conn_info {
 	 */
 	uint16_t reserved[31];
 };
-fuse_static_assert(sizeof(struct fuse_conn_info) == 128,
-		   "Size of struct fuse_conn_info must be 128 bytes");
+FUSE_STATIC_ASSERT(sizeof(struct fuse_conn_info) == 128,
+		   "Size of struct fuse_conn_info must be 128 bytes")
 
 struct fuse_session;
 struct fuse_pollhandle;


### PR DESCRIPTION
For programs that use libfuse, when compiling with the `-Wpedantic` flag,
gcc gives the following warnings:

```
/usr/include/fuse3/fuse_common.h:135:51: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
  135 |                    "fuse_file_info size mismatch");
      |                                                   ^
```

clang warnings:

```
/usr/include/fuse3/fuse_common.h:135:37: warning: extra ';' outside of a function [-Wextra-semi]
  135 |                    "fuse_file_info size mismatch");
      |                                                   ^
```

To make the header code compliant to ISO C and silence compiler warnings,
move the semicolons into the macro definition.

Also capitalize the macro name to distinguish it from functions.