### PR TITLE
very minor fix: add assert to prevent NULL pointer dereference in try_get_path

### DIFF
--- a/lib/fuse.c
+++ b/lib/fuse.c
@@ -1019,6 +1019,7 @@ static int try_get_path(struct fuse *f, fuse_ino_t nodeid, const char *name,
 
 	if (wnodep) {
 		assert(need_lock);
+		assert(name != NULL);
 		wnode = lookup_node(f, nodeid, name);
 		if (wnode) {
 			if (wnode->treelock != 0) {


### PR DESCRIPTION
Svace statical analyzer reported a DEREF_AFTER_NULL.EX defect at lib/fuse.c:1022

```
After having been compared to a NULL value at
fuse.c:1017, pointer 'name' is passed as 3rd parameter in
call to function 'lookup_node' at fuse.c:1026, where it is
dereferenced at fuse.c:856. (CWE476)
```

This is actually a false positive, but there is already one assert(), we can add another one to ensure correct usage of this function.