### PR TITLE
mount_util: terminate the mount and umount argv with --

### DIFF
--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -279,9 +279,14 @@ static int add_mount(const char *progname, const char *fsname,
 		return -1;
 	}
 
+	/*
+	 * fsname comes from -ofsname= (or the service SOURCE command), so it
+	 * can start with '-'. Terminate the options with "--" to keep mount(8)
+	 * from parsing the operands as further options.
+	 */
 	char const * const argv[] = {
 		cmd, "--no-canonicalize", "-i", "-f", "-t", type, "-o", opts,
-		fsname, mnt, NULL
+		"--", fsname, mnt, NULL
 	};
 
 	res = fuse_mount_spawn(&pid, cmd, (char * const *) argv, &oldmask);
@@ -332,10 +337,10 @@ static int exec_umount(const char *progname, const char *rel_mnt, int lazy)
 	}
 
 	char const * const argv_lazy[] = {
-		cmd, "-i", "-l", rel_mnt, NULL
+		cmd, "-i", "-l", "--", rel_mnt, NULL
 	};
 	char const * const argv_normal[] = {
-		cmd, "-i", rel_mnt, NULL
+		cmd, "-i", "--", rel_mnt, NULL
 	};
 	char const * const *argv = lazy ? argv_lazy : argv_normal;
 
@@ -391,7 +396,7 @@ static int remove_mount(const char *progname, const char *mnt)
 	}
 
 	char const * const argv[] =  {
-		cmd, "--no-canonicalize", "-i", "--fake", mnt, NULL
+		cmd, "--no-canonicalize", "-i", "--fake", "--", mnt, NULL
 	};
 
 	res = fuse_mount_spawn(&pid, cmd, (char * const *) argv, &oldmask);


### PR DESCRIPTION
Repro: as a normal user, `fusermount3 -o fsname=-oro,--target=/etc <mnt>` hands `-oro,--target=/etc` to `/bin/mount` as a positional operand. The same value arrives from an unprivileged fuse server as the `SOURCE` command payload on the mount.service socket.
Cause: `add_mount()` places `fsname` and `mnt` after `-o opts` with nothing terminating the option list, and `fuse_mount_spawn()` raises the real uid to 0 right before `posix_spawn()`, so mount(8) is not in restricted mode. getopt_long reads the operand as a second `-o` and the source operand is lost, which puts the caller in control of arguments to a root mount(8) and of the mtab/utab record this call exists to write.
Fix: add `--` after the options. `exec_umount()` and `remove_mount()` build their `/bin/umount` argv through the same spawn helper, so they get it too.
