### PR TITLE
fuse_lowlevel.c: allow passing ops as NULL

### DIFF
--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -2117,6 +2117,8 @@ fuse_session_new_versioned(struct fuse_args *args,
  * If not all options are known, an error message is written to stderr
  * and the function returns NULL.
  *
+ * To create a no-op session just for mounting pass op as NULL.
+ *
  * Option parsing skips argv[0], which is assumed to contain the
  * program name. To prevent accidentally passing an option in
  * argv[0], this element must always be present (even if no options


### PR DESCRIPTION
During testing of LACT using various sanitizers issue with libfuse.so leaking memory and reading uninitialized memory was uncovered. While this was due to ABI misusage on the side of fuser (Rust wrapper for libfuse.so), we now allow creating a no-op session by passing ops as NULL.

fuser and other libfuse users is using fuse_session_new() with NULL struct fuse_lowlevel_ops *op and op_size=0. This resulted in a warning, but otherwise succeeded. The resulting fuse_session is just passed to fuse_session_mount() so that libfuse could do the actual mount. Fuse kernel request handling is not done through libfuse but their own layer.

Edit by Bernd:
- Update the commit message
- moved using null_ops to fuse_session_new_30() as that is actually called by the external fuse_session_new().
- forbidding NULL struct fuse_lowlevel_ops *op and 0 op_size in fuse_session_new_versioned()
- various other NULL ptr checks in fuse_session_new() that now result in failure.