### PR TITLE
fuse: add submount capability and lowlevel attr_flags

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -518,6 +518,17 @@ struct fuse_loop_config_v1 {
 #define FUSE_CAP_ALLOW_IDMAP (1ULL << 32)
 
 /**
+ * Indicates that the kernel supports creating submounts
+ *
+ * When this feature is enabled. If `fuse_lookup()` returns a directory
+ * and `FUSE_LL_ATTR_SUBMOUNT` is set in `fuse_entry_param::attr_flags`,
+ * fuse kernel module will create a virtual submount with distinct std_dev.
+ *
+ * This feature is disabled by default.
+ */
+#define FUSE_CAP_SUBMOUNTS (1UL << 33)
+
+/**
  * Ioctl flags
  *
  * FUSE_IOCTL_COMPAT: 32bit compat ioctl on 64bit machine

--- a/include/fuse_lowlevel.h
+++ b/include/fuse_lowlevel.h
@@ -102,6 +102,18 @@ struct fuse_entry_param {
 	    that come through the kernel, this should be set to a very
 	    large value. */
 	double entry_timeout;
+
+	/** Entry attribute flags. See enum fuse_attr_flags below. */
+	uint32_t attr_flags;
+};
+
+/**
+ * Inode attribute flags
+ *
+ * FUSE_LL_ATTR_SUBMOUNT: Inode is a submount root
+ */
+enum fuse_attr_flags {
+	FUSE_LL_ATTR_SUBMOUNT = (1 << 0),
 };
 
 /**

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -465,8 +465,19 @@ static unsigned int calc_timeout_nsec(double t)
 		return (unsigned int) (f * 1.0e9);
 }
 
+static inline bool fuse_entry_param_has_attr_flags(struct fuse_session *se)
+{
+	const struct libfuse_version *v = &se->version;
+	if ((v->major > 3) || (v->major == 3 && v->minor >= 20)) {
+		/* if any enabled capability uses attr_flags, return true */
+		if (se->conn.want_ext & FUSE_CAP_SUBMOUNTS)
+			return true;
+	}
+	return false;
+}
+
 static void fill_entry(struct fuse_entry_out *arg,
-		       const struct fuse_entry_param *e)
+		       const struct fuse_entry_param *e, bool has_attr_flags)
 {
 	arg->nodeid = e->ino;
 	arg->generation = e->generation;
@@ -475,6 +486,9 @@ static void fill_entry(struct fuse_entry_out *arg,
 	arg->attr_valid = calc_timeout_sec(e->attr_timeout);
 	arg->attr_valid_nsec = calc_timeout_nsec(e->attr_timeout);
 	convert_stat(&e->attr, &arg->attr);
+
+	if (has_attr_flags && (e->attr_flags & FUSE_LL_ATTR_SUBMOUNT))
+		arg->attr.flags |= FUSE_ATTR_SUBMOUNT;
 }
 
 /* `buf` is allowed to be empty so that the proper size may be
@@ -483,7 +497,6 @@ size_t fuse_add_direntry_plus(fuse_req_t req, char *buf, size_t bufsize,
 			      const char *name,
 			      const struct fuse_entry_param *e, off_t off)
 {
-	(void)req;
 	size_t namelen;
 	size_t entlen;
 	size_t entlen_padded;
@@ -496,7 +509,7 @@ size_t fuse_add_direntry_plus(fuse_req_t req, char *buf, size_t bufsize,
 
 	struct fuse_direntplus *dp = (struct fuse_direntplus *) buf;
 	memset(&dp->entry_out, 0, sizeof(dp->entry_out));
-	fill_entry(&dp->entry_out, e);
+	fill_entry(&dp->entry_out, e, fuse_entry_param_has_attr_flags(req->se));
 
 	struct fuse_dirent *dirent = &dp->dirent;
 	dirent->ino = e->attr.st_ino;
@@ -543,7 +556,7 @@ int fuse_reply_entry(fuse_req_t req, const struct fuse_entry_param *e)
 		return fuse_reply_err(req, ENOENT);
 
 	memset(&arg, 0, sizeof(arg));
-	fill_entry(&arg, e);
+	fill_entry(&arg, e, fuse_entry_param_has_attr_flags(req->se));
 	return send_reply_ok(req, &arg, size);
 }
 
@@ -557,7 +570,7 @@ int fuse_reply_create(fuse_req_t req, const struct fuse_entry_param *e,
 	struct fuse_open_out *oarg = (struct fuse_open_out *) (buf + entrysize);
 
 	memset(buf, 0, sizeof(buf));
-	fill_entry(earg, e);
+	fill_entry(earg, e, fuse_entry_param_has_attr_flags(req->se));
 	fill_open(oarg, f);
 	return send_reply_ok(req, buf,
 			     entrysize + sizeof(struct fuse_open_out));
@@ -2788,6 +2801,8 @@ _do_init(fuse_req_t req, const fuse_ino_t nodeid, const void *op_in,
 		}
 		if (inargflags & FUSE_DIRECT_IO_ALLOW_MMAP)
 			se->conn.capable_ext |= FUSE_CAP_DIRECT_IO_ALLOW_MMAP;
+		if (inargflags & FUSE_SUBMOUNTS)
+			se->conn.capable_ext |= FUSE_CAP_SUBMOUNTS;
 		if (arg->minor >= 38 || (inargflags & FUSE_HAS_EXPIRE_ONLY))
 			se->conn.capable_ext |= FUSE_CAP_EXPIRE_ONLY;
 		if (inargflags & FUSE_PASSTHROUGH)
@@ -2938,6 +2953,8 @@ _do_init(fuse_req_t req, const fuse_ino_t nodeid, const void *op_in,
 		outargflags |= FUSE_CACHE_SYMLINKS;
 	if (se->conn.want_ext & FUSE_CAP_EXPLICIT_INVAL_DATA)
 		outargflags |= FUSE_EXPLICIT_INVAL_DATA;
+	if (se->conn.want_ext & FUSE_CAP_SUBMOUNTS)
+		outargflags |= FUSE_SUBMOUNTS;
 	if (se->conn.want_ext & FUSE_CAP_SETXATTR_EXT)
 		outargflags |= FUSE_SETXATTR_EXT;
 	if (se->conn.want_ext & FUSE_CAP_DIRECT_IO_ALLOW_MMAP)


### PR DESCRIPTION
Add submount capability negotiation and lowlevel entry attr_flags so filesystems can mark lookup/create results as submounts.

- add FUSE_CAP_SUBMOUNTS in fuse_common.h and wire it into init capability negotiation
- add attr_flags to struct fuse_entry_param
- add FUSE_LL_ATTR_SUBMOUNT in fuse_lowlevel.h
- map FUSE_LL_ATTR_SUBMOUNT to FUSE_ATTR_SUBMOUNT in entry reply paths

To avoid breaking older callers that were built without attr_flags in struct fuse_entry_param, libfuse only reads e->attr_flags when the session reports a caller libfuse version >= 3.20 and the submount capability is enabled. Older callers therefore continue on the legacy path and never access the new field.