### PR TITLE
build: detect the systemd headers with has_header

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -131,13 +131,6 @@ special_funcs = {
 	  }
 	}
     ''',
-    'systemd_headers': '''
-	#include <systemd/sd-daemon.h>
-
-	int main(int argc, char *argv[]) {
-          return SD_LISTEN_FDS_START;
-	}
-    ''',
 }
 
 foreach name, code : special_funcs
@@ -262,6 +255,12 @@ endif
 
 # Check for systemd support
 #
+# Only the SD_LISTEN_FDS_START macro is used, so the header alone decides
+# this - a link test would additionally demand libsystemd, which nothing
+# here links against.
+private_cfg.set('HAVE_SYSTEMD_HEADERS',
+    cc.has_header('systemd/sd-daemon.h'))
+
 # Only systemd.pc names the unit directory, and it might ship in a package of
 # its own (Debian: systemd-dev); the libsystemd.pc installed with the headers
 # does not carry it. So fall back to looking for the directory itself, rather


### PR DESCRIPTION
Nothing links against libsystemd - lib/fuse_service.c only needs the SD_LISTEN_FDS_START macro - so a link test asks for more than is required. It also strands anyone who installed libsystemd-dev after configuring: meson keys its check cache on the test's source text, so --reconfigure replays the stale negative result and only --wipe clears it. Switching to has_header both matches what the code needs and changes that key, so an existing build directory re-evaluates on its own.