### PR TITLE
Prepare 3.18.0 release

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -260,6 +260,25 @@ Tyler Hall <tylerwhall@gmail.com>
 yangyun <yangyun50@huawei.com>
 Abhishek <abhi_45645@yahoo.com>
 
-# New authors since 666b2c3fa5159e3c72a0d08117507475117c9319
+# New authors since fuse-3.17.1
 Luis Henriques <luis@igalia.com>
 Zegang <zegang.luo@qq.com>
+swj <1186093704@qq.com>
+Gleb Popov <6yearold@gmail.com>
+WekaJosh <80121792+WekaJosh@users.noreply.github.com>
+Alexander Monakov <amonakov@ispras.ru>
+Ben Dooks <ben.dooks@codethink.co.uk>
+Ben Linsay <blinsay@gmail.com>
+Dave Vasilevsky <dave@vasilevsky.ca>
+Darrick J. Wong <djwong@kernel.org>
+Georgi Valkov <gvalkov@gmail.com>
+Alik Aslanyan <inline0@pm.me>
+jnr0006 <jacob.nick.riley@gmail.com>
+Jingbo Xu <jefflexu@linux.alibaba.com>
+Long Li <leo.lilong@huawei.com>
+Maksim Harbachou <maksim.harbachou@resilio.com>
+Meng Lu Wang <mwang@ddn.com>
+Vassili Tchersky <vt+git@vbc.su>
+Vassili Tchersky <vt+git@vbcy.org>
+izxl007 <zeng.zheng@zte.com.cn>
+Zeno Sebastian Endemann <zeno.endemann@mailbox.org>

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,81 @@
-libfuse 3.18
+libfuse 3.18.0 (2025-12-18)
+===========================
 
-libfuse 3.17.1-rc0 (2024-02.10)
+New Features
+------------
+
+* fuse-over-io-uring communication
+* statx support
+* Request timeouts: Prevent hung operations
+* FUSE_NOTIFY_INC_EPOCH: New notification mechanism for epoch counters
+
+Important Fixes
+----------------
+
+* Fixed double unmount on FUSE_DESTROY
+* Fixed junk readdirplus results when filesystem doesn't fill stat info
+* Fixed memory deallocation in fuse_session_loop_remember
+* Fixed COPY_FILE_RANGE interface
+
+Platform Support
+----------------
+
+* Improved FreeBSD support (mount error reporting, test runner, build fixes)
+* Fixed 32-bit architecture builds
+* Fixed build with musl libc and older kernels (< 5.9)
+
+Other Improvements
+------------------
+
+* Added PanFS to fusermount whitelist
+* Thread naming support for easier debugging
+
+
+libfuse 3.17.4 (2025-08-19)
+===========================
+- Try to detect mount-utils by checking for /run/mount/utab
+  and don't try to update mtab if it does not exist
+- Fix a build warning when HAVE_BACKTRACE is undefined
+- fuse_loop_mt.c: fix close-on-exec flag on clone fd
+- Remove struct size assertions from fuse_common.h
+
+libfuse 3.17.3 (2025-07-16)
+===========================
+* more conn->want / conn->want_ext conversion fixes
+* Fix feature detection for close_range
+* Avoid double unmount on FUSE_DESTROY
+
+libfuse 3.17.2 (2025-04-23)
+===========================
+* Fixed uninitized bufsize value (compilation warning and real
+  issue when HAVE_SPLICE was not defined)
+* Fixed initialization races related to buffer realocation when
+  large buf sizes are used (/proc/sys/fs/fuse/max_pages_limit)
+* Fix build with kernel < 5.9
+* Fix static_assert build failure with C++ version < 11
+* Compilation fix (remove second fuse_main_real_versioned declaration)
+* Another conn.want flag conversion fix for high-level applications
+* Check if pthread_setname_np() exists before use it
+* fix example/memfs_ll rename deadlock error
+* signal handlers: Store fuse_session unconditionally and restore
+  previous behavior that with multiple sessions the last session
+  was used for the signal exist handler
+
+libfuse 3.17.1 (2025-03-24)
+===========================
+* fuse: Fix want conn.want flag conversion
+* Prevent re-usage of stdio FDs for fusermount
+* PanFS added to fusermount whitelist
+
+libfuse 3.17.1-rc1 (2025-02-18)
+===============================
+* several BSD fixes
+* x86 (32bit) build fixes
+* nested declarations moved out of the inlined functions to avoid
+  build warnings
+* signify public key added for future 3.18
+
+libfuse 3.17.1-rc0 (2025-02.10)
 ===============================
 
 * Fix libfuse build with FUSE_USE_VERSION 30
@@ -16,7 +91,7 @@ libfuse 3.17.1-rc0 (2024-02.10)
   exported to be able to silence leak checkers
 
 
-libfuse 3.17 (2024-01-01, not officially releaesed)
+libfuse 3.17 (2025-01-01, not officially releaesed)
 ==================================================
 
 * 3.11 and 3.14.2 introduced ABI incompatibilities, the ABI is restored

--- a/signify/fuse-3.19.pub
+++ b/signify/fuse-3.19.pub
@@ -1,0 +1,2 @@
+untrusted comment: signify public key
+RWR4cEcMGJhD3Dnd3NOeJck3WiuVt9A7mrkq+nQYwrwwmMdDDAan/YiU


### PR DESCRIPTION
Update AUTHORS and ChangeLog.rst, added signify/fuse-3.19.pub.