### PR TITLE
mount_util: mark -o dev unsafe for unprivileged mounts

### DIFF
--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -124,7 +124,7 @@ const struct mount_flags mount_flags[] = {
 {"ro",           MS_RDONLY,        1,  1,    1,        MOUNT_ATTR_RDONLY},
 {"suid",         MS_NOSUID,        0,  0,    0,        MOUNT_ATTR_NOSUID},
 {"nosuid",       MS_NOSUID,        1,  1,    0,        MOUNT_ATTR_NOSUID},
-{"dev",          MS_NODEV,         0,  1,    0,        MOUNT_ATTR_NODEV},
+{"dev",          MS_NODEV,         0,  0,    0,        MOUNT_ATTR_NODEV},
 {"nodev",        MS_NODEV,         1,  1,    0,        MOUNT_ATTR_NODEV},
 {"exec",         MS_NOEXEC,        0,  1,    0,        MOUNT_ATTR_NOEXEC},
 {"noexec",       MS_NOEXEC,        1,  1,    0,        MOUNT_ATTR_NOEXEC},

--- a/test/meson.build
+++ b/test/meson.build
@@ -33,6 +33,11 @@ td += executable('test_loop_config', 'test_loop_config.c',
                  link_with: [ libfuse ],
                  dependencies: thread_dep,
                  install: false)
+td += executable('test_mount_flags',
+                 ['test_mount_flags.c', '../lib/mount_util.c',
+                  '../lib/fuse_log.c'],
+                 include_directories: include_dirs,
+                 install: false)
 
 test_scripts = [ 'conftest.py', 'pytest.ini', 'test_examples.py',
                  'util.py', 'test_ctests.py', 'test_custom_io.py',

--- a/test/test_ctests.py
+++ b/test/test_ctests.py
@@ -28,6 +28,10 @@ def test_loop_config():
     """Unit test for fuse_loop_cfg setter interaction — no FUSE mount needed."""
     subprocess.check_call([ pjoin(basename, 'test', 'test_loop_config') ])
 
+def test_mount_flags():
+    """Unit test for the mount_flags safe column — no FUSE mount needed."""
+    subprocess.check_call([ pjoin(basename, 'test', 'test_mount_flags') ])
+
 @pytest.mark.skipif('FUSE_CAP_WRITEBACK_CACHE' not in fuse_caps,
                     reason='not supported by running kernel')
 @pytest.mark.parametrize("writeback", (False, True))

--- a/test/test_mount_flags.c
+++ b/test/test_mount_flags.c
@@ -1,0 +1,94 @@
+/*
+ * Unit tests for the 'safe' column of the shared mount_flags table.
+ *
+ * fusermount3 starts every unprivileged mount from MS_NOSUID | MS_NODEV and
+ * lets -o options edit the flags from there, and mount.fuse3 re-applies the
+ * same two flags for non-root callers.  Both decide what an unprivileged
+ * caller may turn off by looking at 'safe', so an option that clears one of
+ * those flags has to be marked unsafe.  No mount is needed; the table is
+ * checked directly.
+ */
+
+#include "mount_util.h"
+#include <stdio.h>
+#include <string.h>
+
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+static const struct mount_flags *lookup(const char *opt)
+{
+	size_t i;
+
+	for (i = 0; mount_flags[i].opt != NULL; i++)
+		if (strcmp(mount_flags[i].opt, opt) == 0)
+			return &mount_flags[i];
+
+	return NULL;
+}
+
+static int fail(const char *test, const char *opt, const char *problem)
+{
+	fprintf(stderr, "FAIL: %s: option %s %s\n", test, opt, problem);
+	return 1;
+}
+
+/*
+ * An unprivileged caller must not be able to drop nosuid or nodev, so the
+ * options that clear those flags have to be marked unsafe.
+ */
+static int test_hardening_opts_unsafe(void)
+{
+	static const char *const opts[] = { "suid", "dev" };
+	const char *test = "hardening_opts_unsafe";
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(opts); i++) {
+		const struct mount_flags *mf = lookup(opts[i]);
+
+		if (!mf)
+			return fail(test, opts[i], "is missing from the table");
+		if (mf->on)
+			return fail(test, opts[i], "no longer clears its flag");
+		if (mf->safe)
+			return fail(test, opts[i], "is marked safe");
+	}
+
+	printf("PASS: %s\n", test);
+	return 0;
+}
+
+/*
+ * The other direction stays available to everyone: asking for more
+ * restrictions is always allowed.
+ */
+static int test_hardening_opts_grantable(void)
+{
+	static const char *const opts[] = { "nosuid", "nodev" };
+	const char *test = "hardening_opts_grantable";
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(opts); i++) {
+		const struct mount_flags *mf = lookup(opts[i]);
+
+		if (!mf)
+			return fail(test, opts[i], "is missing from the table");
+		if (!mf->on)
+			return fail(test, opts[i], "no longer sets its flag");
+		if (!mf->safe)
+			return fail(test, opts[i], "is marked unsafe");
+	}
+
+	printf("PASS: %s\n", test);
+	return 0;
+}
+
+int main(void)
+{
+	if (test_hardening_opts_unsafe())
+		return 1;
+	if (test_hardening_opts_grantable())
+		return 1;
+
+	printf("All mount_flags tests passed\n");
+	return 0;
+}


### PR DESCRIPTION
Repro: as a normal user, `fusermount3 -o dev <mnt>` mounts with `rw,nosuid,relatime` and prints nothing, while `-o suid` prints "unsafe option suid ignored" and keeps `nodev`.
Cause: the `dev` row in the shared mount_flags table carries safe=1, and `safe` is what both `find_mount_flag()` in fusermount and `adjust_nonroot_mount_flags()` in mount.service use to decide what a non-root caller may clear. fusermount does the mount(2) as root, so nothing puts MS_NODEV back and the filesystem can serve device nodes the kernel honors. The row was safe=0 in the fusermount-local table until eec851b ("Move 'struct mount_flags' to util.h") merged it here.
Fix: restore safe=0 on that row, which covers both callers, and pin the safe column for the two flags in the unprivileged baseline with a unit test.