### PR TITLE
Initialize fuse_entry_param in fuse_lib_lookup()

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -2659,7 +2659,7 @@ static void fuse_lib_lookup(fuse_req_t req, fuse_ino_t parent,
 			    const char *name)
 {
 	struct fuse *f = req_fuse_prepare(req);
-	struct fuse_entry_param e;
+	struct fuse_entry_param e = { .ino = 0 }; /* invalid ino */
 	char *path;
 	int err;
 	struct node *dot = NULL;


### PR DESCRIPTION
"struct fuse_entry_param e" was not initialized when get_path_name() returned an error, which made recent clang versions to correctly complain.

Closes: https://github.com/libfuse/libfuse/issues/1360