### PR TITLE
fuse_uring: continue submission on a failing commit SQE

### DIFF
--- a/lib/fuse_uring.c
+++ b/lib/fuse_uring.c
@@ -352,6 +352,11 @@ static int fuse_queue_setup_io_uring(struct io_uring *ring, size_t qid,
 
 	params.flags = IORING_SETUP_SQE128;
 
+	/* Replies are batched and flushed in one io_uring_enter; don't let a
+	 * single failing commit SQE stall submission of the rest of the batch.
+	 */
+	params.flags |= IORING_SETUP_SUBMIT_ALL;
+
 	/* Avoid cq overflow */
 	params.flags |= IORING_SETUP_CQSIZE;
 	params.cq_entries = depth * 2;


### PR DESCRIPTION
Replies are not submitted as they are produced: while a queue thread is in fuse_uring_queue_handle_cqes() (cqe_processing set), each reply only prepares a COMMIT_AND_FETCH SQE and the per-reply io_uring_submit() is skipped. The whole batch, plus the eventfd poll re-arm, is flushed by the next io_uring_submit_and_wait().

Without IORING_SETUP_SUBMIT_ALL the kernel aborts io_submit_sqes() at the first SQE whose prep fails, leaving the rest of the batch unconsumed until the following loop iteration -- head-of-line blocking the other in-flight replies behind one bad commit. Set the flag so the kernel drains the whole batch and only the failing SQE gets an error CQE.

This might have resulted in fuse-over-io-uring stalls, if applications were waiting for results and libfuse was waiting for CQEs, but not all SQEs had been submitted yet.