### PR TITLE
fuse_lowlevel: add buffer size sanity check for init requests

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -4079,6 +4079,15 @@ void fuse_session_process_buf_internal(struct fuse_session *se,
 	err = ENOSYS;
 	if (in->opcode >= FUSE_MAXOP || !fuse_ll_ops[in->opcode].func)
 		goto reply_err;
+	if (in->opcode == FUSE_INIT || in->opcode == CUSE_INIT) {
+		size_t hdr  = sizeof(struct fuse_in_header);
+		size_t have = buf->size < in->len ? buf->size : in->len;
+		size_t need = offsetof(struct fuse_init_in, max_readahead); /* 8: major+minor */
+		if (have < hdr || have - hdr < need) {
+			err = EPROTO;
+			goto reply_err;
+		}
+	}
 	/* Do not process interrupt request */
 	if (se->conn.no_interrupt && in->opcode == FUSE_INTERRUPT) {
 		if (se->debug)


### PR DESCRIPTION
This PR attempts to fix [#1587](https://github.com/libfuse/libfuse/issues/1587#issue-5169821882)

## Problem

`fuse_session_process_buf_internal()` (`lib/fuse_lowlevel.c`) dispatches into per-opcode handlers with a bare payload pointer and no payload-size check:

```c
inarg = (void *) &in[1];                                   // fuse_lowlevel.c:4034
...
fuse_ll_ops[in->opcode].func(req, in->nodeid, inarg);      // fuse_lowlevel.c:4040
```

The two guards that gate dispatch — `fuse_req_opcode_sanity_ok()` (opcode *type* only, lines 3722–3737) and the `FUSE_MAXOP` / non-NULL-func check (line 3994) — never look at size. The handler signature `void (*func)(req, node, arg)` carries no length. So when a memory-backed `fuse_buf` contains a `FUSE_INIT` request whose payload is shorter than `struct fuse_init_in` (64 bytes), `_do_init()` casts the short payload to the 64-byte struct and dereferences past the end:

```c
const struct fuse_init_in *arg = op_in;          // fuse_lowlevel.c:2724
...
se->conn.proto_major = arg->major;               // :2743  off 0, 4 B — in bounds
se->conn.proto_minor = arg->minor;               // :2744  off 4, 4 B — OOB read
```

## Fix

A single guarded block in `fuse_session_process_buf_internal()`, inserted right after the existing `FUSE_MAXOP` / non-NULL-func guard (line 3995) and before any handler is entered. A `FUSE_INIT` / `CUSE_INIT` request whose payload is shorter than the fields `_do_init` reads unconditionally is replied to with `EPROTO` via the existing `reply_err` path — the same errno `_do_init` already uses for an unsupported protocol version (`fuse_lowlevel.c:2755`) — and the handler is never called:

```c
/* fuse_lowlevel.c — in fuse_session_process_buf_internal(),
   right after the FUSE_MAXOP / func-null guard (line 3995) */
if (in->opcode == FUSE_INIT || in->opcode == CUSE_INIT) {
	size_t hdr  = sizeof(struct fuse_in_header);
	size_t have = buf->size < in->len ? buf->size : in->len;
	size_t need = offsetof(struct fuse_init_in, max_readahead); /* 8: major+minor */
	if (have < hdr || have - hdr < need) {
		err = EPROTO;
		goto reply_err;
	}
}
```

This closes the reported `FUSE_INIT` path and the symmetric `CUSE_INIT` path (same `fuse_init_in` cast). Other opcodes have the same latent shape but are not part of this report; a per-opcode minimum-size table covering them is noted as a separate follow-up.

## Verification

### Sanitizer rebuild

```bash
export CC=clang CXX=clang++ LD=clang++
export CFLAGS="-fsanitize=address,undefined -fno-sanitize=function \
  -fsanitize-address-use-after-scope -g -O0 -fPIC -fno-inline \
  -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
export CXXFLAGS="$CFLAGS" LDFLAGS="$CXXFLAGS"
meson setup src/libfuse build-san --prefix="$PWD/build-san/install" \
    --default-library=static --buildtype=plain \
    -Dutils=false -Dexamples=false -Dtests=false \
    -Ddisable-libc-symbol-version=true -Denable-io-uring=false \
    -Denable-usdt=false -Duseroot=false
ninja -C build-san -j && ninja -C build-san install
```

### Before fix

```bash
$ clang++ -g -O0 -fsanitize=address,undefined \
    -Ibuild-san/install/include poc.cpp -o poc \
    build-san/install/lib/libfuse3.a -lpthread -ldl
$ ASAN_OPTIONS=detect_leaks=0 ./poc
SUMMARY: AddressSanitizer: heap-buffer-overflow fuse_lowlevel.c:2744:30 in _do_init
```
Exit status: non-zero (ASan abort). Crash is deterministic, reproduces on every run.

### After fix

```bash
$ ASAN_OPTIONS=detect_leaks=0 ./poc
fuse: writing device: Bad file descriptor
$ echo $?
0
```

No ASan report; the process exits 0. The `Bad file descriptor` line is the *reply* write failing on a missing `/dev/fuse` fd:
- The check fires → `goto reply_err` → `fuse_reply_err(req, EPROTO)` → `fuse_send_msg` → `writev(se->fd, …)` at `fuse_lowlevel.c:289`.
- The standalone PoC never opens `/dev/fuse`, so `se->fd == -1` and the `writev` fails with `EBADF`; `perror("fuse: writing device")` at `fuse_lowlevel.c:295` prints the line.

The proof the fix works is **what is absent**: before the fix `_do_init` runs and ASan aborts at line 2744 *before* any reply is sent (so this line never appears); after the fix `_do_init` is skipped, the EPROTO reply path finally runs, and the only thing that fails is the harmless reply write to a non-existent device. `_do_init` is never entered; the OOB read cannot occur. (The EBADF would appear for *any* reply this standalone harness triggers — it is a property of having no mounted FUSE channel, not of the fix.)

### Test-suite results

The existing built-in test suite was rebuilt and run under the fix to confirm no regression. The check only rejects messages that previously caused undefined behaviour, so no well-formed request changes behaviour:

```bash
$ meson setup --reconfigure build -Dtests=true
$ ninja -C build
$ meson test -C build -v
```
The suite passes.