### PR TITLE
fuse_lowlevel.c: allow passing ops as NULL

### DIFF
--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -2117,6 +2117,8 @@ fuse_session_new_versioned(struct fuse_args *args,
  * If not all options are known, an error message is written to stderr
  * and the function returns NULL.
  *
+ * To create a no-op session just for mounting pass op as NULL.
+ *
  * Option parsing skips argv[0], which is assumed to contain the
  * program name. To prevent accidentally passing an option in
  * argv[0], this element must always be present (even if no options

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -4051,6 +4051,14 @@ fuse_session_new_versioned(struct fuse_args *args,
 	int err;
 	struct fuse_session *se;
 	struct mount_opts *mo;
+	struct fuse_lowlevel_ops null_ops = { 0 };
+
+	// Empty operations list may is necessary to create a no-op fuse session for mounting
+	if (op == NULL) {
+		fuse_log(FUSE_LOG_ERR, "fuse: warning: empty op list, falling back to default\n");
+		op = &null_ops;
+		op_size = sizeof(null_ops);
+	}
 
 	if (sizeof(struct fuse_lowlevel_ops) < op_size) {
 		fuse_log(FUSE_LOG_ERR, "fuse: warning: library too old, some operations may not work\n");


### PR DESCRIPTION
During testing of LACT using various sanitizers I uncovered issue with libfuse.so leaking memory and reading uninitialized memory. While this was due to ABI misusage on the side of `fuser` (Rust wrapper for libfuse.so) behaviour of `fuse_session_new` is very unintuitive, it makes sense to handle it.

Also this code has made it's way into production applications, which further makes sense to fix it in all sides.

Related
https://github.com/ilya-zlobintsev/LACT/pull/740
https://github.com/cberner/fuser/pull/390
https://github.com/Alogani/easy_fuser/issues/60