### PR TITLE
Fix iconv copy-paste bug and harden fusermount

### DIFF
--- a/lib/modules/iconv.c
+++ b/lib/modules/iconv.c
@@ -722,7 +722,7 @@ static struct fuse_fs *iconv_new(struct fuse_args *args,
 		goto out_free;
 	}
 	ic->fromfs = iconv_open(to, from);
-	if (ic->tofs == (iconv_t) -1) {
+	if (ic->fromfs == (iconv_t) -1) {
 		fuse_log(FUSE_LOG_ERR, "fuse-iconv: cannot convert from %s to %s\n",
 			from, to);
 		goto out_iconv_close_to;

--- a/util/fuser_conf.c
+++ b/util/fuser_conf.c
@@ -192,8 +192,14 @@ static void parse_line(const char *line, int linenum, const char *progname)
 
 	if (strcmp(line, "user_allow_other") == 0)
 		user_allow_other = 1;
-	else if (sscanf(line, "mount_max = %i", &tmp) == 1)
-		mount_max = tmp;
+	else if (sscanf(line, "mount_max = %i", &tmp) == 1) {
+		if (tmp < -1)
+			fprintf(stderr,
+				"%s: invalid mount_max = %i in %s at line %i\n",
+				progname, tmp, FUSE_CONF, linenum);
+		else
+			mount_max = tmp;
+	}
 	else if (line[0])
 		fprintf(stderr,
 			"%s: unknown parameter in %s at line %i: '%s'\n",

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1079,6 +1079,7 @@ static int do_mount(const char *mnt, const char **typep, mode_t rootmode,
 	*typep = type;
 	*mnt_optsp = mnt_opts;
 	free(fsname);
+	free(subtype);
 	free(optbuf);
 
 	return 0;

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -852,7 +852,7 @@ static int get_mnt_opts(int flags, const char *opts, char **mnt_optsp)
 		return -1;
 	/* remove comma from end of opts*/
 	l = strlen(*mnt_optsp);
-	if ((*mnt_optsp)[l-1] == ',')
+	if (l > 0 && (*mnt_optsp)[l-1] == ',')
 		(*mnt_optsp)[l-1] = '\0';
 	if (getuid() != 0) {
 		const char *user = get_user_name();

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -700,8 +700,14 @@ static void parse_line(const char *line, int linenum)
 	int tmp;
 	if (strcmp(line, "user_allow_other") == 0)
 		user_allow_other = 1;
-	else if (sscanf(line, "mount_max = %i", &tmp) == 1)
-		mount_max = tmp;
+	else if (sscanf(line, "mount_max = %i", &tmp) == 1) {
+		if (tmp < -1)
+			fprintf(stderr,
+				"%s: invalid mount_max = %i in %s at line %i\n",
+				progname, tmp, FUSE_CONF, linenum);
+		else
+			mount_max = tmp;
+	}
 	else if(line[0])
 		fprintf(stderr,
 			"%s: unknown parameter in %s at line %i: '%s'\n",

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1319,6 +1319,11 @@ static int mount_fuse(const char *mnt, const char *opts, const char **type)
 			size_t x_mnt_opts_len =  mnt_opts_len+
 						 strlen(x_opts) + 2;
 			char *x_mnt_opts = calloc(1, x_mnt_opts_len);
+			if (!x_mnt_opts) {
+				fprintf(stderr, "%s: failed to allocate memory\n",
+					progname);
+				goto fail_close_fd;
+			}
 
 			if (mnt_opts_len) {
 				strcpy(x_mnt_opts, mnt_opts);

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -600,7 +600,7 @@ static int get_mtab_opts(int flags, const char *opts, char **mtab_optsp)
 		return -1;
 	/* remove comma from end of opts*/
 	l = strlen(*mtab_optsp);
-	if ((*mtab_optsp)[l-1] == ',')
+	if (l > 0 && (*mtab_optsp)[l-1] == ',')
 		(*mtab_optsp)[l-1] = '\0';
 	if (getuid() != 0) {
 		const char *user = get_user_name();


### PR DESCRIPTION
## Summary

Phase 2 of defense-in-depth hardening (follows #1480).

- Fix copy-paste bug in iconv module: error check tested `tofs` instead of `fromfs` after `iconv_open`, silently using an invalid descriptor
- Fix unchecked `calloc` return in fusermount mount option merging
- Guard `[l-1]` access against empty string in `get_mnt_opts`
- Fix `subtype` memory leak on `do_mount` success path
- Reject invalid negative `mount_max` values in `/etc/fuse.conf`

