### PR TITLE
fuse_lowlevel.h: remove incorrect documentation

### DIFF
--- a/doc/README.fuse_reply_errors
+++ b/doc/README.fuse_reply_errors
@@ -1,0 +1,5 @@
+Under normal operation, a call to any fuse_reply_* function should not result
+in an error.
+
+Should the kernel abort the fuse connection, a fuse_reply_* call can return
+-ENOENT.

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -197,6 +197,11 @@ enum fuse_notify_entry_flags {
  * `fuse_session_new()`. In this case, methods will only be called if
  * the kernel's permission check has succeeded.
  *
+ * It is generally not really necessary to check the fuse_reply_* return
+ * values for errors, as any error in sending a reply indicates an
+ * unrecoverable problem with the kernel fuse connection, which will also
+ * terminate the session loop anyway.
+ *
  * This data structure is ABI sensitive, on adding new functions these need to
  * be appended at the end of the struct
  */


### PR DESCRIPTION
It seems fuse_reply_open() cannot actually return -ENOENT under recoverable conditions, so remove the corresponding paragraph claiming otherwise.

For a discussion on this see
https://github.com/libfuse/libfuse/discussions/1262