### PR TITLE
tests: fix a race in wait_for_mount()

### DIFF
--- a/test/util.py
+++ b/test/util.py
@@ -50,6 +50,8 @@ def wait_for_mount(mount_process, mnt_dir,
         if test_fn(mnt_dir):
             return True
         if mount_process.poll() is not None:
+            if test_fn(mnt_dir):
+                return True
             pytest.fail('file system process terminated prematurely')
         time.sleep(0.1)
         elapsed += 0.1


### PR DESCRIPTION
Recheck if target is mounted after the mount process exited, otherwise the test can fail erronously.