### PR TITLE
lib: relay the KILLPRIV_V2 kill-suidgid flags to the filesystem

### DIFF
--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -96,8 +96,13 @@ struct fuse_file_info {
 	    file */
 	uint32_t parallel_direct_writes : 1;
 
+	/** Set in open, create and write if FUSE_CAP_HANDLE_KILLPRIV_V2 was
+	    enabled and the filesystem has to unset the setuid and setgid bits
+	    and drop the capability xattr. */
+	uint32_t kill_suidgid : 1;
+
 	/** Padding.  Reserved for future use*/
-	uint32_t padding : 23;
+	uint32_t padding : 22;
 	uint32_t padding2 : 32;
 	uint32_t padding3 : 32;
 

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1711,8 +1711,11 @@ static void _do_create(fuse_req_t req, const fuse_ino_t nodeid,
 		memset(&fi, 0, sizeof(fi));
 		fi.flags = arg->flags;
 
-		if (req->se->conn.proto_minor >= 12)
+		if (req->se->conn.proto_minor >= 12) {
 			req->ctx.umask = arg->umask;
+			fi.kill_suidgid =
+				(arg->open_flags & FUSE_OPEN_KILL_SUIDGID) != 0;
+		}
 
 		/* XXX: fuse_create_in::open_flags */
 
@@ -1743,6 +1746,7 @@ static void _do_open(fuse_req_t req, const fuse_ino_t nodeid, const void *op_in,
 
 	memset(&fi, 0, sizeof(fi));
 	fi.flags = arg->flags;
+	fi.kill_suidgid = (arg->open_flags & FUSE_OPEN_KILL_SUIDGID) != 0;
 
 	/* XXX: fuse_open_in::open_flags */
 
@@ -1794,6 +1798,7 @@ static void _do_write(fuse_req_t req, const fuse_ino_t nodeid,
 	memset(&fi, 0, sizeof(fi));
 	fi.fh = arg->fh;
 	fi.writepage = (arg->write_flags & FUSE_WRITE_CACHE) != 0;
+	fi.kill_suidgid = (arg->write_flags & FUSE_WRITE_KILL_SUIDGID) != 0;
 
 	if (req->se->conn.proto_minor >= 9) {
 		fi.lock_owner = arg->lock_owner;
@@ -1830,6 +1835,7 @@ static void _do_write_buf(fuse_req_t req, const fuse_ino_t nodeid,
 	memset(&fi, 0, sizeof(fi));
 	fi.fh = arg->fh;
 	fi.writepage = arg->write_flags & FUSE_WRITE_CACHE;
+	fi.kill_suidgid = (arg->write_flags & FUSE_WRITE_KILL_SUIDGID) != 0;
 
 	if (se->conn.proto_minor >= 9) {
 		fi.lock_owner = arg->lock_owner;


### PR DESCRIPTION
With FUSE_CAP_HANDLE_KILLPRIV_V2 the kernel stops clearing suid/sgid and security.capability itself and tells the server per request when to do it. Of the three flags carrying that request only FATTR_KILL_SUIDGID made it through, because FUSE_SET_ATTR_KILL_SUID happens to be the same bit. FUSE_OPEN_KILL_SUIDGID and FUSE_WRITE_KILL_SUIDGID were dropped, so a server that negotiated KILLPRIV_V2 never saw the request on O_TRUNC open and on write, and the bits survived.

Decode both into a new fuse_file_info::kill_suidgid, taken from the padding bits, in open, create, write and write_buf. In create the flag sits in fuse_create_in::open_flags, which only exists since 7.12, hence the existing proto_minor guard.