### PR TITLE
lib: commit the ring entry in fuse_reply_none()

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -461,6 +461,10 @@ int fuse_reply_err(fuse_req_t req, int err)
 
 void fuse_reply_none(fuse_req_t req)
 {
+	if (req->flags.is_uring) {
+		send_reply_uring(req, 0, NULL, 0);
+		return;
+	}
 	fuse_free_req(req);
 }
 


### PR DESCRIPTION
Over io_uring a ring entry only goes back to the kernel via COMMIT_AND_FETCH. fuse_reply_none() merely freed the request, so a FORGET answered this way leaked the entry and left the kernel-side request outstanding.