### PR TITLE
lib: relay the KILLPRIV_V2 kill-suidgid flags to the filesystem

### DIFF
--- a/.github/workflows/abidiff_suppressions.abignore
+++ b/.github/workflows/abidiff_suppressions.abignore
@@ -136,3 +136,10 @@ change_kind = function-subtype-change
 # This is a pre-existing change in the branch
 name = fuse_session
 change_kind = size-change
+
+[suppress_type]
+# fuse_file_info documents its padding bits as the place for new flags.
+# Claiming one shifts the remaining padding but keeps the struct size and
+# every documented member offset, so bound this to size-preserving changes.
+name = fuse_file_info
+has_size_change = no

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -26,6 +26,11 @@ Unreleased Changes
 * ``fuse_session_loop()`` below FUSE_USE_VERSION 319 is deprecated and warns
   at compile time.
 
+* With ``FUSE_CAP_HANDLE_KILLPRIV_V2`` enabled, ``open``, ``create``,
+  ``write`` and ``write_buf`` now get the kernel's per request kill
+  suid/sgid indication in the new ``fuse_file_info::kill_suidgid`` field.
+  Before, only ``setattr`` saw it, through ``FUSE_SET_ATTR_KILL_SUID``.
+
 
 libfuse 3.18.0 (2025-12-18)
 ===========================

--- a/example/passthrough_hp.cc
+++ b/example/passthrough_hp.cc
@@ -177,6 +177,7 @@ struct Fs {
 	std::string fuse_mount_options;
 	bool direct_io;
 	bool passthrough;
+	bool killpriv_v2;
 	bool selinux;
 };
 static Fs fs{};
@@ -217,6 +218,16 @@ static void sfs_init(void *userdata, fuse_conn_info *conn)
 	/* Passthrough and writeback cache are conflicting modes */
 	if (fs.timeout && !fs.passthrough)
 		fuse_set_feature_flag(conn, FUSE_CAP_WRITEBACK_CACHE);
+
+	/*
+	 * KILLPRIV_V2 lets the kernel mark inodes S_NOSEC, which stops it
+	 * probing security.capability on every write. KILLPRIV_V2 conflicts
+	 * with passthrough: the kernel then leaves suid/sgid to this filesystem,
+	 * which in that mode never sees the write.
+	 */
+	if (!fs.passthrough)
+		fs.killpriv_v2 = fuse_set_feature_flag(
+			conn, FUSE_CAP_HANDLE_KILLPRIV_V2);
 
 	fuse_set_feature_flag(conn, FUSE_CAP_FLOCK_LOCKS);
 
@@ -286,6 +297,57 @@ static int with_fd_path(int fd, const std::function<int(const char *)> &f)
 	return f(procname);
 #endif
 }
+/*
+ * The mode with S_ISUID and S_ISGID removed, or 0 when neither is set.
+ * S_ISGID counts as sgid only on a group-executable file; without S_IXGRP it
+ * is a mandatory locking mark and has to be left alone.
+ */
+static mode_t suidgid_dropped_mode(const struct stat &st)
+{
+	mode_t mode = st.st_mode & ~S_ISUID;
+
+	if (st.st_mode & S_IXGRP)
+		mode &= ~S_ISGID;
+
+	return mode == st.st_mode ? 0 : mode;
+}
+
+/* Returns an errno, 0 on success. */
+static int drop_suidgid_fd(int fd)
+{
+	struct stat st;
+	mode_t mode;
+
+	if (fstat(fd, &st) == -1)
+		return errno;
+
+	mode = suidgid_dropped_mode(st);
+	if (!mode)
+		return 0;
+
+	return fchmod(fd, mode) == -1 ? errno : 0;
+}
+
+/* Drops S_ISUID/S_ISGID on an O_PATH descriptor, which fchmod() rejects. */
+static int drop_suidgid_at(int ifd)
+{
+	struct stat st;
+	mode_t mode;
+
+	if (fstatat(ifd, "", &st, AT_EMPTY_PATH) == -1)
+		return errno;
+
+	mode = suidgid_dropped_mode(st);
+	if (!mode)
+		return 0;
+
+	int res = with_fd_path(ifd, [mode](const char *procname) {
+		return chmod(procname, mode);
+	});
+
+	return res == -1 ? errno : 0;
+}
+
 static void do_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
 		       int valid, struct fuse_file_info *fi)
 {
@@ -360,6 +422,15 @@ static void do_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
 		}
 		if (res == -1)
 			goto out_err;
+	}
+	/* After the chown or truncate FUSE_SET_ATTR_KILL_SUID arrived with */
+	if (valid & FUSE_SET_ATTR_KILL_SUID) {
+		int err = fi ? drop_suidgid_fd(fi->fh) : drop_suidgid_at(ifd);
+
+		if (err) {
+			fuse_reply_err(req, err);
+			return;
+		}
 	}
 	return sfs_getattr(req, ino, fi);
 
@@ -1098,6 +1169,16 @@ static void sfs_create(fuse_req_t req, fuse_ino_t parent, const char *name,
 	}
 
 	fi->fh = fd;
+
+	if (fi->kill_suidgid) {
+		auto kill_err = drop_suidgid_fd(fd);
+		if (kill_err) {
+			close(fd);
+			fuse_reply_err(req, kill_err);
+			return;
+		}
+	}
+
 	fuse_entry_param e;
 	auto err = do_lookup(parent, name, &e);
 	if (err) {
@@ -1263,6 +1344,16 @@ static void sfs_open(fuse_req_t req, fuse_ino_t ino, fuse_file_info *fi)
 		return;
 	}
 
+	/* Outside inode.m: a lock must not span a syscall */
+	if (fi->kill_suidgid) {
+		auto err = drop_suidgid_fd(fd);
+		if (err) {
+			close(fd);
+			fuse_reply_err(req, err);
+			return;
+		}
+	}
+
 	{
 		lock_guard<mutex> g{ inode.m };
 		inode.nopen++;
@@ -1379,6 +1470,15 @@ static void sfs_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
 static void do_write_buf(fuse_req_t req, size_t size, off_t off,
 			 fuse_bufvec *in_buf, fuse_file_info *fi)
 {
+	/* Before the data lands, as the VFS does for a local filesystem */
+	if (fi->kill_suidgid) {
+		auto err = drop_suidgid_fd(fi->fh);
+		if (err) {
+			fuse_reply_err(req, err);
+			return;
+		}
+	}
+
 	fuse_bufvec out_buf = FUSE_BUFVEC_INIT(size);
 	out_buf.buf[0].flags =
 		static_cast<fuse_buf_flags>(FUSE_BUF_IS_FD | FUSE_BUF_FD_SEEK);
@@ -1420,6 +1520,21 @@ static void sfs_fallocate(fuse_req_t req, fuse_ino_t ino, int mode,
 			  off_t offset, off_t length, fuse_file_info *fi)
 {
 	(void)ino;
+
+	/*
+	 * KILLPRIV_V2 has no per-request flag for fallocate, and the kernel
+	 * stops clearing suid/sgid itself once it is negotiated, so a content
+	 * change here would otherwise leave the bits behind. Clear them
+	 * unconditionally: a CAP_FSETID caller keeps them on a local
+	 * filesystem, but guessing wrong that way only costs a chmod.
+	 */
+	if (fs.killpriv_v2) {
+		auto kill_err = drop_suidgid_fd(fi->fh);
+		if (kill_err) {
+			fuse_reply_err(req, kill_err);
+			return;
+		}
+	}
 
 	auto err = -do_fallocate(fi->fh, mode, offset, length);
 

--- a/include/fuse_common.h
+++ b/include/fuse_common.h
@@ -96,8 +96,16 @@ struct fuse_file_info {
 	    file */
 	uint32_t parallel_direct_writes : 1;
 
+	/**
+	 * Set in open, create and write when KILLPRIV_V2 was negotiated and
+	 * the application issuing the syscall lacks CAP_FSETID; the
+	 * filesystem's own privileges do not matter. The filesystem then
+	 * has to remove setuid/setgid bits.
+	 */
+	uint32_t kill_suidgid : 1;
+
 	/** Padding.  Reserved for future use*/
-	uint32_t padding : 23;
+	uint32_t padding : 22;
 	uint32_t padding2 : 32;
 	uint32_t padding3 : 32;
 

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -1718,7 +1718,9 @@ static void _do_create(fuse_req_t req, const fuse_ino_t nodeid,
 		if (req->se->conn.proto_minor >= 12)
 			req->ctx.umask = arg->umask;
 
-		/* XXX: fuse_create_in::open_flags */
+		if (req->se->conn.want_ext & FUSE_CAP_HANDLE_KILLPRIV_V2)
+			fi.kill_suidgid =
+				(arg->open_flags & FUSE_OPEN_KILL_SUIDGID) != 0;
 
 		req->se->op.create(req, nodeid, name, arg->mode, &fi);
 	} else {
@@ -1748,7 +1750,9 @@ static void _do_open(fuse_req_t req, const fuse_ino_t nodeid, const void *op_in,
 	memset(&fi, 0, sizeof(fi));
 	fi.flags = arg->flags;
 
-	/* XXX: fuse_open_in::open_flags */
+	if (req->se->conn.want_ext & FUSE_CAP_HANDLE_KILLPRIV_V2)
+		fi.kill_suidgid =
+			(arg->open_flags & FUSE_OPEN_KILL_SUIDGID) != 0;
 
 	if (req->se->op.open)
 		req->se->op.open(req, nodeid, &fi);
@@ -1799,6 +1803,10 @@ static void _do_write(fuse_req_t req, const fuse_ino_t nodeid,
 	fi.fh = arg->fh;
 	fi.writepage = (arg->write_flags & FUSE_WRITE_CACHE) != 0;
 
+	if (req->se->conn.want_ext & FUSE_CAP_HANDLE_KILLPRIV_V2)
+		fi.kill_suidgid =
+			(arg->write_flags & FUSE_WRITE_KILL_SUIDGID) != 0;
+
 	if (req->se->conn.proto_minor >= 9) {
 		fi.lock_owner = arg->lock_owner;
 		fi.flags = arg->flags;
@@ -1834,6 +1842,10 @@ static void _do_write_buf(fuse_req_t req, const fuse_ino_t nodeid,
 	memset(&fi, 0, sizeof(fi));
 	fi.fh = arg->fh;
 	fi.writepage = arg->write_flags & FUSE_WRITE_CACHE;
+
+	if (se->conn.want_ext & FUSE_CAP_HANDLE_KILLPRIV_V2)
+		fi.kill_suidgid =
+			(arg->write_flags & FUSE_WRITE_KILL_SUIDGID) != 0;
 
 	if (se->conn.proto_minor >= 9) {
 		fi.lock_owner = arg->lock_owner;

--- a/test/cases/ctests/kill-suidgid.sh
+++ b/test/cases/ctests/kill-suidgid.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# GROUP: ctests
+# KILLPRIV_V2 asks the filesystem per request to drop suid/sgid. The kernel
+# only asks a caller that lacks CAP_FSETID, which the test binary gives up
+# for itself, so this runs as root too.
+
+. "$TEST_LIB/common.sh"
+
+_require_cap FUSE_CAP_HANDLE_KILLPRIV_V2
+
+"$FUSE_TEST_BIN_DIR/test_setattr" --kill-suidgid "$TEST_MNT"
+"$FUSE_TEST_BIN_DIR/test_setattr" --kill-suidgid --write-buf "$TEST_MNT"
+
+# A filesystem that did not negotiate KILLPRIV_V2 must never see
+# fi->kill_suidgid, even though fuse_direct_io() still puts
+# FUSE_WRITE_KILL_SUIDGID on the wire.
+"$FUSE_TEST_BIN_DIR/test_setattr" --kill-suidgid --no-killpriv "$TEST_MNT"

--- a/test/cases/examples/passthrough-hp-suid-nopassthrough.sh
+++ b/test/cases/examples/passthrough-hp-suid-nopassthrough.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# GROUP: examples passthrough
+# The same check with the write served by the daemon rather than by a backing
+# file, so both of passthrough_hp's write paths get the same assertion.
+
+FS_ARGS="--foreground --nopassthrough"
+
+. "$TEST_LIB/passthrough-suid.sh"

--- a/test/cases/examples/passthrough-hp-suid.sh
+++ b/test/cases/examples/passthrough-hp-suid.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# GROUP: examples passthrough
+# In passthrough mode the daemon never sees the write, so clearing setuid and
+# setgid can only come from the kernel side of the handoff. A backing file needs
+# CAP_SYS_ADMIN, hence the root daemon; --debug is what makes passthrough_hp
+# name the backing file it installs.
+
+. "$TEST_LIB/common.sh"
+
+_require_cap FUSE_CAP_PASSTHROUGH
+_require_root
+
+FS_ARGS="--foreground --debug"
+PT_WANT_BACKING=1
+
+. "$TEST_LIB/passthrough-suid.sh"

--- a/test/cases/lib/checks.py
+++ b/test/cases/lib/checks.py
@@ -14,6 +14,7 @@ or the \\040 escapes subtly wrong.
 """
 
 import argparse
+import ctypes
 import errno
 import filecmp
 import os
@@ -61,6 +62,43 @@ name_generator.counter = 0
 def _require(condition, message):
     if not condition:
         raise CheckFailed(message)
+
+
+# capabilities(7); no Python binding exposes either constant.
+_LINUX_CAPABILITY_VERSION_3 = 0x20080522
+_CAP_FSETID = 4
+
+
+class _CapHeader(ctypes.Structure):
+    _fields_ = [('version', ctypes.c_uint32), ('pid', ctypes.c_int)]
+
+
+class _CapData(ctypes.Structure):
+    _fields_ = [('effective', ctypes.c_uint32),
+                ('permitted', ctypes.c_uint32),
+                ('inheritable', ctypes.c_uint32)]
+
+
+def drop_cap_fsetid():
+    """Clear CAP_FSETID from this process's effective set.
+
+    A caller holding it is exempt from suid/sgid stripping, so a check that
+    wants to see the bits go would otherwise be asserting that nothing
+    happens. Each check is its own process, so losing the capability for the
+    rest of it costs nothing. Unprivileged callers do not hold it and take the
+    early return.
+    """
+    libc = ctypes.CDLL(None, use_errno=True)
+    header = _CapHeader(_LINUX_CAPABILITY_VERSION_3, 0)
+    # Version 3 spans 64 capabilities, so capget writes two data words.
+    data = (_CapData * 2)()
+    if libc.capget(ctypes.byref(header), ctypes.byref(data)) != 0:
+        raise OSError(ctypes.get_errno(), 'capget failed')
+    if not data[0].effective & (1 << _CAP_FSETID):
+        return
+    data[0].effective &= ~(1 << _CAP_FSETID)
+    if libc.capset(ctypes.byref(header), ctypes.byref(data)) != 0:
+        raise OSError(ctypes.get_errno(), 'capset failed')
 
 
 def readdir_inode(path):
@@ -114,6 +152,61 @@ def expect_enoent(path):
 
 
 # ----------------------------------------------------------- POSIX operations
+
+def cmd_suidgid_dropped(mnt_dir, src_dir):
+    """A write or fallocate without CAP_FSETID has to clear setuid and setgid.
+
+    Checked on the backing file, not through the mount: with attribute caching
+    on, the mount is allowed a stale view of the mode.
+
+    The capability goes after the chmod, so this runs the same whether or not
+    the suite is root. passthrough mode needs a root daemon, CAP_SYS_ADMIN
+    being required to open a backing file, so the two cannot be separated by
+    running the whole case unprivileged.
+
+    Only a root daemon discriminates, for either operation: an unprivileged one
+    has no CAP_FSETID either, so the backing filesystem clears the bits on its
+    own and the check passes whatever the filesystem under test does.
+    """
+    name = name_generator()
+    mnt_path = pjoin(mnt_dir, name)
+    src_path = pjoin(src_dir, name)
+
+    with open(mnt_path, 'wb') as fh:
+        fh.write(b'hello')
+
+    # Group execute as well, so the sgid bit is a real sgid and not a
+    # mandatory locking mark, which the kernel leaves alone.
+    mode = stat.S_ISUID | stat.S_ISGID | 0o755
+    os.chmod(mnt_path, mode)
+    _require(stat.S_IMODE(os.stat(src_path).st_mode) == mode,
+             'chmod 0%o did not reach the backing file' % mode)
+
+    drop_cap_fsetid()
+    with open(mnt_path, 'ab') as fh:
+        fh.write(b'more')
+
+    got = stat.S_IMODE(os.stat(src_path).st_mode)
+    _require(got == 0o755,
+             'a write left the backing mode at 0%o, expected 0755' % got)
+
+    # KILLPRIV_V2 has no fallocate flag, so a filesystem acting only on
+    # FUSE_WRITE_KILL_SUIDGID leaves setuid and setgid set here.
+    os.chmod(mnt_path, mode)
+    with open(mnt_path, 'r+b') as fh:
+        try:
+            os.posix_fallocate(fh.fileno(), 0, 8192)
+        except OSError as exc:
+            if exc.errno not in (errno.EOPNOTSUPP, errno.ENOSYS):
+                raise
+            os.unlink(mnt_path)
+            return
+
+    got = stat.S_IMODE(os.stat(src_path).st_mode)
+    _require(got == 0o755,
+             'a fallocate left the backing mode at 0%o, expected 0755' % got)
+    os.unlink(mnt_path)
+
 
 def cmd_unlink(mnt_dir, src_dir=None):
     name = name_generator()
@@ -966,6 +1059,7 @@ def build_parser():
     add('fuse_test_utimens', cmd_utimens, 'mnt', ns_tol={'default': 0})
     add('fuse_test_passthrough', cmd_passthrough, 'src', 'mnt',
         inode_check=_INODE_CHECK)
+    add('fuse_test_suidgid_dropped', cmd_suidgid_dropped, 'mnt', 'src')
     add('fuse_test_xattr', cmd_xattr, 'path')
 
     add('fuse_test_expect_errno', cmd_expect_errno, 'want', 'op',

--- a/test/cases/lib/passthrough-suid.sh
+++ b/test/cases/lib/passthrough-suid.sh
@@ -1,0 +1,36 @@
+# lib/passthrough-suid.sh - body for the passthrough_hp setuid cases.
+#
+# Caller sets before sourcing:
+#   FS_ARGS           passthrough_hp arguments, without source and mountpoint
+#   PT_WANT_BACKING   1 when the run has to install a backing file, so writes
+#                     really do bypass the daemon
+#
+# A write by a caller without CAP_FSETID has to clear setuid and setgid, as it
+# would on a local filesystem. passthrough_hp is the interesting case: it
+# issues the backing write under its own credentials, which normally hold
+# CAP_FSETID, so the backing filesystem never strips the bits. They go away
+# only because the FUSE kernel strips them first - in passthrough mode from
+# backing_file_write_iter(), before those credentials are installed.
+#
+# No uid requirement here: checks.py drops CAP_FSETID for the write itself,
+# which a case that needs a root daemon for passthrough could not do by
+# running unprivileged.
+
+. "$TEST_LIB/common.sh"
+
+fuse_mount_at "$TEST_MNT" passthrough_hp $FS_ARGS "$TEST_SRC" >/dev/null
+
+_check fuse_test_suidgid_dropped "$TEST_MNT" "$TEST_SRC"
+
+# After fuse_test_suidgid_dropped and not before it: passthrough_hp installs
+# the backing file on the first open of an inode, and that open happens inside
+# the check, so a wait placed ahead of it can only ever time out.
+#
+# The FUSE_INIT capability list is no help either: passthrough_hp offers
+# FUSE_CAP_PASSTHROUGH whatever --nopassthrough says, and only declines to
+# install a backing file. passthrough_hp names that backing file under
+# --debug, and a backing file is what makes a write bypass the daemon.
+[ "${PT_WANT_BACKING:-0}" != 1 ] ||
+	_wait_fs_marker 'setup shared backing file'
+
+fuse_umount

--- a/test/cases/lib/passthrough-suid.sh
+++ b/test/cases/lib/passthrough-suid.sh
@@ -8,9 +8,12 @@
 # A write by a caller without CAP_FSETID has to clear setuid and setgid, as it
 # would on a local filesystem. passthrough_hp is the interesting case: it
 # issues the backing write under its own credentials, which normally hold
-# CAP_FSETID, so the backing filesystem never strips the bits. They go away
-# only because the FUSE kernel strips them first - in passthrough mode from
-# backing_file_write_iter(), before those credentials are installed.
+# CAP_FSETID, so the backing filesystem never clears setuid/setgid.
+#
+# What does clear them differs per mode, which is why both are covered:
+# passthrough_hp negotiates KILLPRIV_V2 only with --nopassthrough and clears
+# them itself on fi->kill_suidgid; in passthrough mode the FUSE kernel does it
+# from backing_file_write_iter(), before those credentials are installed.
 #
 # No uid requirement here: checks.py drops CAP_FSETID for the write itself,
 # which a case that needs a root daemon for passthrough could not do by

--- a/test/test_setattr.c
+++ b/test/test_setattr.c
@@ -12,6 +12,9 @@
  * can tell which open file the request belongs to. ftruncate() is used to
  * trigger it, as chmod_common() in the kernel does not pass the struct file
  * down and fchmod() would therefore never carry a handle.
+ *
+ * With --kill-suidgid it also checks that the KILLPRIV_V2 request to drop
+ * suid/sgid reaches open, create and write as fi->kill_suidgid.
  */
 
 #define FUSE_USE_VERSION FUSE_MAKE_VERSION(3, 19)
@@ -35,14 +38,79 @@
 #include <limits.h>
 #else
 #include <linux/limits.h>
+#include <linux/capability.h>
+#include <sys/syscall.h>
 #endif
 
 #define FILE_INO 2
 #define FILE_NAME "truncate_me"
 #define FILE_SIZE 4096
+#define NEW_INO 3
+#define NEW_NAME "create_me"
+
+struct options {
+	int kill_suidgid;
+	int no_killpriv;
+	int write_buf;
+} options;
+
+#define OPTION(t, p) { t, offsetof(struct options, p), 1 }
+static const struct fuse_opt option_spec[] = {
+	OPTION("--kill-suidgid", kill_suidgid),
+	OPTION("--no-killpriv", no_killpriv),
+	OPTION("--write-buf", write_buf),
+	FUSE_OPT_END
+};
 
 static int got_fh;
 static off_t file_size;
+
+/*
+ * fi->kill_suidgid as each operation saw it, -1 until the operation runs. An
+ * operation that never happens must not be mistaken for one that reported a
+ * cleared flag, which is what the --no-killpriv run expects to see.
+ */
+static int seen_create = -1;
+static int seen_open = -1;
+static int seen_write = -1;
+
+/*
+ * The kernel sets FUSE_OPEN_KILL_SUIDGID and FUSE_WRITE_KILL_SUIDGID only for
+ * a caller without CAP_FSETID, so a root test process has to give it up.
+ */
+static void drop_cap_fsetid(void)
+{
+#ifdef __linux__
+	struct __user_cap_header_struct hdr = {
+		.version = _LINUX_CAPABILITY_VERSION_3,
+		.pid = 0,
+	};
+	struct __user_cap_data_struct data[2];
+
+	assert(syscall(SYS_capget, &hdr, data) == 0);
+	if (!(data[0].effective & (1U << CAP_FSETID)))
+		return;
+
+	data[0].effective &= ~(1U << CAP_FSETID);
+	assert(syscall(SYS_capset, &hdr, data) == 0);
+#endif
+}
+
+static void tfs_init(void *userdata, struct fuse_conn_info *conn)
+{
+	(void)userdata;
+
+	if (!options.kill_suidgid)
+		return;
+
+	/* The test case gates on FUSE_CAP_HANDLE_KILLPRIV_V2 before this */
+	assert(fuse_get_feature_flag(conn, FUSE_CAP_HANDLE_KILLPRIV_V2));
+
+	if (options.no_killpriv)
+		fuse_unset_feature_flag(conn, FUSE_CAP_HANDLE_KILLPRIV_V2);
+	else
+		fuse_set_feature_flag(conn, FUSE_CAP_HANDLE_KILLPRIV_V2);
+}
 
 static int tfs_stat(fuse_ino_t ino, struct stat *stbuf)
 {
@@ -52,10 +120,10 @@ static int tfs_stat(fuse_ino_t ino, struct stat *stbuf)
 		stbuf->st_nlink = 1;
 	}
 
-	else if (ino == FILE_INO) {
+	else if (ino == FILE_INO || ino == NEW_INO) {
 		stbuf->st_mode = S_IFREG | 0644;
 		stbuf->st_nlink = 1;
-		stbuf->st_size = file_size;
+		stbuf->st_size = ino == FILE_INO ? file_size : 0;
 	}
 
 	else
@@ -105,9 +173,62 @@ static void tfs_open(fuse_req_t req, fuse_ino_t ino, struct fuse_file_info *fi)
 		fuse_reply_err(req, EISDIR);
 	else {
 		assert(ino == FILE_INO);
+		/* The kernel sets FUSE_OPEN_KILL_SUIDGID only on O_TRUNC */
+		if (fi->flags & O_TRUNC)
+			seen_open = fi->kill_suidgid;
 		fi->fh = FILE_INO;
 		fuse_reply_open(req, fi);
 	}
+}
+
+static void tfs_create(fuse_req_t req, fuse_ino_t parent, const char *name,
+		       mode_t mode, struct fuse_file_info *fi)
+{
+	struct fuse_entry_param e;
+
+	(void)mode;
+
+	if (parent != FUSE_ROOT_ID || strcmp(name, NEW_NAME) != 0) {
+		fuse_reply_err(req, EINVAL);
+		return;
+	}
+
+	seen_create = fi->kill_suidgid;
+	fi->fh = NEW_INO;
+
+	/*
+	 * Puts the write on fuse_direct_io(), which sets
+	 * FUSE_WRITE_KILL_SUIDGID without checking handle_killpriv_v2, and
+	 * delivers it before write() returns.
+	 */
+	fi->direct_io = 1;
+
+	memset(&e, 0, sizeof(e));
+	e.ino = NEW_INO;
+	assert(tfs_stat(e.ino, &e.attr) == 0);
+	fuse_reply_create(req, &e, fi);
+}
+
+static void tfs_write(fuse_req_t req, fuse_ino_t ino, const char *buf,
+		      size_t size, off_t off, struct fuse_file_info *fi)
+{
+	(void)ino;
+	(void)buf;
+	(void)off;
+
+	seen_write = fi->kill_suidgid;
+	fuse_reply_write(req, size);
+}
+
+static void tfs_write_buf(fuse_req_t req, fuse_ino_t ino,
+			  struct fuse_bufvec *bufv, off_t off,
+			  struct fuse_file_info *fi)
+{
+	(void)ino;
+	(void)off;
+
+	seen_write = fi->kill_suidgid;
+	fuse_reply_write(req, fuse_buf_size(bufv));
 }
 
 static void tfs_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
@@ -132,9 +253,12 @@ static void tfs_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
 }
 
 static struct fuse_lowlevel_ops tfs_oper = {
+	.init = tfs_init,
 	.lookup = tfs_lookup,
 	.getattr = tfs_getattr,
 	.open = tfs_open,
+	.create = tfs_create,
+	.write = tfs_write,
 	.setattr = tfs_setattr,
 };
 
@@ -162,6 +286,40 @@ static void test_fs(const char *mountpoint)
 	assert(fstat(fd, &stbuf) == 0);
 	assert(stbuf.st_size == FILE_SIZE);
 	assert(close(fd) == 0);
+
+	if (!options.kill_suidgid)
+		return;
+
+	drop_cap_fsetid();
+
+	/* O_TRUNC, no O_EXCL: CREATE carries FUSE_OPEN_KILL_SUIDGID */
+	assert(snprintf(fname, PATH_MAX, "%s/" NEW_NAME, mountpoint) > 0);
+	fd = open(fname, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+	if (fd == -1) {
+		perror(fname);
+		assert(0);
+	}
+	assert(write(fd, "x", 1) == 1);
+	assert(close(fd) == 0);
+
+	/* O_TRUNC on an existing file: OPEN carries FUSE_OPEN_KILL_SUIDGID */
+	assert(snprintf(fname, PATH_MAX, "%s/" FILE_NAME, mountpoint) > 0);
+	fd = open(fname, O_WRONLY | O_TRUNC);
+	if (fd == -1) {
+		perror(fname);
+		assert(0);
+	}
+	assert(close(fd) == 0);
+}
+
+static void check_kill_suidgid(const char *op, int got, int expected)
+{
+	if (got == expected)
+		return;
+
+	fprintf(stderr, "ERROR: %s: kill_suidgid is %d, expected %d\n", op, got,
+		expected);
+	exit(1);
 }
 
 int main(int argc, char *argv[])
@@ -171,10 +329,16 @@ int main(int argc, char *argv[])
 	struct fuse_cmdline_opts fuse_opts;
 	pthread_t fs_thread;
 
+	assert(fuse_opt_parse(&args, &options, option_spec, NULL) == 0);
 	assert(fuse_parse_cmdline(&args, &fuse_opts) == 0);
 #ifndef __FreeBSD__
 	assert(fuse_opt_add_arg(&args, "-oauto_unmount") == 0);
 #endif
+	if (options.write_buf) {
+		tfs_oper.write = NULL;
+		tfs_oper.write_buf = tfs_write_buf;
+	}
+
 	se = fuse_session_new(&args, &tfs_oper, sizeof(tfs_oper), NULL);
 	fuse_opt_free_args(&args);
 	assert(se != NULL);
@@ -194,6 +358,15 @@ int main(int argc, char *argv[])
 	assert(pthread_join(fs_thread, NULL) == 0);
 
 	assert(got_fh == 1);
+
+	if (options.kill_suidgid) {
+		int expected = options.no_killpriv ? 0 : 1;
+
+		check_kill_suidgid("create", seen_create, expected);
+		check_kill_suidgid("open", seen_open, expected);
+		check_kill_suidgid("write", seen_write, expected);
+	}
+
 	fuse_remove_signal_handlers(se);
 	fuse_session_destroy(se);
 


### PR DESCRIPTION
[updated version of PR #1580 ]

With FUSE_CAP_HANDLE_KILLPRIV_V2 the kernel stops clearing suid/sgid and security.capability itself and tells the server per request when to do it. Of the three flags carrying that request only FATTR_KILL_SUIDGID made it through, because FUSE_SET_ATTR_KILL_SUID happens to be the same bit. FUSE_OPEN_KILL_SUIDGID and FUSE_WRITE_KILL_SUIDGID were dropped, so a server that negotiated KILLPRIV_V2 never saw the request on O_TRUNC open and on write, and the bits survived.

Decode both into a new fuse_file_info::kill_suidgid, taken from the padding bits, in open, create, write and write_buf. In create the flag sits in fuse_create_in::open_flags, which only exists since 7.12, hence the existing proto_minor guard.