### PR TITLE
tests: move struct size assertions into a test

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -30,12 +30,6 @@
 #define FUSE_MAKE_VERSION(maj, min)  ((maj) * 100 + (min))
 #define FUSE_VERSION FUSE_MAKE_VERSION(FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION)
 
-#ifdef HAVE_STATIC_ASSERT
-#define fuse_static_assert(condition, message) static_assert(condition, message)
-#else
-#define fuse_static_assert(condition, message)
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -129,8 +123,6 @@ struct fuse_file_info {
 
 	uint64_t reserved[2];
 };
-fuse_static_assert(sizeof(struct fuse_file_info) == 64,
-		   "fuse_file_info size mismatch");
 
 /**
  * Configuration parameters passed to fuse_session_loop_mt() and
@@ -719,8 +711,6 @@ struct fuse_conn_info {
 	 */
 	uint16_t reserved[31];
 };
-fuse_static_assert(sizeof(struct fuse_conn_info) == 128,
-		   "Size of struct fuse_conn_info must be 128 bytes");
 
 struct fuse_session;
 struct fuse_pollhandle;

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,6 @@ include_default = '''
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <assert.h>     /* For static_assert */
 #include <pthread.h>    /* For pthread_setname_np */
 '''
 args_default = [ '-D_GNU_SOURCE' ]
@@ -82,11 +81,6 @@ endforeach
 
 # Special case checks that need custom code
 special_funcs = {
-    'static_assert': '''
-        #include <assert.h>
-        static_assert(1, "test");
-        int main(void) { return 0; }
-    ''',
     'pthread_setname_np': '''
         #include <pthread.h>
         int main(void) {

--- a/test/meson.build
+++ b/test/meson.build
@@ -22,6 +22,9 @@ td += executable('test_want_conversion', 'test_want_conversion.c',
 td += executable('test_signals', 'test_signals.c',
                  dependencies: [ libfuse_dep, thread_dep ],
                  install: false)
+td += executable('test_abi', 'test_abi.c',
+                 dependencies: [ libfuse_dep ],
+                 install: false)
 
 test_scripts = [ 'conftest.py', 'pytest.ini', 'test_examples.py',
                  'util.py', 'test_ctests.py', 'test_custom_io.py' ]

--- a/test/test_abi.c
+++ b/test/test_abi.c
@@ -1,0 +1,18 @@
+#define FUSE_USE_VERSION 30
+
+#include "fuse.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void)
+{
+	if (sizeof(struct fuse_file_info) != 64) {
+		fprintf(stderr, "struct fuse_file_info size mismatch\n");
+		exit(1);
+	}
+	if (sizeof(struct fuse_conn_info) != 128) {
+		fprintf(stderr, "struct fuse_conn_info size mismatch\n");
+		exit(1);
+	}
+}

--- a/test/test_ctests.py
+++ b/test/test_ctests.py
@@ -20,6 +20,10 @@ import os.path
 
 pytestmark = fuse_test_marker()
 
+def test_abi():
+    cmdline = [ pjoin(basename, 'test', 'test_abi') ]
+    subprocess.check_call(cmdline)
+
 @pytest.mark.skipif('FUSE_CAP_WRITEBACK_CACHE' not in fuse_caps,
                     reason='not supported by running kernel')
 @pytest.mark.parametrize("writeback", (False, True))


### PR DESCRIPTION
These checks are meant for libfuse maintainers only, and should not be exposed to users.