### PR TITLE
example/passthrough_hp: fix race in forget_one()

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -620,6 +620,7 @@ static void sfs_unlink(fuse_req_t req, fuse_ino_t parent, const char *name)
 static void forget_one(fuse_ino_t ino, uint64_t n)
 {
 	Inode &inode = get_inode(ino);
+	unique_lock<mutex> l{ inode.m };
 
 	if (n > inode.nlookup) {
 		cerr << "INTERNAL ERROR: Negative lookup count for inode "
@@ -635,6 +636,7 @@ static void forget_one(fuse_ino_t ino, uint64_t n)
 
 	if (!inode.nlookup) {
 		lock_guard<mutex> g_fs{ fs.mutex };
+		l.unlock();
 		if (!inode.nlookup) {
 			cerr << "DEBUG: forget: cleaning up inode "
 				<< inode.src_ino << endl;


### PR DESCRIPTION
When multiple threads concurrently call forget_one() on the same inode, a use-after-free memory issue can occur.
```
 forget_one()               forget_one()
 ----------------           ---------------
           <inode.nlookup == 2>
 inode.nlookup -= 1
                            inode.nlookup -= 1
           <inode.nlookup == 0>
 if (!inode.nlookup)
   fs.inodes.erase()
                            if (!inode.nlookup) {} //UAF
```
Fix it by restoring the inode lock protection in forget_one().