### PR TITLE
Fix a codeql report in add_default_subtype()

### DIFF
--- a/lib/helper.c
+++ b/lib/helper.c
@@ -180,8 +180,7 @@ static int fuse_helper_opt_proc(void *data, const char *arg, int key,
    function actually sets the fsname */
 static int add_default_subtype(const char *progname, struct fuse_args *args)
 {
-	int res;
-	char *subtype_opt;
+	char subtype_opt[PATH_MAX];
 
 	const char *basename = strrchr(progname, '/');
 	if (basename == NULL)
@@ -189,19 +188,12 @@ static int add_default_subtype(const char *progname, struct fuse_args *args)
 	else if (basename[1] != '\0')
 		basename++;
 
-	subtype_opt = (char *) malloc(strlen(basename) + 64);
-	if (subtype_opt == NULL) {
-		fuse_log(FUSE_LOG_ERR, "fuse: memory allocation failed\n");
-		return -1;
-	}
 #ifdef __FreeBSD__
-	sprintf(subtype_opt, "-ofsname=%s", basename);
+	snprintf(subtype_opt, sizeof(subtype_opt), "-ofsname=%s", basename);
 #else
-	sprintf(subtype_opt, "-osubtype=%s", basename);
+	snprintf(subtype_opt, sizeof(subtype_opt), "-osubtype=%s", basename);
 #endif
-	res = fuse_opt_add_arg(args, subtype_opt);
-	free(subtype_opt);
-	return res;
+	return fuse_opt_add_arg(args, subtype_opt);
 }
 
 int fuse_parse_cmdline_312(struct fuse_args *args,


### PR DESCRIPTION
Came up on the container branch and not sure why it triggers there only, but malloc is not needed and snprintf should check for the max size.