### PR TITLE
mount_util: skip mtab updates for option-like mount arguments

### DIFF
--- a/lib/mount_util.c
+++ b/lib/mount_util.c
@@ -259,6 +259,19 @@ out_destroy:
 }
 
 /*
+ * These values become command line arguments of /bin/mount and /bin/umount.
+ * BusyBox mount(8) parses an argument starting with '-' as an option even
+ * behind an end-of-options marker ("--"); NULL would end the argument list
+ * early.
+ *
+ * @return 1 if @value is unsafe as a /bin/mount or /bin/umount argument.
+ */
+static int unsafe_operand(const char *value)
+{
+	return value == NULL || value[0] == '-';
+}
+
+/*
  * @return caller expects 0 or -1
  */
 static int add_mount(const char *progname, const char *fsname,
@@ -270,6 +283,21 @@ static int add_mount(const char *progname, const char *fsname,
 	sigset_t blockmask;
 	sigset_t oldmask;
 	const char *cmd = "/bin/mount";
+
+	if (fsname == NULL || mnt == NULL || type == NULL || opts == NULL) {
+		fuse_log(FUSE_LOG_DEBUG,
+			"%s: missing mount argument, skipping mtab update\n",
+			progname);
+		return 0;
+	}
+
+	if (unsafe_operand(fsname) || unsafe_operand(mnt) ||
+	    unsafe_operand(type) || unsafe_operand(opts)) {
+		fuse_log(FUSE_LOG_DEBUG,
+			"%s: option-like mount argument, skipping mtab update\n",
+			progname);
+		return 0;
+	}
 
 	sigemptyset(&blockmask);
 	sigaddset(&blockmask, SIGCHLD);
@@ -367,7 +395,11 @@ static int exec_umount(const char *progname, const char *rel_mnt, int lazy)
 int fuse_mnt_umount(const char *progname, const char *abs_mnt,
 		    const char *rel_mnt, int lazy)
 {
-	if (!mtab_needs_update(abs_mnt)) {
+	/*
+	 * umount(8) may read an option-like rel_mnt as an option: unmount here
+	 * instead and leave the mtab/utab record behind
+	 */
+	if (!mtab_needs_update(abs_mnt) || unsafe_operand(rel_mnt)) {
 		int res = umount2(rel_mnt, lazy ? 2 : 0);
 		if (res == -1)
 			fuse_log(FUSE_LOG_ERR, "%s: failed to unmount %s: %s\n",
@@ -386,6 +418,9 @@ static int remove_mount(const char *progname, const char *mnt)
 	sigset_t blockmask;
 	sigset_t oldmask;
 	const char *cmd = "/bin/umount";
+
+	if (unsafe_operand(mnt))
+		return 0;
 
 	sigemptyset(&blockmask);
 	sigaddset(&blockmask, SIGCHLD);

--- a/test/cases/README.md
+++ b/test/cases/README.md
@@ -289,6 +289,8 @@ fuse_test_assert_super_opt <mnt> <opt>...      # present in super_options
 fuse_test_assert_super_opt_prefix <mnt> <p>... # e.g. user_id=
 fuse_test_assert_fstype <mnt> <fstype>...      # any one is acceptable
 fuse_test_assert_source <mnt> <source>...      # any one is acceptable
+fuse_test_assert_utab_target <mnt>             # recorded in /run/mount/utab
+fuse_test_refute_utab_target <mnt>             # not recorded there
 
 # the remainder
 fuse_test_printcap_caps <src-root>          # every FUSE_CAP_* is in the header
@@ -307,7 +309,8 @@ or `fuse_test_stat`.
 underscore-prefixed naming shell uses elsewhere: `_assert_errno`,
 `_assert_listdir`, `_assert_xattr_roundtrip`, `mountinfo_field`,
 `_assert_mount_opt`, `_refute_mount_opt`, `_assert_super_opt`,
-`_assert_super_opt_prefix`, `_assert_fstype`, `_assert_source`.
+`_assert_super_opt_prefix`, `_assert_fstype`, `_assert_source`,
+`_assert_utab_target`, `_refute_utab_target`.
 
 ## Adding a variant of an existing test
 

--- a/test/cases/lib/checks.py
+++ b/test/cases/lib/checks.py
@@ -707,6 +707,48 @@ def cmd_assert_source(mnt_dir, expected):
              % (info['source'], expected))
 
 
+UTAB_PATH = '/run/mount/utab'
+
+# libmount escapes these four, and only these four, as \NNN octal.
+UTAB_ESCAPES = {' ': r'\040', '\t': r'\011', '\n': r'\012', '\\': r'\134'}
+
+
+def _utab_escape(path):
+    """Spell *path* the way libmount spells it in a TARGET= field."""
+    out = ''
+    for char in path:
+        escaped = UTAB_ESCAPES.get(char)
+        if escaped is not None:
+            out += escaped
+        else:
+            out += char
+    return out
+
+
+def utab_targets():
+    """Every TARGET= field in /run/mount/utab, as written."""
+    prefix = 'TARGET='
+    targets = []
+    with open(UTAB_PATH, encoding='utf8') as fh:
+        for line in fh:
+            for field in line.split():
+                if field.startswith(prefix):
+                    targets.append(field[len(prefix):])
+    return targets
+
+
+def cmd_assert_utab_target(mnt_dir):
+    target = _utab_escape(os.path.realpath(mnt_dir))
+    _require(target in utab_targets(),
+             '%s missing from %s' % (target, UTAB_PATH))
+
+
+def cmd_refute_utab_target(mnt_dir):
+    target = _utab_escape(os.path.realpath(mnt_dir))
+    _require(target not in utab_targets(),
+             'unexpected %s in %s' % (target, UTAB_PATH))
+
+
 # ------------------------------------------------------------- odds and ends
 
 def cmd_printcap_caps(src_root):
@@ -945,6 +987,8 @@ def build_parser():
                        ('fuse_test_assert_fstype', cmd_assert_fstype),
                        ('fuse_test_assert_source', cmd_assert_source)):
         add(name, func, 'mnt', ('values', {'nargs': '+'}))
+    add('fuse_test_assert_utab_target', cmd_assert_utab_target, 'mnt')
+    add('fuse_test_refute_utab_target', cmd_refute_utab_target, 'mnt')
 
     add('fuse_test_printcap_caps', cmd_printcap_caps, 'src_root')
     add('fuse_test_reachable_without_caps', cmd_reachable_without_caps, 'path')

--- a/test/cases/lib/common.sh
+++ b/test/cases/lib/common.sh
@@ -296,6 +296,8 @@ _assert_super_opt()        { _check fuse_test_assert_super_opt "$@"; }
 _assert_super_opt_prefix() { _check fuse_test_assert_super_opt_prefix "$@"; }
 _assert_fstype()           { _check fuse_test_assert_fstype "$@"; }
 _assert_source()           { _check fuse_test_assert_source "$@"; }
+_assert_utab_target()      { _check fuse_test_assert_utab_target "$@"; }
+_refute_utab_target()      { _check fuse_test_refute_utab_target "$@"; }
 
 # ---------------------------------------------------------------- cleanup hooks
 

--- a/test/cases/lib/utab.sh
+++ b/test/cases/lib/utab.sh
@@ -1,0 +1,30 @@
+# lib/utab.sh - body for the /run/mount/utab cases.
+#
+# Caller sets FS_NAME (hello or hello_ll), optionally MOUNT_OPTS, and defines
+# utab_assert(). It may also define utab_setup(), which runs before the mount
+# and may set MOUNT_DIR or extend MOUNT_OPTS.
+#
+# These tests assert what the mount left behind in /run/mount/utab, the record
+# lib/mount_util.c skips for an argument a mount(8) could read as an option.
+
+. "$TEST_LIB/common.sh"
+
+# utab is util-linux's, and the assertions read /proc/self/mountinfo with it.
+_require_linux "/run/mount/utab"
+[ -e /run/mount/utab ] || _notrun "no /run/mount/utab on this host"
+
+# hello_ll supports single-threading only.
+FS_EXTRA=
+[ "$FS_NAME" != hello_ll ] || FS_EXTRA=-s
+
+if declare -F utab_setup >/dev/null; then
+	utab_setup
+fi
+
+fuse_mount_at "${MOUNT_DIR:-$TEST_MNT}" "$FS_NAME" -f $FS_EXTRA \
+	${MOUNT_OPTS:+-o "$MOUNT_OPTS"} >/dev/null
+
+# While it is still mounted: the utab record goes away with the mount.
+utab_assert
+
+fuse_umount

--- a/test/cases/mount/utab-fsname-dash-hello-ll.sh
+++ b/test/cases/mount/utab-fsname-dash-hello-ll.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# GROUP: mount
+
+. "$TEST_LIB/common.sh"
+
+# The utab update runs only for a root mount; fusermount3 writes its own.
+_require_root
+
+FS_NAME=hello_ll
+MOUNT_OPTS=fsname=-oro
+
+utab_assert()
+{
+	# The mount still carries the fsname ...
+	_assert_source "$TEST_MNT" -oro
+	# ... but a mount(8) could read it as an option, so no utab record.
+	_refute_utab_target "$TEST_MNT"
+}
+
+. "$TEST_LIB/utab.sh"

--- a/test/cases/mount/utab-fsname-dash-hello.sh
+++ b/test/cases/mount/utab-fsname-dash-hello.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# GROUP: mount
+
+. "$TEST_LIB/common.sh"
+
+# The utab update runs only for a root mount; fusermount3 writes its own.
+_require_root
+
+FS_NAME=hello
+MOUNT_OPTS=fsname=-oro
+
+utab_assert()
+{
+	# The mount still carries the fsname ...
+	_assert_source "$TEST_MNT" -oro
+	# ... but a mount(8) could read it as an option, so no utab record.
+	_refute_utab_target "$TEST_MNT"
+}
+
+. "$TEST_LIB/utab.sh"

--- a/test/cases/mount/utab-mountpoint-dash-hello-ll.sh
+++ b/test/cases/mount/utab-mountpoint-dash-hello-ll.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# GROUP: mount
+
+FS_NAME=hello_ll
+
+utab_setup()
+{
+	MOUNT_DIR=$TEST_TMP/-evil
+	mkdir "$MOUNT_DIR"
+}
+
+utab_assert()
+{
+	# fuse_mnt_resolve_path() makes the mountpoint absolute, so a
+	# dash-prefixed basename never becomes an option-like operand.
+	_assert_utab_target "$MOUNT_DIR"
+}
+
+. "$TEST_LIB/utab.sh"

--- a/test/cases/mount/utab-mountpoint-dash-hello.sh
+++ b/test/cases/mount/utab-mountpoint-dash-hello.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# GROUP: mount
+
+FS_NAME=hello
+
+utab_setup()
+{
+	MOUNT_DIR=$TEST_TMP/-evil
+	mkdir "$MOUNT_DIR"
+}
+
+utab_assert()
+{
+	# fuse_mnt_resolve_path() makes the mountpoint absolute, so a
+	# dash-prefixed basename never becomes an option-like operand.
+	_assert_utab_target "$MOUNT_DIR"
+}
+
+. "$TEST_LIB/utab.sh"


### PR DESCRIPTION
Commit 9d63190c9c56 ("mount_util: terminate the mount and umount argv with --") appends "--" so that a caller-controlled fsname cannot be read as an option. That only holds where mount(8) honours "--", which BusyBox does not, as of now.

Mounting as root with -ofsname=-oro:

  1. mount(2) succeeds
  2. add_mount() execs /bin/mount -i -f ... -- -oro <mnt> to write the mtab/utab record
  3. BusyBox mount(8) folds every "--xxx" argument into its option string before getopt runs, so the "--" is swallowed and -oro is parsed as -o ro
  4. <mnt> is then the only operand left, so BusyBox mount(8) looks it up in /etc/fstab, does not find it, and exits non-zero
  5. add_mount() returns -1, and fuse_kern_do_mount(), fuse_kern_fsmount() and fusermount3's do_mount() unmount and fail

POSIX advises against a leading <hyphen-minus> in a filename for exactly this reason (XBD 3.264, "Portable Filename"), so declining to record such an fsname loses little.

mount -f and umount --fake only record a mount(2) or umount2() that has already happened, so add_mount() and remove_mount() return 0 for such an operand, and for a NULL that would truncate argv. fuse_mnt_umount() runs a real umount(8), which cannot be skipped, so it unmounts with umount2().