### PR TITLE
lib mount: rename mnt_opts param to mtab_opts

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -4603,7 +4603,7 @@ static int session_wait_sync_init_completion(struct fuse_session *se)
  */
 static int new_api_fusermount(struct fuse_session *se,
 			      const char *mountpoint,
-			      const char *mnt_opts,
+			      const char *mtab_opts,
 			      int *sock_fd, pid_t *fusermount_pid,
 			      bool *is_sync_init)
 {
@@ -4618,7 +4618,7 @@ static int new_api_fusermount(struct fuse_session *se,
 		fuse_log(FUSE_LOG_ERR, "fuse: sync init completion failed\n");
 
 	/* Call fusermount3 with --sync-init */
-	fd = mount_fusermount_obtain_fd(mountpoint, se->mo, mnt_opts, sock_fd,
+	fd = mount_fusermount_obtain_fd(mountpoint, se->mo, mtab_opts, sock_fd,
 					fusermount_pid);
 	if (fd < 0) {
 		fuse_log(FUSE_LOG_ERR,
@@ -4657,12 +4657,12 @@ static int fuse_session_mount_new_api(struct fuse_session *se,
 	int sock_fd = -1;
 	pid_t fusermount_pid = -1;
 	int res, err;
-	char *mnt_opts = NULL;
-	char *mnt_opts_with_fd = NULL;
+	char *mtab_opts = NULL;
+	char *mtab_opts_with_fd = NULL;
 	char fd_opt[32];
 	bool is_sync_init = false;
 
-	res = fuse_kern_mount_get_base_mnt_opts(se->mo, &mnt_opts);
+	res = fuse_kern_mount_get_base_mtab_opts(se->mo, &mtab_opts);
 	err = -EIO;
 	if (res == -1) {
 		fuse_log(FUSE_LOG_ERR,
@@ -4683,19 +4683,19 @@ static int fuse_session_mount_new_api(struct fuse_session *se,
 
 	snprintf(fd_opt, sizeof(fd_opt), "fd=%i", fd);
 	err = -ENOMEM;
-	if (fuse_opt_add_opt(&mnt_opts_with_fd, mnt_opts) == -1 ||
-	    fuse_opt_add_opt(&mnt_opts_with_fd, fd_opt) == -1) {
+	if (fuse_opt_add_opt(&mtab_opts_with_fd, mtab_opts) == -1 ||
+	    fuse_opt_add_opt(&mtab_opts_with_fd, fd_opt) == -1) {
 		goto err;
 	}
 
 	/* Try to mount directly */
-	err = fuse_kern_fsmount_mo(mountpoint, se->mo, mnt_opts_with_fd);
+	err = fuse_kern_fsmount_mo(mountpoint, se->mo, mtab_opts_with_fd);
 
 	/* If mount failed with EPERM, fall back to fusermount3 with sync-init */
 	if (err < 0 && errno == EPERM) {
 		close(fd);
 		se->fd = -1;
-		fd = new_api_fusermount(se, mountpoint, mnt_opts,
+		fd = new_api_fusermount(se, mountpoint, mtab_opts,
 					&sock_fd, &fusermount_pid,
 					&is_sync_init);
 		if (fd < 0) {
@@ -4730,8 +4730,8 @@ err:
 	if (session_wait_sync_init_completion(se) < 0)
 		fuse_log(FUSE_LOG_ERR, "fuse: sync init completion failed\n");
 
-	free(mnt_opts);
-	free(mnt_opts_with_fd);
+	free(mtab_opts);
+	free(mtab_opts_with_fd);
 	return fd;
 }
 #else

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -622,19 +622,20 @@ out_close:
  * Wrapper for fuse_kern_fsmount that accepts struct mount_opts
  * @mnt: mountpoint
  * @mo: mount options
- * @mnt_opts: mount options to pass to the kernel
+ * @mtab_opts: options recorded in /etc/mtab via fuse_mnt_add_mount_helper();
+ *             see fuse_kern_fsmount() for details
  *
  * Returns: 0 on success, -1 on failure with errno set
  */
 int fuse_kern_fsmount_mo(const char *mnt, const struct mount_opts *mo,
-			 const char *mnt_opts)
+			 const char *mtab_opts)
 {
 	/* codeql[cpp/path-injection] verification is in the function */
 	const char *devname = fuse_mnt_get_devname();
 
 	return fuse_kern_fsmount(mnt, mo->flags, mo->blkdev, mo->fsname,
 				 mo->subtype, devname, mo->kernel_opts,
-				 mnt_opts);
+				 mtab_opts);
 }
 #endif
 

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -643,13 +643,16 @@ int fuse_kern_fsmount_mo(const char *mnt, const struct mount_opts *mo,
  * Complete the mount operation with an already-opened fd
  * @mnt: mountpoint
  * @mo: mount options
- * @mnt_opts: mount options to pass to the kernel
+ * @mtab_opts: mtab/utab record string written via fuse_mnt_add_mount_helper().
+ *             Built by fuse_kern_mount_get_base_mtab_opts(); intentionally
+ *             overlaps with mo->kernel_opts so /etc/mtab reflects the options
+ *             the kernel saw.
  *
  * Returns: 0 on success, -1 on failure,
  *          FUSE_MOUNT_FALLBACK_NEEDED if fusermount should be used
  */
 int fuse_kern_do_mount(const char *mnt, struct mount_opts *mo,
-		       const char *mnt_opts)
+		       const char *mtab_opts)
 {
 	char *source = NULL;
 	char *type = NULL;
@@ -709,7 +712,7 @@ int fuse_kern_do_mount(const char *mnt, struct mount_opts *mo,
 		goto out_close;
 	}
 
-	res = fuse_mnt_add_mount_helper(mnt, source, type, mnt_opts);
+	res = fuse_mnt_add_mount_helper(mnt, source, type, mtab_opts);
 	if (res == -1)
 		goto out_umount;
 
@@ -727,7 +730,7 @@ out_close:
 }
 
 static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
-				  const char *mnt_opts)
+				  const char *mtab_opts)
 {
 	int fd;
 	int res;
@@ -736,7 +739,7 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
 	if (fd == -1)
 		return -1;
 
-	res = fuse_kern_do_mount(mnt, mo, mnt_opts);
+	res = fuse_kern_do_mount(mnt, mo, mtab_opts);
 	if (res) {
 		close(fd);
 		return res;
@@ -745,16 +748,20 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
 	return fd;
 }
 
-static int get_mnt_flag_opts(char **mnt_optsp, int flags)
+/*
+ * Append the flag-mirror prefix (rw/nosuid/nodev/...) of the mtab record
+ * to @mtab_optsp, derived from the MS_* bitmask in @flags.
+ */
+static int get_mtab_flag_opts(char **mtab_optsp, int flags)
 {
 	int i;
 
-	if (!(flags & MS_RDONLY) && fuse_opt_add_opt(mnt_optsp, "rw") == -1)
+	if (!(flags & MS_RDONLY) && fuse_opt_add_opt(mtab_optsp, "rw") == -1)
 		return -1;
 
 	for (i = 0; mount_flags[i].opt != NULL; i++) {
 		if (mount_flags[i].on && (flags & mount_flags[i].flag) &&
-		    fuse_opt_add_opt(mnt_optsp, mount_flags[i].opt) == -1)
+		    fuse_opt_add_opt(mtab_optsp, mount_flags[i].opt) == -1)
 			return -1;
 	}
 	return 0;
@@ -793,13 +800,21 @@ void destroy_mount_opts(struct mount_opts *mo)
 	free(mo);
 }
 
-int fuse_kern_mount_get_base_mnt_opts(const struct mount_opts *mo, char **mnt_optsp)
+/*
+ * Build the mtab/utab record string for this mount: flag-mirrors of MS_*
+ * (rw/nosuid/nodev/...) + the kernel-bound -o options + the mtab-only
+ * annotations. The result is what fuse_mnt_add_mount_helper() writes into
+ * /etc/mtab (or /run/mount/utab). The overlap with @mo->kernel_opts is
+ * intentional so the mtab line reflects what the kernel saw.
+ */
+int fuse_kern_mount_get_base_mtab_opts(const struct mount_opts *mo,
+				       char **mtab_optsp)
 {
-	if (get_mnt_flag_opts(mnt_optsp, mo->flags) == -1)
+	if (get_mtab_flag_opts(mtab_optsp, mo->flags) == -1)
 		return -1;
-	if (mo->kernel_opts && fuse_opt_add_opt(mnt_optsp, mo->kernel_opts) == -1)
+	if (mo->kernel_opts && fuse_opt_add_opt(mtab_optsp, mo->kernel_opts) == -1)
 		return -1;
-	if (mo->mtab_opts &&  fuse_opt_add_opt(mnt_optsp, mo->mtab_opts) == -1)
+	if (mo->mtab_opts &&  fuse_opt_add_opt(mtab_optsp, mo->mtab_opts) == -1)
 		return -1;
 	return 0;
 }
@@ -807,13 +822,13 @@ int fuse_kern_mount_get_base_mnt_opts(const struct mount_opts *mo, char **mnt_op
 int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo)
 {
 	int res = -1;
-	char *mnt_opts = NULL;
+	char *mtab_opts = NULL;
 
 	res = -1;
-	if (fuse_kern_mount_get_base_mnt_opts(mo, &mnt_opts) == -1)
+	if (fuse_kern_mount_get_base_mtab_opts(mo, &mtab_opts) == -1)
 		goto out;
 
-	res = fuse_mount_sys(mountpoint, mo, mnt_opts);
+	res = fuse_mount_sys(mountpoint, mo, mtab_opts);
 	if (res >= 0 && mo->auto_unmount) {
 		if(0 > setup_auto_unmount(mountpoint, 0)) {
 			// Something went wrong, let's umount like in fuse_mount_sys.
@@ -822,14 +837,14 @@ int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo)
 		}
 	} else if (res == FUSE_MOUNT_FALLBACK_NEEDED) {
 		if (mo->fusermount_opts &&
-		    fuse_opt_add_opt(&mnt_opts, mo->fusermount_opts) == -1)
+		    fuse_opt_add_opt(&mtab_opts, mo->fusermount_opts) == -1)
 			goto out;
 
 		if (mo->subtype) {
 			char *tmp_opts = NULL;
 
 			res = -1;
-			if (fuse_opt_add_opt(&tmp_opts, mnt_opts) == -1 ||
+			if (fuse_opt_add_opt(&tmp_opts, mtab_opts) == -1 ||
 			    fuse_opt_add_opt(&tmp_opts, mo->subtype_opt) == -1) {
 				free(tmp_opts);
 				goto out;
@@ -839,12 +854,12 @@ int fuse_kern_mount(const char *mountpoint, struct mount_opts *mo)
 			free(tmp_opts);
 			if (res == -1)
 				res = fuse_mount_fusermount(mountpoint, mo,
-							    mnt_opts, 0);
+							    mtab_opts, 0);
 		} else {
-			res = fuse_mount_fusermount(mountpoint, mo, mnt_opts, 0);
+			res = fuse_mount_fusermount(mountpoint, mo, mtab_opts, 0);
 		}
 	}
 out:
-	free(mnt_opts);
+	free(mtab_opts);
 	return res;
 }

--- a/lib/mount_fsmount.c
+++ b/lib/mount_fsmount.c
@@ -314,9 +314,9 @@ static int apply_mount_opts(int fsfd, const char *opts)
 		 * not fsconfig().
 		 *
 		 * These string options (nosuid, nodev, etc.) are reconstructed
-		 * from MS_* flags by get_mnt_flag_opts() in lib/mount.c and
-		 * get_mnt_opts() in util/fusermount.c. Both the library path
-		 * (via fuse_kern_mount_get_base_mnt_opts) and fusermount3 path
+		 * from MS_* flags by get_mtab_flag_opts() in lib/mount.c and
+		 * get_mtab_opts() in util/fusermount.c. Both the library path
+		 * (via fuse_kern_mount_get_base_mtab_opts) and fusermount3 path
 		 * rebuild these strings from the flags bitmask and pass them in
 		 * mtab_opts. They must be filtered here because they are mount
 		 * attributes (passed to fsmount via MOUNT_ATTR_*), not

--- a/lib/mount_fsmount.c
+++ b/lib/mount_fsmount.c
@@ -314,12 +314,11 @@ static int apply_mount_opts(int fsfd, const char *opts)
 		 * not fsconfig().
 		 *
 		 * These string options (nosuid, nodev, etc.) are reconstructed
-		 * Skip mtab-only options - they're for /run/mount/utab, not kernel
 		 * from MS_* flags by get_mnt_flag_opts() in lib/mount.c and
 		 * get_mnt_opts() in util/fusermount.c. Both the library path
 		 * (via fuse_kern_mount_get_base_mnt_opts) and fusermount3 path
 		 * rebuild these strings from the flags bitmask and pass them in
-		 * mnt_opts. They must be filtered here because they are mount
+		 * mtab_opts. They must be filtered here because they are mount
 		 * attributes (passed to fsmount via MOUNT_ATTR_*), not
 		 * filesystem parameters (which would be passed to fsconfig).
 		 *
@@ -343,7 +342,7 @@ static int apply_mount_opts(int fsfd, const char *opts)
 int fuse_kern_fsmount(const char *mnt, unsigned long flags, int blkdev,
 		      const char *fsname, const char *subtype,
 		      const char *source_dev, const char *kernel_opts,
-		      const char *mnt_opts)
+		      const char *mtab_opts)
 {
 	char *type = NULL;
 	char *source = NULL;
@@ -408,13 +407,13 @@ int fuse_kern_fsmount(const char *mnt, unsigned long flags, int blkdev,
 		goto out_free;
 	}
 
-	/* Apply additional mount options */
-	err = apply_mount_opts(fsfd, mnt_opts);
+	/* Apply mtab options (overlap with kernel_opts is filtered and tolerated) */
+	err = apply_mount_opts(fsfd, mtab_opts);
 	if (err < 0) {
 		log_fsconfig_kmsg(fsfd);
 		fprintf(stderr,
-			"fuse: failed to apply additional mount options '%s'\n",
-			mnt_opts);
+			"fuse: failed to apply mtab options '%s'\n",
+			mtab_opts);
 		goto out_free;
 	}
 
@@ -459,7 +458,7 @@ int fuse_kern_fsmount(const char *mnt, unsigned long flags, int blkdev,
 		goto out_close_mntfd;
 	}
 
-	err = fuse_mnt_add_mount_helper(mnt, source, type, mnt_opts);
+	err = fuse_mnt_add_mount_helper(mnt, source, type, mtab_opts);
 	if (err == -1)
 		goto out_umount;
 

--- a/lib/mount_i_linux.h
+++ b/lib/mount_i_linux.h
@@ -41,18 +41,22 @@ int fuse_kern_mount_get_base_mnt_opts(const struct mount_opts *mo, char **mnt_op
  * @fsname: filesystem name (or NULL)
  * @subtype: filesystem subtype (or NULL)
  * @source_dev: device name for building source string
- * @kernel_opts: kernel mount options string
- * @mnt_opts: additional mount options to pass to the kernel
+ * @kernel_opts: kernel mount options applied via fsconfig()
+ * @mtab_opts:  options recorded in /etc/mtab (or /run/mount/utab) via
+ *              fuse_mnt_add_mount_helper(). May overlap with @kernel_opts
+ *              because /etc/mtab is expected to display kernel-visible
+ *              options; the overlap is filtered before fsconfig where
+ *              needed and is idempotent at the kernel.
  *
  * Returns: 0 on success, -1 on failure with errno set
  */
 int fuse_kern_fsmount(const char *mnt, unsigned long flags, int blkdev,
 		      const char *fsname, const char *subtype,
 		      const char *source_dev, const char *kernel_opts,
-		      const char *mnt_opts);
+		      const char *mtab_opts);
 
 int fuse_kern_fsmount_mo(const char *mnt, const struct mount_opts *mo,
-			 const char *mnt_opts);
+			 const char *mtab_opts);
 int mount_fusermount_obtain_fd(const char *mountpoint,
 			       struct mount_opts *mo,
 			       const char *opts, int *sock_fd_out,

--- a/lib/mount_i_linux.h
+++ b/lib/mount_i_linux.h
@@ -31,7 +31,8 @@ struct mount_opts {
 
 int fuse_kern_mount_prepare(const char *mnt, struct mount_opts *mo);
 
-int fuse_kern_mount_get_base_mnt_opts(const struct mount_opts *mo, char **mnt_optsp);
+int fuse_kern_mount_get_base_mtab_opts(const struct mount_opts *mo,
+				       char **mtab_optsp);
 
 /**
  * Mount using the new Linux mount API (fsopen/fsconfig/fsmount/move_mount)

--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -478,7 +478,7 @@ int fuse_mnt_parse_fuse_fd(const char *mountpoint)
 }
 
 int fuse_mnt_add_mount_helper(const char *mnt, const char *source,
-			       const char *type, const char *mnt_opts)
+			       const char *type, const char *mtab_opts)
 {
 #ifndef IGNORE_MTAB
 	if (geteuid() == 0) {
@@ -489,7 +489,7 @@ int fuse_mnt_add_mount_helper(const char *mnt, const char *source,
 			return -1;
 
 		res = fuse_mnt_add_mount("fuse", source, newmnt, type,
-					 mnt_opts);
+					 mtab_opts);
 		free(newmnt);
 		return res;
 	}
@@ -497,7 +497,7 @@ int fuse_mnt_add_mount_helper(const char *mnt, const char *source,
 	(void)mnt;
 	(void)source;
 	(void)type;
-	(void)mnt_opts;
+	(void)mtab_opts;
 	return 0;
 }
 

--- a/lib/mount_util.h
+++ b/lib/mount_util.h
@@ -35,7 +35,7 @@ int fuse_mnt_parse_fuse_fd(const char *mountpoint);
 /* Helper functions for mount operations */
 const char *fuse_mnt_get_devname(void);
 int fuse_mnt_add_mount_helper(const char *mnt, const char *source,
-			       const char *type, const char *mnt_opts);
+			       const char *type, const char *mtab_opts);
 
 /* Build source and type strings for mounting */
 char *fuse_mnt_build_source(const char *fsname, const char *subtype,

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -810,34 +810,41 @@ static int add_option(char **optsp, const char *opt, unsigned expand)
 	return 0;
 }
 
-static int get_mnt_opts(int flags, const char *opts, char **mnt_optsp)
+/*
+ * Build the mtab/utab record string for this mount: flag-mirrors of MS_*
+ * (rw/nosuid/nodev/...) + the kernel-bound -o options + "user=<n>" when
+ * mounted by a non-root user. The result is what add_mount() writes into
+ * /etc/mtab (or /run/mount/utab). The overlap with @opts is intentional so
+ * the mtab line reflects what the kernel saw.
+ */
+static int get_mtab_opts(int flags, const char *opts, char **mtab_optsp)
 {
 	int i;
 	int l;
 
-	if (!(flags & MS_RDONLY) && add_option(mnt_optsp, "rw", 0) == -1)
+	if (!(flags & MS_RDONLY) && add_option(mtab_optsp, "rw", 0) == -1)
 		return -1;
 
 	for (i = 0; mount_flags[i].opt != NULL; i++) {
 		if (mount_flags[i].on && (flags & mount_flags[i].flag) &&
-		    add_option(mnt_optsp, mount_flags[i].opt, 0) == -1)
+		    add_option(mtab_optsp, mount_flags[i].opt, 0) == -1)
 			return -1;
 	}
 
-	if (add_option(mnt_optsp, opts, 0) == -1)
+	if (add_option(mtab_optsp, opts, 0) == -1)
 		return -1;
 	/* remove comma from end of opts*/
-	l = strlen(*mnt_optsp);
-	if ((*mnt_optsp)[l-1] == ',')
-		(*mnt_optsp)[l-1] = '\0';
+	l = strlen(*mtab_optsp);
+	if ((*mtab_optsp)[l-1] == ',')
+		(*mtab_optsp)[l-1] = '\0';
 	if (getuid() != 0) {
 		const char *user = get_user_name();
 		if (user == NULL)
 			return -1;
 
-		if (add_option(mnt_optsp, "user=", strlen(user)) == -1)
+		if (add_option(mtab_optsp, "user=", strlen(user)) == -1)
 			return -1;
-		strcat(*mnt_optsp, user);
+		strcat(*mtab_optsp, user);
 	}
 	return 0;
 }
@@ -909,7 +916,11 @@ struct mount_params {
 	/* Generated mount parameters */
 	char *source;           /* Mount source string */
 	char *type;             /* Filesystem type string */
-	char *mnt_opts;         /* Mount table options */
+
+	/* mtab/utab record content: MS_* flag mirrors + kernel-bound -o opts
+	 * + user=<n> (non-root)
+	 */
+	char *mtab_opts;
 
 	/* Pointer for optbuf manipulation */
 	char *optbuf_end;       /* Points to end of optbuf for sprintf */
@@ -922,7 +933,7 @@ static void free_mount_params(struct mount_params *mp)
 	free(mp->subtype);
 	free(mp->source);
 	free(mp->type);
-	free(mp->mnt_opts);
+	free(mp->mtab_opts);
 	memset(mp, 0, sizeof(*mp));
 }
 
@@ -1036,7 +1047,7 @@ static int prepare_mount(const char *opts, struct mount_params *mp)
 			s++;
 	}
 	*d = '\0';
-	res = get_mnt_opts(mp->flags, mp->optbuf, &mp->mnt_opts);
+	res = get_mtab_opts(mp->flags, mp->optbuf, &mp->mtab_opts);
 	if (res == -1)
 		goto err;
 
@@ -1103,7 +1114,7 @@ static int perform_mount(const char *mnt, struct mount_params *mp)
 
 static int do_mount(const char *mnt, const char **typep, mode_t rootmode,
 		    int fd, const char *opts, const char *dev, char **sourcep,
-		    char **mnt_optsp)
+		    char **mtab_optsp)
 {
 	struct mount_params mp = { .fd = fd }; /* implicit zero of other params */
 	int res;
@@ -1123,7 +1134,7 @@ static int do_mount(const char *mnt, const char **typep, mode_t rootmode,
 
 	*sourcep = mp.source;
 	*typep = mp.type;
-	*mnt_optsp = mp.mnt_opts;
+	*mtab_optsp = mp.mtab_opts;
 
 	/* Free only the intermediate allocations, not the returned ones */
 	free(mp.fsname);
@@ -1308,9 +1319,9 @@ struct mount_context {
 	const char *dev;
 	struct stat stbuf;
 	char *source;
-	char *mnt_opts;
+	char *mtab_opts;     /* mtab/utab record string for add_mount() */
 	char *x_opts;
-	char *kern_mnt_opts; /* mnt_opts with removed x_opts */
+	char *kern_mnt_opts; /* user-provided -o opts with x-* removed */
 };
 
 /*
@@ -1384,7 +1395,7 @@ static int mount_fuse_finish_fsmount(const char *mnt,
 		.rootmode = ctx->stbuf.st_mode & S_IFMT,
 		.dev = ctx->dev,
 	};
-	char *final_mnt_opts = NULL;
+	char *final_mtab_opts = NULL;
 
 	res = prepare_mount(ctx->kern_mnt_opts, &mp);
 	if (res == -1)
@@ -1394,27 +1405,27 @@ static int mount_fuse_finish_fsmount(const char *mnt,
 	 * Merge x-options if running as root, root is allowed to update
 	 * /etc/mtab or /run/mount/utab
 	 */
-	final_mnt_opts = mp.mnt_opts;
+	final_mtab_opts = mp.mtab_opts;
 	if (geteuid() == 0 && ctx->x_opts && strlen(ctx->x_opts) > 0) {
-		char *x_mnt_opts = NULL;
+		char *x_mtab_opts = NULL;
 		int ret;
 
-		if (strlen(mp.mnt_opts) > 0)
-			ret = asprintf(&x_mnt_opts, "%s,%s",
-				       mp.mnt_opts, ctx->x_opts);
+		if (strlen(mp.mtab_opts) > 0)
+			ret = asprintf(&x_mtab_opts, "%s,%s",
+				       mp.mtab_opts, ctx->x_opts);
 		else
-			ret = asprintf(&x_mnt_opts, "%s", ctx->x_opts);
+			ret = asprintf(&x_mtab_opts, "%s", ctx->x_opts);
 
 		if (ret < 0)
 			goto fail_free_params;
 
-		final_mnt_opts = x_mnt_opts;
+		final_mtab_opts = x_mtab_opts;
 	}
 
 	/* Use new mount API */
 	res = fuse_kern_fsmount(mnt, mp.flags, mp.blkdev,
 				mp.fsname, mp.subtype, ctx->dev,
-				mp.optbuf, final_mnt_opts);
+				mp.optbuf, final_mtab_opts);
 	if (res == -1)
 		goto fail_free_merged;
 
@@ -1427,7 +1438,7 @@ static int mount_fuse_finish_fsmount(const char *mnt,
 
 	/* Store results in context */
 	ctx->source = mp.source;
-	ctx->mnt_opts = final_mnt_opts;
+	ctx->mtab_opts = final_mtab_opts;
 	*type = mp.type;
 
 	res = 0;
@@ -1436,15 +1447,15 @@ static int mount_fuse_finish_fsmount(const char *mnt,
 	free(mp.fsname);
 	free(mp.subtype);
 	free(mp.optbuf);
-	if (final_mnt_opts != mp.mnt_opts)
-		free(mp.mnt_opts);
+	if (final_mtab_opts != mp.mtab_opts)
+		free(mp.mtab_opts);
 
 out:
 	return res;
 
 fail_free_merged:
-	if (final_mnt_opts != mp.mnt_opts)
-		free(final_mnt_opts);
+	if (final_mtab_opts != mp.mtab_opts)
+		free(final_mtab_opts);
 fail_free_params:
 	free_mount_params(&mp);
 fail:
@@ -1461,7 +1472,7 @@ static int mount_fuse(const char *mnt, const char *opts, const char **type)
 	const char *dev = fuse_mnt_get_devname();
 	struct stat stbuf;
 	char *source = NULL;
-	char *mnt_opts = NULL;
+	char *mtab_opts = NULL;
 	const char *real_mnt = mnt;
 	int mountpoint_fd = -1;
 	char *do_mount_opts = NULL;
@@ -1491,7 +1502,7 @@ static int mount_fuse(const char *mnt, const char *opts, const char **type)
 	restore_privs();
 	if (res != -1)
 		res = do_mount(real_mnt, type, stbuf.st_mode & S_IFMT,
-			       fd, do_mount_opts, dev, &source, &mnt_opts);
+			       fd, do_mount_opts, dev, &source, &mtab_opts);
 
 	if (mountpoint_fd != -1)
 		close(mountpoint_fd);
@@ -1511,24 +1522,24 @@ static int mount_fuse(const char *mnt, const char *opts, const char **type)
 			 * Add back the options starting with "x-" to opts from
 			 * do_mount. +2 for ',' and '\0'
 			 */
-			size_t mnt_opts_len = strlen(mnt_opts);
-			size_t x_mnt_opts_len =  mnt_opts_len+
+			size_t mtab_opts_len = strlen(mtab_opts);
+			size_t x_mtab_opts_len = mtab_opts_len +
 						 strlen(x_prefixed_opts) + 2;
-			char *x_mnt_opts = calloc(1, x_mnt_opts_len);
+			char *x_mtab_opts = calloc(1, x_mtab_opts_len);
 
-			if (mnt_opts_len) {
-				strcpy(x_mnt_opts, mnt_opts);
-				strncat(x_mnt_opts, ",", 2);
+			if (mtab_opts_len) {
+				strcpy(x_mtab_opts, mtab_opts);
+				strncat(x_mtab_opts, ",", 2);
 			}
 
-			strncat(x_mnt_opts, x_prefixed_opts,
-				x_mnt_opts_len - mnt_opts_len - 2);
+			strncat(x_mtab_opts, x_prefixed_opts,
+				x_mtab_opts_len - mtab_opts_len - 2);
 
-			free(mnt_opts);
-			mnt_opts = x_mnt_opts;
+			free(mtab_opts);
+			mtab_opts = x_mtab_opts;
 		}
 
-		res = add_mount(source, mnt, *type, mnt_opts);
+		res = add_mount(source, mnt, *type, mtab_opts);
 		if (res == -1) {
 			/* Can't clean up mount in a non-racy way */
 			goto fail_close_fd;
@@ -1537,7 +1548,7 @@ static int mount_fuse(const char *mnt, const char *opts, const char **type)
 
 out_free:
 	free(source);
-	free(mnt_opts);
+	free(mtab_opts);
 	free(x_prefixed_opts);
 	free(do_mount_opts);
 
@@ -1596,7 +1607,7 @@ static int mount_fuse_sync_init(const char *mnt, const char *opts,
 out:
 	close(fd);
 	free(ctx.source);
-	free(ctx.mnt_opts);
+	free(ctx.mtab_opts);
 	free(ctx.x_opts);
 	free(ctx.kern_mnt_opts);
 


### PR DESCRIPTION
mnt_opts was rather confusing, mtab_opts is easier to read. Also add more comments about the possible dup of options with 'kernel_opts'.