### PR TITLE
libfuse: don't put HAVE_STATX in a public header

### DIFF
--- a/example/memfs_ll.cc
+++ b/example/memfs_ll.cc
@@ -6,7 +6,7 @@
   See the file GPL2.txt.
 */
 
-#define FUSE_USE_VERSION 317
+#define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 18)
 
 #include <algorithm>
 #include <stdio.h>

--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -23,7 +23,7 @@
  */
 
 
-#define FUSE_USE_VERSION 31
+#define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 18)
 
 #define _GNU_SOURCE
 

--- a/example/passthrough_fh.c
+++ b/example/passthrough_fh.c
@@ -23,7 +23,7 @@
  * \include passthrough_fh.c
  */
 
-#define FUSE_USE_VERSION 31
+#define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 18)
 
 #define _GNU_SOURCE
 

--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -35,7 +35,7 @@
  */
 
 #define _GNU_SOURCE
-#define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 12)
+#define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 18)
 
 #include <fuse_lowlevel.h>
 #include <unistd.h>

--- a/include/fuse.h
+++ b/include/fuse.h
@@ -854,7 +854,6 @@ struct fuse_operations {
 	 */
 	off_t (*lseek) (const char *, off_t off, int whence, struct fuse_file_info *);
 
-#ifdef HAVE_STATX
 	/**
 	 * Get extended file attributes.
 	 *
@@ -865,7 +864,6 @@ struct fuse_operations {
 	 */
 	int (*statx)(const char *path, int flags, int mask, struct statx *stxbuf,
 		     struct fuse_file_info *fi);
-#endif
 };
 
 /** Extra context that may be needed by some filesystems

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -1327,7 +1327,6 @@ struct fuse_lowlevel_ops {
 	void (*tmpfile) (fuse_req_t req, fuse_ino_t parent,
 			mode_t mode, struct fuse_file_info *fi);
 
-#ifdef HAVE_STATX
 	/**
 	 * Get extended file attributes.
 	 *
@@ -1343,7 +1342,6 @@ struct fuse_lowlevel_ops {
 	 */
 	void (*statx)(fuse_req_t req, fuse_ino_t ino, int flags, int mask,
 		      struct fuse_file_info *fi);
-#endif
 };
 
 /**

--- a/meson.build
+++ b/meson.build
@@ -122,8 +122,6 @@ private_cfg.set('HAVE_ICONV',
     cc.has_function('iconv', prefix: '#include <iconv.h>'))
 private_cfg.set('HAVE_BACKTRACE',
     cc.has_function('backtrace', prefix: '#include <execinfo.h>'))
-public_cfg.set('HAVE_STATX',
-        cc.has_function('statx',  prefix : '#define _GNU_SOURCE\n#include <sys/stat.h>'))
 private_cfg.set('HAVE_STATX',
         cc.has_function('statx',  prefix : '#define _GNU_SOURCE\n#include <sys/stat.h>'))
 


### PR DESCRIPTION
fuse.h and fuse_lowlevel.h are already forward declaring struct statx, there is no need for HAVE_STATX anymore. HAVE_STATX also bears the risk to conflict with an application define. Alternatively it would have been possible to change to HAVE_FUSE_STATX.

Get rid of the conditionals in the public header files and also remove HAVE_STATX definition from the public
libfuse_config.h.

Edit by Bernd: Commit message and removal of HAVE_STATX from public libfuse_config.h.