### PR TITLE
Use `listmount` and `statmount` to count filesystems

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,25 @@ special_funcs = {
             unsigned int flags = CLOSE_RANGE_UNSHARE;
             return close_range(3, ~0U, flags);
         }
+    ''',
+    'listmount': '''
+	#include <syscall.h>
+	#include <linux/mount.h>
+	#include <unistd.h>
+	#include <stdint.h>
+
+	int main(int argc, char *argv[]) {
+	  struct mnt_id_req req = {
+	    .size = sizeof(struct mnt_id_req),
+		  .mnt_id = LSMT_ROOT,
+	  };
+	  uint64_t mnt_ids[1];
+
+	  int n = syscall(SYS_listmount, &req, &mnt_ids, 1, 0);
+	  if (n == -1) {
+	    return -1;
+	  }
+	}
     '''
 }
 

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -40,6 +40,12 @@
 #include <linux/close_range.h>
 #endif
 
+#if defined HAVE_LISTMOUNT
+#include <linux/mount.h>
+#include <syscall.h>
+#include <stdint.h>
+#endif
+
 #define FUSE_COMMFD_ENV		"_FUSE_COMMFD"
 #define FUSE_KERN_DEVICE_ENV	"FUSE_KERN_DEVICE"
 
@@ -566,7 +572,7 @@ static int unmount_fuse(const char *mnt, int quiet, int lazy)
 	return res;
 }
 
-static int count_fuse_fs(void)
+static int count_fuse_fs_mtab(void)
 {
 	struct mntent *entp;
 	int count = 0;
@@ -586,6 +592,72 @@ static int count_fuse_fs(void)
 	return count;
 }
 
+#ifdef HAVE_LISTMOUNT
+static int count_fuse_fs_ls_mnt(void)
+{
+	#define SMBUF_SIZE 1024
+	#define MNT_ID_LEN 128
+
+	int fuse_count = 0;
+	int n_mounts = 0;
+	int ret = 0;
+	uint64_t mnt_ids[MNT_ID_LEN];
+	unsigned char smbuf[SMBUF_SIZE];
+	struct mnt_id_req req = {
+		.size = sizeof(struct mnt_id_req),
+	};
+	struct statmount *sm;
+
+	for (;;) {
+		req.mnt_id = LSMT_ROOT;
+
+		n_mounts = syscall(SYS_listmount, &req, &mnt_ids, MNT_ID_LEN, 0);
+		if (n_mounts == -1) {
+			if (errno != ENOSYS) {
+				fprintf(stderr, "%s: failed to list mounts: %s\n", progname,
+					strerror(errno));
+			}
+			return -1;
+		}
+
+		for (int i = 0; i < n_mounts; i++) {
+			req.mnt_id = mnt_ids[i];
+			req.param = STATMOUNT_FS_TYPE;
+			ret = syscall(SYS_statmount, &req, &smbuf, SMBUF_SIZE, 0);
+			if (ret) {
+				if (errno == ENOENT)
+					continue;
+
+				fprintf(stderr, "%s: failed to stat mount %lld: %s\n", progname,
+					req.mnt_id, strerror(errno));
+				return -1;
+			}
+
+			sm = (struct statmount *)smbuf;
+			if (sm->mask & STATMOUNT_FS_TYPE &&
+			    strcmp(&sm->str[sm->fs_type], "fuse") == 0)
+				fuse_count++;
+		}
+
+		if (n_mounts < MNT_ID_LEN)
+			break;
+		req.param = mnt_ids[MNT_ID_LEN - 1];
+	}
+	return fuse_count;
+}
+
+static int count_fuse_fs(void)
+{
+	int count = count_fuse_fs_ls_mnt();
+
+	return count >= 0 ? count : count_fuse_fs_mtab();
+}
+#else
+static int count_fuse_fs(void)
+{
+	return count_fuse_fs_mtab();
+}
+#endif
 
 #else /* IGNORE_MTAB */
 static int count_fuse_fs(void)


### PR DESCRIPTION
### background

I've been fuzz-testing a FUSE implementation by running a loop that creates and mounts a new FUSE, runs some operations against it, and unmounts. The fuzz test does this repeatedly from a single thread, and should never be mounting more than one FUSE at a time.

Despite that, occasionally I see the following error, with `max_mount` set to the default value of 1000:

```
fusermount3: too many FUSE filesystems mounted; mount_max=N can be set in /etc/fuse.conf
```

After manually digging in `/proc` it seemed like the fuzzing wasn't leaving unmounted filesystems around, so I copied [`count_fuse_fs`](https://github.com/libfuse/libfuse/blob/564d79e4d3132924d33f0a0848b9d54c84b42a17/util/fusermount.c#L569-L587) and wrote some code based on [the new `statmount` and `listmount`](https://lwn.net/Articles/950569/) APIs see if I could get a better view of what was going on:

<details>

<summary>count_fuse_fs.c</summary>

```c
#include <stdio.h>
#include <mntent.h>
#include <syscall.h>
#include <linux/mount.h>
#include <unistd.h>
#include <errno.h>
#include <stdint.h>
#include <string.h>


static int count_fuse_fs_listmount(void) {
	struct mnt_id_req req = {
		.size = sizeof(struct mnt_id_req),
	      	.mnt_id = LSMT_ROOT,
	};
	uint64_t mnt_ids[128];
	unsigned char smbuf[1024];
	int count = 0;

	int n = syscall(SYS_listmount, &req, &mnt_ids, 128, 0);
	if (n == -1) {
		return errno;
	}

	for (int i = 0; i < n; i++) {
		req.mnt_id = mnt_ids[i];
		req.param = STATMOUNT_SB_BASIC | STATMOUNT_FS_TYPE | STATMOUNT_MNT_ROOT | STATMOUNT_MNT_POINT;
		int ret = syscall(SYS_statmount, &req, &smbuf, 1024, 0);
		if (ret) {
			if (errno != ENOENT) {
				perror("statmount failed");
			}
			continue;
		}


		struct statmount *sm = (struct statmount *)smbuf;
		if ((sm->mask & STATMOUNT_FS_TYPE) && strcmp(&sm->str[sm->fs_type], "fuse") == 0) {
			count++;
		}
	}	

	return count;
}

static int count_fuse_fs(const char* mtab) {
	struct mntent *entp;
	int count = 0;
	FILE *fp = setmntent(mtab, "r");
	if (fp == NULL) {
		fprintf(stderr, "failed to open %s: %s\n", mtab, strerror(errno));
		return -1;
	}
	while ((entp = getmntent(fp)) != NULL) {
		if (strcmp(entp->mnt_type, "fuse") == 0 || strncmp(entp->mnt_type, "fuse.", 5) == 0) {
			count ++;
		}
	}
	endmntent(fp);
	return count;
}

int main(int argc, char *argv[]) {
	int proc_count = count_fuse_fs("/proc/mounts");
	int statmount_count = count_fuse_fs_listmount();

	if ((proc_count > 0) || (statmount_count > 0)) {
		printf("/proc/mounts=%d listmount=%d\n", proc_count, statmount_count);
	}
}
``` 

</details>

In a few hours of fuzzing, I haven't seen `listmount` ever report a count of more than one FUSE, while every few minutes I see counting lines in `/proc/mounts` report that hundreds of FUSEs exist. 

```
$ while true; do ./count_fuse_fs; sleep 0.1; done/proc/mounts=0 listmount=1
...
/proc/mounts=0 listmount=1
/proc/mounts=1 listmount=1
/proc/mounts=916 listmount=0
/proc/mounts=1 listmount=1
...
/proc/mounts=1 listmount=1
/proc/mounts=1107 listmount=0
/proc/mounts=1 listmount=0
```

There's a delay between the two counts being called so I expect to occasionally see different results, but if the fuzz test was actually leaving a few hundred unmounted FUSEs around I would expect `listmount` to report that at some point. This really does seem like [the classic problem with parsing `/proc`](https://stackoverflow.com/questions/5713451/is-it-safe-to-parse-a-proc-file).

### the change

I took a stab at using `listmount` and `statmount` to count filesystems when they're available. There are no libc wrappers for these functions, so they're called directly through `syscall`. I'm sure there's plenty else to fix here, especially the commit message, but before we get into details I want to make sure folks would be comfortable using `listmount` and `statmount` without libc wrappers.