### PR TITLE
Add newer ioctl prototype for CUSE too

### DIFF
--- a/.github/workflows/abidiff_suppressions.abignore
+++ b/.github/workflows/abidiff_suppressions.abignore
@@ -35,6 +35,21 @@ name = fuse_lowlevel_ops
 has_data_member_inserted_at = end
 has_size_change = yes
 
+[suppress_type]
+# cuse_lowlevel_ops gained the op_size safe-copy (clop_size) in cuse_prep_data();
+# appended members are ABI-safe, same pattern as fuse_operations / fuse_lowlevel_ops.
+name = cuse_lowlevel_ops
+has_data_member_inserted_at = end
+has_size_change = yes
+
+[suppress_type]
+# ioctl 'cmd' widened int -> unsigned int at FUSE_USE_VERSION >= 319 (mirrors
+# fuse_lowlevel_ops.ioctl, widened at v35). Same size and calling convention, so
+# layout-preserving. libabigail cannot scope a type suppression to one
+# function-pointer member, so this stays bounded to size-preserving changes.
+name = cuse_lowlevel_ops
+has_size_change = no
+
 [suppress_function]
 # Suppress const qualification changes to fuse_get_session parameter
 # Adding const to pointer parameters is ABI-compatible (compile-time only)

--- a/example/cuse.c
+++ b/example/cuse.c
@@ -31,7 +31,7 @@
  */
 
 
-#define FUSE_USE_VERSION 31
+#define FUSE_USE_VERSION 319
 
 #include <cuse_lowlevel.h>
 #include <fuse_opt.h>
@@ -202,7 +202,7 @@ static void fioc_do_rw(fuse_req_t req, void *addr, const void *in_buf,
 	}
 }
 
-static void cusexmp_ioctl(fuse_req_t req, int cmd, void *arg,
+static void cusexmp_ioctl(fuse_req_t req, unsigned int cmd, void *arg,
 			  struct fuse_file_info *fi, unsigned flags,
 			  const void *in_buf, size_t in_bufsz, size_t out_bufsz)
 {

--- a/include/cuse_lowlevel.h
+++ b/include/cuse_lowlevel.h
@@ -12,8 +12,17 @@
 #ifndef CUSE_LOWLEVEL_H_
 #define CUSE_LOWLEVEL_H_
 
+/** @file
+ *
+ * Low level API
+ *
+ * IMPORTANT: you should define FUSE_USE_VERSION before including this
+ * header.  To use the newest API define it to 319 (recommended for any
+ * new application).
+ */
+
 #ifndef FUSE_USE_VERSION
-#define FUSE_USE_VERSION 29
+#define FUSE_USE_VERSION 30
 #endif
 
 #include "fuse_lowlevel.h"
@@ -58,9 +67,15 @@ struct cuse_lowlevel_ops {
 	void (*flush) (fuse_req_t req, struct fuse_file_info *fi);
 	void (*release) (fuse_req_t req, struct fuse_file_info *fi);
 	void (*fsync) (fuse_req_t req, int datasync, struct fuse_file_info *fi);
-	void (*ioctl) (fuse_req_t req, int cmd, void *arg,
-		       struct fuse_file_info *fi, unsigned int flags,
+#if FUSE_USE_VERSION < 319
+	void (*ioctl)(fuse_req_t req, int cmd,
+		       void *arg, struct fuse_file_info *fi, unsigned int flags,
 		       const void *in_buf, size_t in_bufsz, size_t out_bufsz);
+#else
+	void (*ioctl)(fuse_req_t req, unsigned int cmd,
+		       void *arg, struct fuse_file_info *fi, unsigned int flags,
+		       const void *in_buf, size_t in_bufsz, size_t out_bufsz);
+#endif
 	void (*poll) (fuse_req_t req, struct fuse_file_info *fi,
 		      struct fuse_pollhandle *ph);
 };

--- a/include/cuse_lowlevel.h
+++ b/include/cuse_lowlevel.h
@@ -65,20 +65,83 @@ struct cuse_lowlevel_ops {
 		      struct fuse_pollhandle *ph);
 };
 
-struct fuse_session *cuse_lowlevel_new(struct fuse_args *args,
-				       const struct cuse_info *ci,
-				       const struct cuse_lowlevel_ops *clop,
-				       void *userdata);
+/* Do not call directly, use cuse_lowlevel_new() */
+struct fuse_session *
+cuse_lowlevel_new_319(struct fuse_args *args, const struct cuse_info *ci,
+		      const struct cuse_lowlevel_ops *clop, size_t clop_size,
+		      const struct libfuse_version *version, void *userdata);
 
-struct fuse_session *cuse_lowlevel_setup(int argc, char *argv[],
-					 const struct cuse_info *ci,
-					 const struct cuse_lowlevel_ops *clop,
-					 int *multithreaded, void *userdata);
+static inline struct fuse_session *
+cuse_lowlevel_new_fn(struct fuse_args *args, const struct cuse_info *ci,
+		     const struct cuse_lowlevel_ops *clop, void *userdata)
+{
+	struct libfuse_version version = {
+		.major = FUSE_MAJOR_VERSION,
+		.minor = FUSE_MINOR_VERSION,
+		.hotfix = FUSE_HOTFIX_VERSION,
+		.padding = 0
+	};
+
+	return cuse_lowlevel_new_319(args, ci, clop,
+				     sizeof(struct cuse_lowlevel_ops), &version,
+				     userdata);
+}
+#define cuse_lowlevel_new(args, ci, clop, userdata) \
+	cuse_lowlevel_new_fn(args, ci, clop, userdata)
+
+/* Do not call directly, use cuse_lowlevel_setup() */
+struct fuse_session *
+cuse_lowlevel_setup_319(int argc, char *argv[], const struct cuse_info *ci,
+			const struct cuse_lowlevel_ops *clop, size_t clop_size,
+			const struct libfuse_version *version,
+			int *multithreaded, void *userdata);
+
+static inline struct fuse_session *
+cuse_lowlevel_setup_fn(int argc, char *argv[], const struct cuse_info *ci,
+		       const struct cuse_lowlevel_ops *clop, int *multithreaded,
+		       void *userdata)
+{
+	struct libfuse_version version = {
+		.major = FUSE_MAJOR_VERSION,
+		.minor = FUSE_MINOR_VERSION,
+		.hotfix = FUSE_HOTFIX_VERSION,
+		.padding = 0
+	};
+
+	return cuse_lowlevel_setup_319(argc, argv, ci, clop,
+				       sizeof(struct cuse_lowlevel_ops),
+				       &version, multithreaded, userdata);
+}
+#define cuse_lowlevel_setup(argc, argv, ci, clop, multithreaded, userdata) \
+	cuse_lowlevel_setup_fn(argc, argv, ci, clop, multithreaded, userdata)
 
 void cuse_lowlevel_teardown(struct fuse_session *se);
 
-int cuse_lowlevel_main(int argc, char *argv[], const struct cuse_info *ci,
-		       const struct cuse_lowlevel_ops *clop, void *userdata);
+/* Do not call directly, use cuse_lowlevel_main() */
+int cuse_lowlevel_main_319(int argc, char *argv[], const struct cuse_info *ci,
+			   const struct cuse_lowlevel_ops *clop,
+			   size_t clop_size,
+			   const struct libfuse_version *version,
+			   void *userdata);
+
+static inline int cuse_lowlevel_main_fn(int argc, char *argv[],
+					const struct cuse_info *ci,
+					const struct cuse_lowlevel_ops *clop,
+					void *userdata)
+{
+	struct libfuse_version version = {
+		.major = FUSE_MAJOR_VERSION,
+		.minor = FUSE_MINOR_VERSION,
+		.hotfix = FUSE_HOTFIX_VERSION,
+		.padding = 0
+	};
+
+	return cuse_lowlevel_main_319(argc, argv, ci, clop,
+				      sizeof(struct cuse_lowlevel_ops),
+				      &version, userdata);
+}
+#define cuse_lowlevel_main(argc, argv, ci, clop, userdata) \
+	cuse_lowlevel_main_fn(argc, argv, ci, clop, userdata)
 
 #ifdef __cplusplus
 }

--- a/lib/cuse_lowlevel.c
+++ b/lib/cuse_lowlevel.c
@@ -113,7 +113,8 @@ static size_t cuse_pack_info(int argc, const char **argv, char *buf)
 }
 
 static struct cuse_data *cuse_prep_data(const struct cuse_info *ci,
-					const struct cuse_lowlevel_ops *clop)
+					const struct cuse_lowlevel_ops *clop,
+					size_t clop_size)
 {
 	struct cuse_data *cd;
 	size_t dev_info_len;
@@ -133,7 +134,13 @@ static struct cuse_data *cuse_prep_data(const struct cuse_info *ci,
 		return NULL;
 	}
 
-	memcpy(&cd->clop, clop, sizeof(cd->clop));
+	/*
+	 * Copy only min(caller, library) ops; cd is calloc'd so trailing ops
+	 * stay NULL and a newer library never reads past an older caller.
+	 */
+	if (clop_size > sizeof(cd->clop))
+		clop_size = sizeof(cd->clop);
+	memcpy(&cd->clop, clop, clop_size);
 	cd->max_read = 131072;
 	cd->dev_major = ci->dev_major;
 	cd->dev_minor = ci->dev_minor;
@@ -144,16 +151,16 @@ static struct cuse_data *cuse_prep_data(const struct cuse_info *ci,
 	return cd;
 }
 
-struct fuse_session *cuse_lowlevel_new(struct fuse_args *args,
-				       const struct cuse_info *ci,
-				       const struct cuse_lowlevel_ops *clop,
-				       void *userdata)
+struct fuse_session *
+cuse_lowlevel_new_319(struct fuse_args *args, const struct cuse_info *ci,
+		      const struct cuse_lowlevel_ops *clop, size_t clop_size,
+		      const struct libfuse_version *version, void *userdata)
 {
 	struct fuse_lowlevel_ops lop;
 	struct cuse_data *cd;
 	struct fuse_session *se;
 
-	cd = cuse_prep_data(ci, clop);
+	cd = cuse_prep_data(ci, clop, clop_size);
 	if (!cd)
 		return NULL;
 
@@ -169,7 +176,8 @@ struct fuse_session *cuse_lowlevel_new(struct fuse_args *args,
 	lop.ioctl	= clop->ioctl		? cuse_fll_ioctl	: NULL;
 	lop.poll	= clop->poll		? cuse_fll_poll		: NULL;
 
-	se = fuse_session_new(args, &lop, sizeof(lop), userdata);
+	se = fuse_session_new_versioned(args, &lop, sizeof(lop), version,
+					userdata);
 	if (!se) {
 		free(cd);
 		return NULL;
@@ -270,10 +278,11 @@ void cuse_lowlevel_init(fuse_req_t req, fuse_ino_t nodeid, const void *inarg)
 	_cuse_lowlevel_init(req, nodeid, inarg, NULL);
 }
 
-struct fuse_session *cuse_lowlevel_setup(int argc, char *argv[],
-					 const struct cuse_info *ci,
-					 const struct cuse_lowlevel_ops *clop,
-					 int *multithreaded, void *userdata)
+struct fuse_session *
+cuse_lowlevel_setup_319(int argc, char *argv[], const struct cuse_info *ci,
+			const struct cuse_lowlevel_ops *clop, size_t clop_size,
+			const struct libfuse_version *version,
+			int *multithreaded, void *userdata)
 {
 	const char *devname = "/dev/cuse";
 	static const struct fuse_opt kill_subtype_opts[] = {
@@ -305,7 +314,8 @@ struct fuse_session *cuse_lowlevel_setup(int argc, char *argv[],
 			close(fd);
 	} while (fd >= 0 && fd <= 2);
 
-	se = cuse_lowlevel_new(&args, ci, clop, userdata);
+	se = cuse_lowlevel_new_319(&args, ci, clop, clop_size, version,
+				   userdata);
 	if (se == NULL)
 		goto out1;
 
@@ -347,15 +357,18 @@ void cuse_lowlevel_teardown(struct fuse_session *se)
 	fuse_session_destroy(se);
 }
 
-int cuse_lowlevel_main(int argc, char *argv[], const struct cuse_info *ci,
-		       const struct cuse_lowlevel_ops *clop, void *userdata)
+int cuse_lowlevel_main_319(int argc, char *argv[], const struct cuse_info *ci,
+			   const struct cuse_lowlevel_ops *clop,
+			   size_t clop_size,
+			   const struct libfuse_version *version,
+			   void *userdata)
 {
 	struct fuse_session *se;
 	int multithreaded;
 	int res;
 
-	se = cuse_lowlevel_setup(argc, argv, ci, clop, &multithreaded,
-				 userdata);
+	se = cuse_lowlevel_setup_319(argc, argv, ci, clop, clop_size, version,
+				     &multithreaded, userdata);
 	if (se == NULL)
 		return 1;
 
@@ -372,4 +385,67 @@ int cuse_lowlevel_main(int argc, char *argv[], const struct cuse_info *ci,
 		return 1;
 
 	return 0;
+}
+
+/*
+ * FUSE_3.0 ABI compat: applications built before clop_size/version were added
+ * link these bare names with no size argument. Forward the clop size frozen at
+ * the 3.0 layout so a newer library never reads past an old caller's clop, and
+ * an unknown version.
+ */
+#undef cuse_lowlevel_new
+#undef cuse_lowlevel_setup
+#undef cuse_lowlevel_main
+
+/*
+ * Size of cuse_lowlevel_ops at the FUSE_3.0 ABI. 'poll' is the last 3.0 field;
+ * a field appended after it leaves this unchanged, so the bare symbols below
+ * keep forwarding the original size rather than the library's current one.
+ */
+#define CUSE_LOWLEVEL_OPS_SIZE_30 \
+	(offsetof(struct cuse_lowlevel_ops, poll) + \
+	 sizeof(((const struct cuse_lowlevel_ops *)0)->poll))
+
+struct fuse_session *cuse_lowlevel_new(struct fuse_args *args,
+				       const struct cuse_info *ci,
+				       const struct cuse_lowlevel_ops *clop,
+				       void *userdata);
+struct fuse_session *cuse_lowlevel_new(struct fuse_args *args,
+				       const struct cuse_info *ci,
+				       const struct cuse_lowlevel_ops *clop,
+				       void *userdata)
+{
+	struct libfuse_version version = { 0 };
+
+	return cuse_lowlevel_new_319(args, ci, clop,
+				     CUSE_LOWLEVEL_OPS_SIZE_30, &version,
+				     userdata);
+}
+
+struct fuse_session *cuse_lowlevel_setup(int argc, char *argv[],
+					 const struct cuse_info *ci,
+					 const struct cuse_lowlevel_ops *clop,
+					 int *multithreaded, void *userdata);
+struct fuse_session *cuse_lowlevel_setup(int argc, char *argv[],
+					 const struct cuse_info *ci,
+					 const struct cuse_lowlevel_ops *clop,
+					 int *multithreaded, void *userdata)
+{
+	struct libfuse_version version = { 0 };
+
+	return cuse_lowlevel_setup_319(argc, argv, ci, clop,
+				       CUSE_LOWLEVEL_OPS_SIZE_30,
+				       &version, multithreaded, userdata);
+}
+
+int cuse_lowlevel_main(int argc, char *argv[], const struct cuse_info *ci,
+		       const struct cuse_lowlevel_ops *clop, void *userdata);
+int cuse_lowlevel_main(int argc, char *argv[], const struct cuse_info *ci,
+		       const struct cuse_lowlevel_ops *clop, void *userdata)
+{
+	struct libfuse_version version = { 0 };
+
+	return cuse_lowlevel_main_319(argc, argv, ci, clop,
+				      CUSE_LOWLEVEL_OPS_SIZE_30,
+				      &version, userdata);
 }

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -253,6 +253,10 @@ FUSE_3.19 {
 		fuse_req_secctx_count;
 		fuse_req_secctx_reset;
 		fuse_req_secctx_next;
+
+		cuse_lowlevel_new_319;
+		cuse_lowlevel_setup_319;
+		cuse_lowlevel_main_319;
 } FUSE_3.18;
 
 # Local Variables:

--- a/lib/util.c
+++ b/lib/util.c
@@ -11,7 +11,7 @@
 #include <errno.h>
 
 #ifndef FUSE_USE_VERSION
-#define FUSE_USE_VERSION (FUSE_MAKE_VERSION(3, 18))
+#define FUSE_USE_VERSION (FUSE_MAKE_VERSION(3, 19))
 #endif
 
 #include "util.h"


### PR DESCRIPTION
Mirror the fuse-side change commit abdd45f83cea
("Make ioctl prototype conditional on FUSE_USE_VERSION. (#482)")' for cuse too.

Crank versions to 3.19 as this is an ABI change.

Closes: https://github.com/libfuse/libfuse/issues/1406