### PR TITLE
example/passthrough_hp: fix debug output in forget_one

### DIFF
--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -638,8 +638,9 @@ static void forget_one(fuse_ino_t ino, uint64_t n)
 		lock_guard<mutex> g_fs{ fs.mutex };
 		l.unlock();
 		if (!inode.nlookup) {
-			cerr << "DEBUG: forget: cleaning up inode "
-				<< inode.src_ino << endl;
+			if (fs.debug)
+				cerr << "DEBUG: forget: cleaning up inode "
+				     << inode.src_ino << endl;
 			fs.inodes.erase({ inode.src_ino, inode.src_dev });
 		}
 	} else if (fs.debug)


### PR DESCRIPTION
The incorrect removeal of the fs.debug check caused the message "DEBUG: cleaning up inode" to be printed even when debug was not enabled.

Unfortunately, this issue was introduced by my previous patch. I didn't notice it because I had enabled debugging during testing.