### PR TITLE
add support for more mount options to avoid xfstests failure

### DIFF
--- a/lib/mount.c
+++ b/lib/mount.c
@@ -126,6 +126,7 @@ static const struct fuse_opt fuse_mount_opts[] = {
 	FUSE_OPT_KEY("nolazytime",		KEY_KERN_FLAG),
 	FUSE_OPT_KEY("symfollow",		KEY_KERN_FLAG),
 	FUSE_OPT_KEY("nosymfollow",		KEY_KERN_FLAG),
+	FUSE_OPT_KEY("remount",			KEY_KERN_FLAG),
 	FUSE_OPT_END
 };
 
@@ -204,6 +205,7 @@ static const struct mount_flags mount_flags[] = {
 	{"nosymfollow",	    MS_NOSYMFOLLOW,	1},
 #ifndef __NetBSD__
 	{"dirsync", MS_DIRSYNC,	    1},
+	{"remount", MS_REMOUNT,	    1},
 	{"lazytime",	    MS_LAZYTIME,	1},
 	{"nolazytime",	    MS_LAZYTIME,	0},
 #endif


### PR DESCRIPTION
"mount: add relatime mount option " to avoid xfstests generic/003 skip
"mount: add remount mount option" to avoid xfstests generic/294 and generic/452 failure