### PR TITLE
libfuse: fix COPY_FILE_RANGE interface

### DIFF
--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -235,6 +235,10 @@
  *
  *  7.44
  *  - add FUSE_NOTIFY_INC_EPOCH
+ *
+ *  7.45
+ *  - add FUSE_COPY_FILE_RANGE_64
+ *  - add struct fuse_copy_file_range_out
  */
 
 #ifndef _LINUX_FUSE_H
@@ -270,7 +274,7 @@
 #define FUSE_KERNEL_VERSION 7
 
 /** Minor version number of this interface */
-#define FUSE_KERNEL_MINOR_VERSION 44
+#define FUSE_KERNEL_MINOR_VERSION 45
 
 /** The node ID of the root inode */
 #define FUSE_ROOT_ID 1
@@ -657,6 +661,7 @@ enum fuse_opcode {
 	FUSE_SYNCFS		= 50,
 	FUSE_TMPFILE		= 51,
 	FUSE_STATX		= 52,
+	FUSE_COPY_FILE_RANGE_64	= 53,
 
 	/* CUSE specific operations */
 	CUSE_INIT		= 4096,
@@ -1146,6 +1151,11 @@ struct fuse_copy_file_range_in {
 	uint64_t	off_out;
 	uint64_t	len;
 	uint64_t	flags;
+};
+
+/* For FUSE_COPY_FILE_RANGE_64 */
+struct fuse_copy_file_range_out {
+	uint64_t	bytes_copied;
 };
 
 #define FUSE_SETUPMAPPING_FLAG_WRITE (1ull << 0)

--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -40,6 +40,7 @@ struct fuse_req {
 	int interrupted;
 	unsigned int ioctl_64bit : 1;
 	unsigned int is_uring : 1;
+	unsigned int is_copy_file_range_64 : 1;
 	union {
 		struct {
 			uint64_t unique;


### PR DESCRIPTION
The FUSE protocol uses struct fuse_write_out to convey the return value of copy_file_range, which is restricted to uint32_t.  But the COPY_FILE_RANGE interface supports a 64-bit size copies.

Currently the number of bytes copied is silently truncated to 32-bit, which is unfortunate at best.

Implement the COPY_FILE_RANGE_64 interface which is identical to the old one, except the number of bytes copied is returned in a 64-bit value.

The library interface remains the same.

If the kernel does not support the new interface or the server is running as a 32-bit process, limit the copy size to size to UINT_MAX - 4096.

Reported-by: Florian Weimer <fweimer@redhat.com>
Closes: https://lore.kernel.org/all/lhuh5ynl8z5.fsf@oldenburg.str.redhat.com/