### PR TITLE
lib/fuse.c: fix deallocation in fuse_session_loop_remember

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -4626,7 +4626,7 @@ static int fuse_session_loop_remember(struct fuse *f)
 		}
 	}
 
-	free(fbuf.mem);
+	fuse_buf_free(&fbuf);
 	return res < 0 ? -1 : 0;
 }
 


### PR DESCRIPTION
Starting from commit 752b59ac0876, the buffer must be freed with fuse_buf_free, not plain free.

Fixes #1376.