### PR TITLE
meson.build: Add Rocky Linux 9 compatibility for new mount API

### DIFF
--- a/lib/mount_fsmount.c
+++ b/lib/mount_fsmount.c
@@ -30,7 +30,93 @@
  * This file is only compiled conditionally when support for the new
  * mount API is detected - only flags that were not in the initial linux
  * commit introducing that API are defined here.
+ *
+ * Syscall number definitions and wrapper functions for new mount API.
+ * glibc < 2.36 (e.g., Rocky 9's glibc 2.34) lacks these wrappers, so we
+ * provide our own using direct syscall() invocations to access the kernel APIs.
  */
+#ifndef __NR_fsopen
+#define __NR_fsopen 430
+#endif
+#ifndef __NR_fsconfig
+#define __NR_fsconfig 431
+#endif
+#ifndef __NR_fsmount
+#define __NR_fsmount 432
+#endif
+#ifndef __NR_move_mount
+#define __NR_move_mount 429
+#endif
+#if !__GLIBC_PREREQ(2, 36)
+static inline int fsopen(const char *fsname, unsigned int flags)
+{
+	return syscall(__NR_fsopen, fsname, flags);
+}
+
+static inline int fsconfig(int fd, unsigned int cmd, const char *key,
+			   const void *value, int aux)
+{
+	return syscall(__NR_fsconfig, fd, cmd, key, value, aux);
+}
+
+static inline int fsmount(int fd, unsigned int flags, unsigned int ms_flags)
+{
+	return syscall(__NR_fsmount, fd, flags, ms_flags);
+}
+
+static inline int move_mount(int from_dfd, const char *from_pathname,
+			     int to_dfd, const char *to_pathname,
+			     unsigned int flags)
+{
+	return syscall(__NR_move_mount, from_dfd, from_pathname,
+		       to_dfd, to_pathname, flags);
+}
+#endif /* glibc < 2.36 */
+
+/*
+ * Mount attribute flags and fsconfig commands - from linux/mount.h
+ * Define missing constants for Rocky 9 compatibility
+ */
+#ifndef FSOPEN_CLOEXEC
+#define FSOPEN_CLOEXEC 0x00000001
+#endif
+
+#ifndef FSMOUNT_CLOEXEC
+#define FSMOUNT_CLOEXEC 0x00000001
+#endif
+
+#ifndef MOVE_MOUNT_F_EMPTY_PATH
+#define MOVE_MOUNT_F_EMPTY_PATH 0x00000004
+#endif
+
+#ifndef FSCONFIG_SET_STRING
+#define FSCONFIG_SET_STRING 1
+#endif
+
+#ifndef FSCONFIG_CMD_CREATE
+#define FSCONFIG_CMD_CREATE 6
+#endif
+
+#ifndef MOUNT_ATTR_RDONLY
+#define MOUNT_ATTR_RDONLY 0x00000001
+#endif
+
+#ifndef MOUNT_ATTR_NOSUID
+#define MOUNT_ATTR_NOSUID 0x00000002
+#endif
+
+#ifndef MOUNT_ATTR_NODEV
+#define MOUNT_ATTR_NODEV 0x00000004
+#endif
+
+#ifndef MOUNT_ATTR_NOEXEC
+#define MOUNT_ATTR_NOEXEC 0x00000008
+#endif
+
+#ifndef MOUNT_ATTR_NOATIME
+#define MOUNT_ATTR_NOATIME 0x00000010
+#endif
+
 #ifndef MOUNT_ATTR_NOSYMFOLLOW
 #define MOUNT_ATTR_NOSYMFOLLOW  0x00200000
 #endif

--- a/meson.build
+++ b/meson.build
@@ -155,10 +155,34 @@ special_funcs = {
     ''',
 }
 
+# Detect if we're on Rocky Linux 9
+is_rocky9 = false
+if platform == 'linux'
+    os_release = run_command('sh', '-c', 'cat /etc/os-release 2>/dev/null || echo ""', check: false)
+    if os_release.returncode() == 0
+        os_info = os_release.stdout()
+        # Check for Rocky Linux (ID="rocky")
+        is_rocky = os_info.contains('ID="rocky"')
+        # Check for version 9.x (VERSION_ID="9.x")
+        is_version9 = os_info.contains('VERSION_ID="9.')
+
+        if is_rocky and is_version9
+            is_rocky9 = true
+            message('Detected Rocky Linux 9 - enabling new mount API workaround')
+        endif
+    endif
+endif
+
 foreach name, code : special_funcs
-    private_cfg.set('HAVE_' + name.to_upper(),
-        cc.links(code, args: args_default,
-                 name: name + ' check'))
+    if name == 'new_mount_api' and is_rocky9
+        # Force-enable new mount API for Rocky 9 - syscalls exist but glibc lacks wrappers
+        private_cfg.set('HAVE_NEW_MOUNT_API', true)
+        message('Force-enabling new mount API for Rocky 9')
+    else
+        private_cfg.set('HAVE_' + name.to_upper(),
+            cc.links(code, args: args_default,
+                     name: name + ' check'))
+    endif
 endforeach
 
 # Headers checks


### PR DESCRIPTION
Rocky Linux 9 has kernel 5.14 which includes the new mount API syscalls (fsopen, fsconfig, fsmount, move_mount) introduced in Linux 5.2, but ships with glibc 2.34 which lacks the wrapper functions for these syscalls (wrappers were added in glibc 2.36).

Changes:
- meson.build: Detect Rocky Linux 9 at build time and force-enable HAVE_NEW_MOUNT_API instead of relying on compile check that would fail due to missing glibc wrappers

- mount_fsmount.c: Provide syscall wrappers for new mount API when glibc < 2.36 using direct syscall() invocations via __NR_* syscall numbers

This allows libfuse to use the new mount API on Rocky 9 systems by calling the kernel syscalls directly when glibc wrappers are not available, while automatically using glibc wrappers on systems with glibc >= 2.36.