### PR TITLE
fuse-io-uring: fix endless loop in fuse_uring_start

### DIFF
--- a/lib/fuse_uring.c
+++ b/lib/fuse_uring.c
@@ -78,7 +78,7 @@ struct fuse_ring_pool {
 	/* size of a single queue */
 	size_t queue_mem_size;
 
-	unsigned int started_threads;
+	volatile unsigned int started_threads;
 	unsigned int failed_threads;
 
 	/* Avoid sending queue entries before FUSE_INIT reply*/


### PR DESCRIPTION
fuse_uring_start keep check started_threads until all queue has been ready to go. However, the compiler might optimize this while loop to read started_threads only once. Fix it by mark started_threads as volatile. Find this problem since local test.