### PR TITLE
libfuse: always send the subtype to the kernel when using fsconfig()

### DIFF
--- a/lib/mount_fsmount.c
+++ b/lib/mount_fsmount.c
@@ -359,6 +359,19 @@ int fuse_kern_fsmount(const char *mnt, unsigned long flags, int blkdev,
 		goto out_free;
 	}
 
+	/* Configure subtype */
+	if (subtype) {
+		res = fsconfig(fsfd, FSCONFIG_SET_STRING, "subtype",
+			       subtype, 0);
+		if (res) {
+			err = -errno;
+			log_fsconfig_kmsg(fsfd);
+			fprintf(stderr, "fuse: fsconfig subtype failed: %s\n",
+				strerror(-err));
+			goto out_free;
+		}
+	}
+
 	/* Configure source */
 	res = fsconfig(fsfd, FSCONFIG_SET_STRING, "source", source, 0);
 	if (res == -1) {


### PR DESCRIPTION
Although it's possible to supply a filesystem subtype when calling fsopen(), it does not pass the stuff after the dot to the mount option parsing mechanism like the legacy mount() call does.  Therefore, it's necessary to pass the subtype explicitly via fsconfig() or else the subtype will be missing from the /proc/mounts output.

For example, fuse4fs with the old mount API produces this:

/dev/sda /mnt fuse.ext4 rw,nosuid,nodev,relatime,user_id=0,group_id=0 0 0

But with the new mount API, we only get:

/dev/sda /mnt fuse rw,nosuid,nodev,relatime,user_id=0,group_id=0 0 0

...which breaks fstests, which requires the fsname to match the string that it passes to mount -t.  Update the comment in mount_service.c to match this requirement.

Fixes: 14cb7b93bb9688 ("Add support for the new linux mount API")