### PR TITLE
fuse-io-uring: fix narrowing integer conversion of commit_id

### DIFF
--- a/lib/fuse_uring.c
+++ b/lib/fuse_uring.c
@@ -119,7 +119,7 @@ static void *fuse_uring_get_sqe_cmd(struct io_uring_sqe *sqe)
 
 static void fuse_uring_sqe_set_req_data(struct fuse_uring_cmd_req *req,
 					const unsigned int qid,
-					const unsigned int commit_id)
+					const uint64_t commit_id)
 {
 	req->qid = qid;
 	req->commit_id = commit_id;


### PR DESCRIPTION
commid_id is 64 bits.  fuse_uring_sqe_set_req_data() accepts commid_id as 'unsigned int' type, which is only guaranteed to be no less than 32 bits.  Thus the high 32 bits are dropped, and the replied commit_id is truncated to the lower 32 bits as well in the following replied fuse_uring_cmd_req when issuing FUSE_IO_URING_CMD_COMMIT_AND_FETCH subcmd.

This can lead to "fuse: qid=XX commit_id YY not found" error, where YY is the low 32 bits of the actual commid_id.