### PR TITLE
test stub for FUSE FORGET over io-uring

### DIFF
--- a/include/fuse_kernel.h
+++ b/include/fuse_kernel.h
@@ -240,6 +240,9 @@
  *  - add FUSE_COPY_FILE_RANGE_64
  *  - add struct fuse_copy_file_range_out
  *  - add FUSE_NOTIFY_PRUNE
+ *
+ *  7.46
+ *  - add FUSE_IO_URING_REGISTER_FORGET_COMMIT (fuse_uring_cmd_req.flags)
  */
 
 #ifndef _LINUX_FUSE_H
@@ -275,7 +278,7 @@
 #define FUSE_KERNEL_VERSION 7
 
 /** Minor version number of this interface */
-#define FUSE_KERNEL_MINOR_VERSION 45
+#define FUSE_KERNEL_MINOR_VERSION 46
 
 /** The node ID of the root inode */
 #define FUSE_ROOT_ID 1
@@ -1306,5 +1309,8 @@ struct fuse_uring_cmd_req {
 	uint16_t qid;
 	uint8_t padding[6];
 };
+
+/* fuse_uring_cmd_req.flags for FUSE_IO_URING_CMD_REGISTER */
+#define FUSE_IO_URING_REGISTER_FORGET_COMMIT (1ULL << 0)
 
 #endif /* _LINUX_FUSE_H */

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1317,6 +1317,16 @@ static void _do_forget(fuse_req_t req, const fuse_ino_t nodeid,
 
 	struct fuse_forget_in *arg = (struct fuse_forget_in *)op_in;
 
+	/*
+	 * TEST ONLY: kernel sends FORGET on io-uring when REGISTER carries
+	 * FUSE_IO_URING_REGISTER_FORGET_COMMIT. Complete the ring slot with
+	 * an empty reply without invoking op.forget (no real inode teardown).
+	 */
+	if (req->flags.is_uring) {
+		fuse_reply_err(req, 0);
+		return;
+	}
+
 	if (req->se->op.forget)
 		req->se->op.forget(req, nodeid, arg->nlookup);
 	else
@@ -1337,6 +1347,14 @@ static void _do_batch_forget(fuse_req_t req, const fuse_ino_t nodeid,
 
 	const struct fuse_batch_forget_in *arg = op_in;
 	const struct fuse_forget_one *forgets = in_payload;
+
+	/*
+	 * TEST ONLY: same as _do_forget for io-uring delivered BATCH_FORGET.
+	 */
+	if (req->flags.is_uring) {
+		fuse_reply_err(req, 0);
+		return;
+	}
 
 	if (req->se->op.forget_multi) {
 		req->se->op.forget_multi(req, arg->count,

--- a/lib/fuse_uring.c
+++ b/lib/fuse_uring.c
@@ -461,7 +461,10 @@ static int fuse_uring_register_ent(struct fuse_ring_queue *queue,
 	sqe->len = 2;
 
 	/* this is a fetch, kernel does not read commit id */
-	fuse_uring_sqe_set_req_data(fuse_uring_get_sqe_cmd(sqe), queue->qid, 0);
+	struct fuse_uring_cmd_req *cmd = fuse_uring_get_sqe_cmd(sqe);
+
+	fuse_uring_sqe_set_req_data(cmd, queue->qid, 0);
+	cmd->flags |= FUSE_IO_URING_REGISTER_FORGET_COMMIT;
 
 	return 0;
 


### PR DESCRIPTION
Enable testing against the kernel feature that optionally delivers FORGET over io-uring when userspace sets FUSE_IO_URING_REGISTER_FORGET_COMMIT on the REGISTER command.

Changes:
- include/fuse_kernel.h: Bump protocol minor to 7.46 and define FUSE_IO_URING_REGISTER_FORGET_COMMIT for fuse_uring_cmd_req.flags on REGISTER.
- lib/fuse_uring.c: Set that flag in fuse_uring_register_ent so the kernel submits FORGET requests on the io-uring ring.
- lib/fuse_lowlevel.c: For FORGET and BATCH_FORGET delivered via io-uring, complete with fuse_reply_err(0) without calling op.forget, to avoid real inode teardown during testing.

For testing the "Send FORGET over io_uring" kernel patch only; currently not intended for upstream merging.