### PR TITLE
fuse_lowlevel: fix extension parse over-read on splice path

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3984,16 +3984,7 @@ void fuse_session_process_buf_internal(struct fuse_session *se,
 	}
 
 	fuse_session_in2req(req, in);
-	if (in->total_extlen)
-		fuse_req_parse_extensions(req, in->total_extlen, in, in->len);
 	req->ch = ch ? fuse_chan_get(ch) : NULL;
-
-	if (se->debug && req->secctx_len > 0) {
-		fuse_log(FUSE_LOG_DEBUG,
-			"  secctx: %zu bytes (%u contexts)\n",
-			req->secctx_len,
-			req->secctx_count);
-	}
 
 	err = fuse_req_opcode_sanity_ok(se, in->opcode);
 	if (err)
@@ -4042,6 +4033,21 @@ void fuse_session_process_buf_internal(struct fuse_session *se,
 			goto reply_err;
 
 		in = mbuf;
+	}
+
+	/*
+	 * Extensions are appended at the end of the request. On the splice path
+	 * 'in' only holds the fixed header until the payload is copied in above,
+	 * so parse them here, where 'in' spans the whole request for every path.
+	 */
+	if (in->total_extlen)
+		fuse_req_parse_extensions(req, in->total_extlen, in, in->len);
+
+	if (se->debug && req->secctx_len > 0) {
+		fuse_log(FUSE_LOG_DEBUG,
+			"  secctx: %zu bytes (%u contexts)\n",
+			req->secctx_len,
+			req->secctx_count);
 	}
 
 	inarg = (void *) &in[1];

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3932,6 +3932,8 @@ void fuse_session_process_buf_internal(struct fuse_session *se,
 	struct fuse_bufvec bufv = { .buf[0] = *buf, .count = 1 };
 	struct fuse_bufvec tmpbuf = FUSE_BUFVEC_INIT(write_header_size);
 	struct fuse_in_header *in;
+	/* 'in' spans the whole request, not just the fixed header */
+	bool buf_is_complete;
 	const void *inarg;
 	struct fuse_req *req;
 	void *mbuf = NULL;
@@ -3954,8 +3956,10 @@ void fuse_session_process_buf_internal(struct fuse_session *se,
 			goto clear_pipe;
 
 		in = mbuf;
+		buf_is_complete = (tmpbuf.buf[0].size == buf->size);
 	} else {
 		in = buf->mem;
+		buf_is_complete = true;
 	}
 
 	trace_request_process(in->opcode, in->unique);
@@ -3984,16 +3988,7 @@ void fuse_session_process_buf_internal(struct fuse_session *se,
 	}
 
 	fuse_session_in2req(req, in);
-	if (in->total_extlen)
-		fuse_req_parse_extensions(req, in->total_extlen, in, in->len);
 	req->ch = ch ? fuse_chan_get(ch) : NULL;
-
-	if (se->debug && req->secctx_len > 0) {
-		fuse_log(FUSE_LOG_DEBUG,
-			"  secctx: %zu bytes (%u contexts)\n",
-			req->secctx_len,
-			req->secctx_count);
-	}
 
 	err = fuse_req_opcode_sanity_ok(se, in->opcode);
 	if (err)
@@ -4042,6 +4037,31 @@ void fuse_session_process_buf_internal(struct fuse_session *se,
 			goto reply_err;
 
 		in = mbuf;
+		buf_is_complete = true;
+	}
+
+	/*
+	 * Extensions sit at the end of the request and are only reachable once
+	 * 'in' spans it. The splice path leaves FUSE_WRITE (with write_buf) and
+	 * FUSE_NOTIFY_REPLY payloads in the pipe; as of Linux 7.1 the kernel
+	 * attaches no extensions to those.
+	 */
+	if (in->total_extlen) {
+		if (buf_is_complete)
+			fuse_req_parse_extensions(req, in->total_extlen, in,
+						  in->len);
+		else
+			fuse_log(FUSE_LOG_WARNING,
+				"fuse: %s: %zu extension bytes outside the header buffer, ignored\n",
+				opname((enum fuse_opcode) in->opcode),
+				FUSE_EXT_SIZE(in->total_extlen));
+	}
+
+	if (se->debug && req->secctx_len > 0) {
+		fuse_log(FUSE_LOG_DEBUG,
+			"  secctx: %zu bytes (%u contexts)\n",
+			req->secctx_len,
+			req->secctx_count);
 	}
 
 	inarg = (void *) &in[1];


### PR DESCRIPTION
Repro: on a splice_read mount with a security context, an unprivileged user makes a symlink with a ~4KB target, so the request arrives as FUSE_BUF_IS_FD.
Cause: fuse_session_process_buf_internal parses the extensions before the payload is copied in, so on that path it reads past the header-sized mbuf using in->len.
Fix: move the parse below the payload copy where 'in' spans the whole request, as the io_uring path already does.