### PR TITLE
fix: enforce permission checks for allow_other mounts

### DIFF
--- a/example/passthrough.c
+++ b/example/passthrough.c
@@ -38,6 +38,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <dirent.h>
 #include <errno.h>
 #include <sys/time.h>
@@ -96,11 +97,35 @@ static int xmp_getattr(const char *path, struct stat *stbuf,
 
 static int xmp_access(const char *path, int mask)
 {
-	int res;
+	struct fuse_context *ctx = fuse_get_context();
+	int res, saved_errno;
+	int switched = 0;
+
+	/*
+	 * When running as root, temporarily switch to the requesting
+	 * user's credentials so that access() checks permissions
+	 * correctly for multi-user mounts (allow_other).
+	 *
+	 * We use raw syscalls because glibc's setresuid/setresgid
+	 * wrappers synchronize across all threads, but the raw
+	 * syscalls are per-thread on Linux.
+	 */
+	if (getuid() == 0 && ctx->uid != 0) {
+		syscall(SYS_setresgid, ctx->gid, ctx->gid, 0);
+		syscall(SYS_setresuid, ctx->uid, ctx->uid, 0);
+		switched = 1;
+	}
 
 	res = access(path, mask);
+	saved_errno = errno;
+
+	if (switched) {
+		syscall(SYS_setresuid, 0, 0, 0);
+		syscall(SYS_setresgid, 0, 0, 0);
+	}
+
 	if (res == -1)
-		return -errno;
+		return -saved_errno;
 
 	return 0;
 }

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1169,5 +1169,246 @@ def test_printcap_has_all_fuse_caps():
         assert False, "\n".join(msg)
 
 
+@pytest.mark.skipif(os.getuid() != 0,
+                    reason='needs to run as root')
+@pytest.mark.xfail(strict=False,
+                    reason="kernel fuse_permission() does not check directory "
+                           "traverse permission when default_permissions is OFF")
+def test_perm_cache_dir_traversal(short_tmpdir, output_checker):
+    """Demonstrate kernel fuse_permission() gap: directory traversal.
+
+    When default_permissions is OFF, the kernel's fuse_permission() returns 0
+    for directory traversal (MAY_EXEC on directories) without checking
+    permissions. Combined with the dentry cache (entry_timeout), chmod 000 on
+    a directory does not prevent reading files inside it through cached
+    dentries until the cache expires.
+    """
+
+    mnt_dir = str(short_tmpdir.mkdir('mnt'))
+    src_dir = str(short_tmpdir.mkdir('src'))
+
+    os.chmod(str(short_tmpdir), 0o755)
+    os.chmod(mnt_dir, 0o755)
+    os.chmod(src_dir, 0o755)
+
+    # Mount passthrough WITHOUT default_permissions, with long cache timeouts.
+    # This is the scenario where the kernel bug manifests.
+    cmdline = base_cmdline + \
+              [ pjoin(basename, 'example', 'passthrough'),
+                '-f', mnt_dir,
+                '-o', 'auto_cache,allow_other,'
+                      'entry_timeout=600,attr_timeout=600' ]
+
+    output_checker.register_output(r'error', count=0)
+
+    mount_process = subprocess.Popen(cmdline, stdout=output_checker.fd,
+                                     stderr=output_checker.fd)
+    try:
+        wait_for_mount(mount_process, mnt_dir)
+        work_dir = mnt_dir + src_dir
+
+        # Create subdir (mode 755) with a file inside
+        subdir_src = pjoin(src_dir, 'subdir')
+        os.mkdir(subdir_src, 0o755)
+        testfile = pjoin(subdir_src, 'file')
+        with open(testfile, 'w') as fh:
+            fh.write('hello')
+        os.chmod(testfile, 0o644)
+
+        subdir_mnt = pjoin(work_dir, 'subdir')
+        testfile_mnt = pjoin(subdir_mnt, 'file')
+
+        # Access as nobody to populate the kernel's dentry/attr cache
+        result = subprocess.run(
+            ['runuser', '-u', 'nobody', '--', 'cat', testfile_mnt],
+            capture_output=True)
+        assert result.returncode == 0, \
+            f'Initial access failed: {result.stderr.decode()}'
+        assert result.stdout == b'hello'
+
+        # Remove all permissions on the directory via the FUSE mount
+        os.chmod(subdir_mnt, 0o000)
+
+        # Without default_permissions, the kernel's fuse_permission() returns 0
+        # for directory traversal. The cached dentry means no LOOKUP is sent,
+        # so the file remains accessible despite the directory being mode 000.
+        result = subprocess.run(
+            ['runuser', '-u', 'nobody', '--', 'cat', testfile_mnt],
+            capture_output=True)
+        assert result.returncode != 0, \
+            'Access should be denied after chmod 000 on parent directory, ' \
+            'but kernel fuse_permission() skips traverse check without ' \
+            'default_permissions'
+
+    except:
+        try:
+            os.chmod(pjoin(mnt_dir + src_dir, 'subdir'), 0o755)
+        except:
+            pass
+        cleanup(mount_process, mnt_dir)
+        raise
+    else:
+        umount(mount_process, mnt_dir)
+
+
+@pytest.mark.skipif(os.getuid() != 0,
+                    reason='needs to run as root')
+@pytest.mark.xfail(strict=False,
+                    reason="kernel fuse_permission() does not check file write "
+                           "permission for truncate when default_permissions is OFF")
+def test_perm_cache_file_truncate(short_tmpdir, output_checker):
+    """Demonstrate kernel fuse_permission() gap: file truncation.
+
+    When default_permissions is OFF, the kernel's fuse_permission() returns 0
+    for file write/truncate operations without checking permissions. Combined
+    with the inode attr cache (attr_timeout), chmod 000 on a file does not
+    prevent truncation through the cached inode until the cache expires.
+    """
+
+    mnt_dir = str(short_tmpdir.mkdir('mnt'))
+    src_dir = str(short_tmpdir.mkdir('src'))
+
+    os.chmod(str(short_tmpdir), 0o755)
+    os.chmod(mnt_dir, 0o755)
+    os.chmod(src_dir, 0o755)
+
+    cmdline = base_cmdline + \
+              [ pjoin(basename, 'example', 'passthrough'),
+                '-f', mnt_dir,
+                '-o', 'auto_cache,allow_other,'
+                      'entry_timeout=600,attr_timeout=600' ]
+
+    output_checker.register_output(r'error', count=0)
+
+    mount_process = subprocess.Popen(cmdline, stdout=output_checker.fd,
+                                     stderr=output_checker.fd)
+    try:
+        wait_for_mount(mount_process, mnt_dir)
+        work_dir = mnt_dir + src_dir
+
+        # Create a world-writable file
+        truncfile_src = pjoin(src_dir, 'truncfile')
+        with open(truncfile_src, 'w') as fh:
+            fh.write('original data')
+        os.chmod(truncfile_src, 0o666)
+
+        truncfile_mnt = pjoin(work_dir, 'truncfile')
+
+        # Access as nobody to populate the kernel's attr cache
+        result = subprocess.run(
+            ['runuser', '-u', 'nobody', '--', 'cat', truncfile_mnt],
+            capture_output=True)
+        assert result.returncode == 0, \
+            f'Initial access failed: {result.stderr.decode()}'
+        assert result.stdout == b'original data'
+
+        # Remove all permissions on the file via the FUSE mount
+        os.chmod(truncfile_mnt, 0o000)
+
+        # Without default_permissions, the kernel's fuse_permission() returns 0
+        # for write operations. The cached inode attrs mean no permission
+        # recheck happens, so truncate succeeds despite mode 000.
+        result = subprocess.run(
+            ['runuser', '-u', 'nobody', '--', 'truncate', '--size=0',
+             truncfile_mnt],
+            capture_output=True)
+        assert result.returncode != 0, \
+            'Truncate should be denied after chmod 000, but kernel ' \
+            'fuse_permission() skips write permission check without ' \
+            'default_permissions'
+
+    except:
+        try:
+            os.chmod(pjoin(mnt_dir + src_dir, 'truncfile'), 0o666)
+        except:
+            pass
+        cleanup(mount_process, mnt_dir)
+        raise
+    else:
+        umount(mount_process, mnt_dir)
+
+
+@pytest.mark.skipif(os.getuid() != 0,
+                    reason='needs to run as root')
+@pytest.mark.xfail(strict=False,
+                    reason="kernel fuse_permission() does not check directory "
+                           "execute permission for traversal when "
+                           "default_permissions is OFF")
+def test_perm_cache_dir_read_after_noexec(short_tmpdir, output_checker):
+    """Demonstrate kernel fuse_permission() gap: directory noexec traversal.
+
+    When default_permissions is OFF, the kernel's fuse_permission() returns 0
+    for directory traversal. Removing the execute bit from a directory
+    (chmod 644) should prevent traversal while still allowing listing. But
+    with cached dentries, files inside remain accessible because the kernel
+    never re-checks directory execute permission.
+    """
+
+    mnt_dir = str(short_tmpdir.mkdir('mnt'))
+    src_dir = str(short_tmpdir.mkdir('src'))
+
+    os.chmod(str(short_tmpdir), 0o755)
+    os.chmod(mnt_dir, 0o755)
+    os.chmod(src_dir, 0o755)
+
+    cmdline = base_cmdline + \
+              [ pjoin(basename, 'example', 'passthrough'),
+                '-f', mnt_dir,
+                '-o', 'auto_cache,allow_other,'
+                      'entry_timeout=600,attr_timeout=600' ]
+
+    output_checker.register_output(r'error', count=0)
+
+    mount_process = subprocess.Popen(cmdline, stdout=output_checker.fd,
+                                     stderr=output_checker.fd)
+    try:
+        wait_for_mount(mount_process, mnt_dir)
+        work_dir = mnt_dir + src_dir
+
+        # Create directory (mode 755) with a readable file
+        noexec_dir_src = pjoin(src_dir, 'noexec_dir')
+        os.mkdir(noexec_dir_src, 0o755)
+        readable = pjoin(noexec_dir_src, 'readable')
+        with open(readable, 'w') as fh:
+            fh.write('readable content')
+        os.chmod(readable, 0o644)
+
+        noexec_dir_mnt = pjoin(work_dir, 'noexec_dir')
+        readable_mnt = pjoin(noexec_dir_mnt, 'readable')
+
+        # Access as nobody to populate the kernel's dentry/attr cache
+        result = subprocess.run(
+            ['runuser', '-u', 'nobody', '--', 'cat', readable_mnt],
+            capture_output=True)
+        assert result.returncode == 0, \
+            f'Initial access failed: {result.stderr.decode()}'
+        assert result.stdout == b'readable content'
+
+        # Remove execute bit from directory (644 = read+write, no traverse)
+        os.chmod(noexec_dir_mnt, 0o644)
+
+        # Without default_permissions, the kernel's fuse_permission() returns 0
+        # for directory traversal (MAY_EXEC on dirs). The cached dentry means
+        # no LOOKUP is sent, so the file remains accessible despite the
+        # directory lacking execute permission.
+        result = subprocess.run(
+            ['runuser', '-u', 'nobody', '--', 'cat', readable_mnt],
+            capture_output=True)
+        assert result.returncode != 0, \
+            'Access should be denied after removing directory execute bit, ' \
+            'but kernel fuse_permission() skips traverse check without ' \
+            'default_permissions'
+
+    except:
+        try:
+            os.chmod(pjoin(mnt_dir + src_dir, 'noexec_dir'), 0o755)
+        except:
+            pass
+        cleanup(mount_process, mnt_dir)
+        raise
+    else:
+        umount(mount_process, mnt_dir)
+
+
 # avoid warning about unused import
 assert test_printcap


### PR DESCRIPTION
Closes #15

When default_permissions is not set and allow_other is enabled, the kernel's fuse_permission() returns 0 for most permission checks without consulting userspace. This means that after a chmod 000, cached dentries still allow access by other users — the kernel never sends FUSE_ACCESS to verify permissions.

This is a two-layer problem requiring fixes in both the kernel and the FUSE daemon:

**Daemon fix (example/passthrough.c)**:
  Fix xmp_access() to check permissions as the requesting user (via fuse_get_context()) rather than as root. Uses raw SYS_setresuid/SYS_setresgid syscalls for per-thread credential switching, since glibc wrappers synchronize across all threads.

**Associated kernel patch (fs/fuse/dir.c fuse_permission)**:
  When allow_other is set and default_permissions is not, add an else-if branch that sends FUSE_ACCESS to userspace for all permission checks. Includes a MAY_NOT_BLOCK guard that returns -ECHILD to force retry outside RCU walk mode, since fuse_access() sends a blocking request to userspace.

```diff
--- a/fs/fuse/dir.c
+++ b/fs/fuse/dir.c
@@ -1607,6 +1607,17 @@ static int fuse_permission(...)
      } else if (mask & (MAY_ACCESS | MAY_CHDIR)) {
          err = fuse_access(inode, mask);
+     } else if (fc->allow_other) {
+         /*
+          * With allow_other, multiple users can access this mount.
+          * Verify permissions via userspace to prevent user A from
+          * accessing files/directories owned by user B with
+          * restrictive permissions.
+          */
+         if (mask & MAY_NOT_BLOCK)
+             return -ECHILD;
+
+         err = fuse_access(inode, mask);
      } else if ((mask & MAY_EXEC) && S_ISREG(inode->i_mode)) {
```

**Tests (xfail without kernel patch)**:
- test_perm_cache_dir_traversal: chmod 000 dir, verify files inside are denied
- test_perm_cache_file_truncate: chmod 000 file, verify truncate is denied
- test_perm_cache_dir_read_after_noexec: remove dir execute bit, verify traversal is denied

I have verified that recompiling the Linux kernel with the patch passes the above added tests.