### PR TITLE
fix typo in comments; FUSE_LOOP_MT_DEF_IDLE_THREADS is -1, not 10

### DIFF
--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -190,7 +190,7 @@ struct fuse_loop_config
 	/**
 	 * The maximum number of available worker threads before they
 	 * start to get deleted when they become idle. If not
-	 * specified, the default is 10.
+	 * specified, the default is -1.
 	 *
 	 * Adjusting this has performance implications; a very small number
 	 * of threads in the pool will cause a lot of thread creation and


### PR DESCRIPTION
Fixes a small typo