### PR TITLE
docs: the fuse-devel list moved to lists.linux.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ directory and at http://libfuse.github.io/doxygen.
 Getting Help
 ------------
 
-If you need help, please ask on the <fuse-devel@lists.sourceforge.net>
-mailing list (subscribe at
-https://lists.sourceforge.net/lists/listinfo/fuse-devel).
+If you need help, please ask on the <fuse-devel@lists.linux.dev>
+mailing list (subscribe by mailing
+<fuse-devel+subscribe@lists.linux.dev>, archive at
+https://lore.kernel.org/fuse-devel/).
 
 Please report any bugs on the GitHub issue tracker at
 https://github.com/libfuse/libfuse/issues.

--- a/dev-docs/release-process.md
+++ b/dev-docs/release-process.md
@@ -33,7 +33,7 @@ Release Process
 Announcement email template
 
 ```
-To: fuse-devel@lists.sourceforge.net
+To: fuse-devel@lists.linux.dev
 Subject: [ANNOUNCE] libfuse XXXX has been released
 
 Dear all,


### PR DESCRIPTION
The sourceforge address in the README is the only contact the project gives, and the release announcement template mails it too.