### PR TITLE
Update OSXFUSE to macFUSE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Supported Platforms
 
 * Linux (fully)
 * BSD (mostly/best-effort)
-* For OS-X, please use [OSXFUSE](https://osxfuse.github.io/)
+* For macOS, please use [macFUSE](https://macfuse.github.io)
   
 
 Installation


### PR DESCRIPTION
OSXFUSE is now named macFUSE. The subdomain changed (with a redirect) from `osxfuse` to `macfuse`

- [x] Changed `OS-X` to `macOS`
- [x] Changed `https://osxfuse.github.io` to `https://macfuse.github.io`