### PR TITLE
fuse_log: Add __attribute__((format(printf, ) and fix warnings

### DIFF
--- a/example/passthrough_ll.c
+++ b/example/passthrough_ll.c
@@ -315,7 +315,7 @@ static struct lo_inode *create_new_inode(int fd, struct fuse_entry_param *e, str
 {
 	struct lo_inode *inode = NULL;
 	struct lo_inode *prev, *next;
-	
+
 	inode = calloc(1, sizeof(struct lo_inode));
 	if (!inode)
 		return NULL;
@@ -352,7 +352,7 @@ static int fill_entry_param_new_inode(fuse_req_t req, fuse_ino_t parent, int fd,
 	e->ino = (uintptr_t) create_new_inode(dup(fd), e, lo);
 
 	if (lo_debug(req))
-		fuse_log(FUSE_LOG_DEBUG, "  %lli/%lli -> %lli\n",
+		fuse_log(FUSE_LOG_DEBUG, "  %lli/%d -> %lli\n",
 			(unsigned long long) parent, fd, (unsigned long long) e->ino);
 
 	return 0;
@@ -712,7 +712,7 @@ static void lo_do_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
 					err = errno;
 					goto error;
 				} else {  // End of stream
-					break; 
+					break;
 				}
 			}
 		}
@@ -744,11 +744,11 @@ static void lo_do_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
 						    &st, nextoff);
 		}
 		if (entsize > rem) {
-			if (entry_ino != 0) 
+			if (entry_ino != 0)
 				lo_forget_one(req, entry_ino, 1);
 			break;
 		}
-		
+
 		p += entsize;
 		rem -= entsize;
 
@@ -816,9 +816,9 @@ static void lo_tmpfile(fuse_req_t req, fuse_ino_t parent,
 	/* parallel_direct_writes feature depends on direct_io features.
 	   To make parallel_direct_writes valid, need set fi->direct_io
 	   in current function. */
-	fi->parallel_direct_writes = 1; 
-	
-	err = fill_entry_param_new_inode(req, parent, fd, &e); 
+	fi->parallel_direct_writes = 1;
+
+	err = fill_entry_param_new_inode(req, parent, fd, &e);
 	if (err)
 		fuse_reply_err(req, err);
 	else
@@ -981,8 +981,8 @@ static void lo_write_buf(fuse_req_t req, fuse_ino_t ino,
 	out_buf.buf[0].pos = off;
 
 	if (lo_debug(req))
-		fuse_log(FUSE_LOG_DEBUG, "lo_write(ino=%" PRIu64 ", size=%zd, off=%lu)\n",
-			ino, out_buf.buf[0].size, (unsigned long) off);
+		fuse_log(FUSE_LOG_DEBUG, "lo_write(ino=%" PRIu64 ", size=%zd, off=%jd)\n",
+			ino, out_buf.buf[0].size, (intmax_t) off);
 
 	res = fuse_buf_copy(&out_buf, in_buf, 0);
 	if(res < 0)
@@ -1187,10 +1187,12 @@ static void lo_copy_file_range(fuse_req_t req, fuse_ino_t ino_in, off_t off_in,
 	ssize_t res;
 
 	if (lo_debug(req))
-		fuse_log(FUSE_LOG_DEBUG, "lo_copy_file_range(ino=%" PRIu64 "/fd=%lu, "
-				"off=%lu, ino=%" PRIu64 "/fd=%lu, "
-				"off=%lu, size=%zd, flags=0x%x)\n",
-			ino_in, fi_in->fh, off_in, ino_out, fi_out->fh, off_out,
+		fuse_log(FUSE_LOG_DEBUG,
+			"%s(ino=%lld fd=%lld off=%jd ino=%lld fd=%lld off=%jd, size=%zd, flags=0x%x)\n",
+			__func__,  (unsigned long long)ino_in,
+			(unsigned long long)fi_in->fh,
+			(intmax_t) off_in, (unsigned long long)ino_out,
+			(unsigned long long)fi_out->fh, (intmax_t) off_out,
 			len, flags);
 
 	res = copy_file_range(fi_in->fh, &off_in, fi_out->fh, &off_out, len,

--- a/include/fuse_log.h
+++ b/include/fuse_log.h
@@ -73,7 +73,8 @@ void fuse_set_log_func(fuse_log_func_t func);
  * @param level severity level (FUSE_LOG_ERR, FUSE_LOG_DEBUG, etc)
  * @param fmt sprintf-style format string including newline
  */
-void fuse_log(enum fuse_log_level level, const char *fmt, ...);
+void fuse_log(enum fuse_log_level level, const char *fmt, ...)
+	__attribute__((format(printf, 2, 3)));
 
 /**
  * Switch default log handler from stderr to syslog

--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -2122,10 +2122,10 @@ int fuse_fs_utimens(struct fuse_fs *fs, const char *path,
 	if (fs->debug) {
 		char buf[10];
 
-		fuse_log(FUSE_LOG_DEBUG, "utimens[%s] %s %li.%09lu %li.%09lu\n",
-			file_info_string(fi, buf, sizeof(buf)),
-			path, tv[0].tv_sec, tv[0].tv_nsec,
-			tv[1].tv_sec, tv[1].tv_nsec);
+		fuse_log(FUSE_LOG_DEBUG, "utimens[%s] %s %jd.%09ld %jd.%09ld\n",
+			 file_info_string(fi, buf, sizeof(buf)),
+			 path, (intmax_t)tv[0].tv_sec, tv[0].tv_nsec,
+			 (intmax_t)tv[1].tv_sec, tv[1].tv_nsec);
 	}
 	return fs->op.utimens(path, tv, fi);
 }

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -23,6 +23,7 @@
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -753,11 +754,15 @@ static int read_back(int fd, char *buf, size_t len)
 
 	res = read(fd, buf, len);
 	if (res == -1) {
-		fuse_log(FUSE_LOG_ERR, "fuse: internal error: failed to read back from pipe: %s\n", strerror(errno));
+		fuse_log(FUSE_LOG_ERR,
+			 "fuse: internal error: failed to read back from pipe: %s\n",
+			 strerror(errno));
 		return -EIO;
 	}
 	if (res != len) {
-		fuse_log(FUSE_LOG_ERR, "fuse: internal error: short read back from pipe: %i from %zi\n", res, len);
+		fuse_log(FUSE_LOG_ERR,
+			 "fuse: internal error: short read back from pipe: %i from %zd\n",
+			 res, len);
 		return -EIO;
 	}
 	return 0;
@@ -2550,8 +2555,8 @@ static bool want_flags_valid(uint64_t capable, uint64_t want)
 	uint64_t unknown_flags = want & (~capable);
 	if (unknown_flags != 0) {
 		fuse_log(FUSE_LOG_ERR,
-			 "fuse: unknown connection 'want' flags: 0x%08lx\n",
-			unknown_flags);
+			 "fuse: unknown connection 'want' flags: 0x%08llx\n",
+			(unsigned long long)unknown_flags);
 		return false;
 	}
 	return true;
@@ -2577,10 +2582,12 @@ int fuse_convert_to_conn_want_ext(struct fuse_conn_info *conn)
 	    fuse_lower_32_bits(conn->want_ext) != conn->want) {
 		if (conn->want_ext != se->conn_want_ext) {
 			fuse_log(FUSE_LOG_ERR,
-				"%s: Both conn->want_ext and conn->want are set.\n"
-				"want=%x, want_ext=%lx, se->want=%lx se->want_ext=%lx\n",
-				__func__, conn->want, conn->want_ext,
-				se->conn_want, se->conn_want_ext);
+				 "%s: Both conn->want_ext and conn->want are set.\n"
+				 "want=%x want_ext=%llx, se->want=%x se->want_ext=%llx\n",
+				 __func__, conn->want,
+				 (unsigned long long)conn->want_ext,
+				 se->conn_want,
+				 (unsigned long long)se->conn_want_ext);
 			return -EINVAL;
 		}
 

--- a/lib/fuse_uring.c
+++ b/lib/fuse_uring.c
@@ -18,6 +18,7 @@
 #include <liburing.h>
 #include <sys/sysinfo.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
 #include <unistd.h>
@@ -180,7 +181,7 @@ static int fuse_uring_commit_sqe(struct fuse_ring_pool *ring_pool,
 				    ring_ent->req_commit_id);
 
 	if (se->debug) {
-		fuse_log(FUSE_LOG_DEBUG, "    unique: %llu, result=%d\n",
+		fuse_log(FUSE_LOG_DEBUG, "    unique: %" PRIu64 ", result=%d\n",
 			 out->unique, ent_in_out->payload_sz);
 	}
 
@@ -453,7 +454,7 @@ static int fuse_uring_prepare_fetch_sqes(struct fuse_ring_queue *queue)
 	sq_ready = io_uring_sq_ready(&queue->ring);
 	if (sq_ready != ring_pool->queue_depth) {
 		fuse_log(FUSE_LOG_ERR,
-			 "SQE ready mismatch, expected %d got %d\n",
+			 "SQE ready mismatch, expected %zu got %u\n",
 			 ring_pool->queue_depth, sq_ready);
 		return -EINVAL;
 	}

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -361,7 +361,7 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
 
 	res = socketpair(PF_UNIX, SOCK_STREAM, 0, fds);
 	if(res == -1) {
-		fuse_log(FUSE_LOG_ERR, "Setting up auto-unmountsocketpair() failed",
+		fuse_log(FUSE_LOG_ERR, "Setting up auto-unmount socketpair() failed: %s\n",
 			 strerror(errno));
 		return -1;
 	}


### PR DESCRIPTION
fuse_log() did not have that attribute and so compilers didn't give warnings for plain printf().
Add the attribute and fix related warnings.