### PR TITLE
fuse_uring: defer REGISTER until the connection is initialized

### DIFF
--- a/lib/fuse_i.h
+++ b/lib/fuse_i.h
@@ -71,7 +71,8 @@ struct fuse_notify_req {
 };
 
 struct fuse_session_uring {
-	bool enable;
+	/* the wish until FUSE_INIT is negotiated, the result afterwards */
+	bool enabled;
 	unsigned int q_depth;
 	struct fuse_ring_pool *pool;
 };

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -3157,7 +3157,17 @@ _do_init(fuse_req_t req, const fuse_ino_t nodeid, const void *op_in,
 	se->got_init = 1;
 	fuse_daemonize_set_got_init();
 	send_reply_ok(req, &outarg, outargsize);
-	if (enable_io_uring)
+	/*
+	 * With async init, send_reply_ok() has already marked the connection
+	 * initialized (that happens in the reply write()), so the ring threads
+	 * can send REGISTER now. With sync init, _do_init() runs on the
+	 * sync-init worker thread while the mount is still in progress. The
+	 * connection is not initialized until the mount completes, which is
+	 * after _do_init() returns. Waking the ring threads here would let
+	 * REGISTER race ahead of initialization and get -EAGAIN, so defer the
+	 * wake to fuse_session_mount_new_api() after the mount returns.
+	 */
+	if (enable_io_uring && !se->is_sync_init)
 		fuse_uring_wake_ring_threads(se);
 
 	/*
@@ -5179,6 +5189,15 @@ err:
 	/* Wait for synchronous FUSE_INIT to complete */
 	if (session_wait_sync_init_completion(se) < 0)
 		fuse_log(FUSE_LOG_ERR, "fuse: sync init completion failed\n");
+
+	/*
+	 * For sync init the ring threads were not woken in _do_init() because
+	 * the connection was not yet initialized. Now that the mount has
+	 * completed, the connection is initialized and REGISTER can be sent, so
+	 * wake them here
+	 */
+	if (se->is_sync_init && se->uring.enabled)
+		fuse_uring_wake_ring_threads(se);
 
 	free(mtab_opts);
 	free(mtab_opts_with_fd);

--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -2773,7 +2773,7 @@ static void report_init_test_status(struct fuse_session *se, int ring_rc)
 				      strerror(-ring_rc));
 	else if (se->io != NULL)
 		EMIT_INIT_STATUS_LINE("io_uring=off:custom_io");
-	else if (!se->uring.enable)
+	else if (!se->uring.enabled)
 		EMIT_INIT_STATUS_LINE("io_uring=off:disabled");
 	else
 		EMIT_INIT_STATUS_LINE("io_uring=off:not_offered");
@@ -3062,7 +3062,7 @@ _do_init(fuse_req_t req, const fuse_ino_t nodeid, const void *op_in,
 	}
 	if (se->conn.want_ext & FUSE_CAP_NO_EXPORT_SUPPORT)
 		outargflags |= FUSE_NO_EXPORT_SUPPORT;
-	if (se->uring.enable && se->conn.want_ext & FUSE_CAP_OVER_IO_URING) {
+	if (se->uring.enabled && se->conn.want_ext & FUSE_CAP_OVER_IO_URING) {
 		outargflags |= FUSE_OVER_IO_URING;
 		enable_io_uring = true;
 	}
@@ -3134,6 +3134,13 @@ _do_init(fuse_req_t req, const fuse_ino_t nodeid, const void *op_in,
 		fuse_unset_feature_flag(&se->conn, FUSE_CAP_OVER_IO_URING);
 
 	report_init_test_status(se, ring_rc);
+
+	/*
+	 * Only now, after the report has had its look at the wish - later
+	 * phases need to know whether the ring came up, not whether it was
+	 * asked for.
+	 */
+	se->uring.enabled = enable_io_uring;
 
 	if (inargflags & FUSE_INIT_EXT) {
 		outargflags |= FUSE_INIT_EXT;
@@ -4237,7 +4244,7 @@ static const struct fuse_opt fuse_ll_opts[] = {
 	LL_OPTION("-d", debug, 1),
 	LL_OPTION("--debug", debug, 1),
 	LL_OPTION("allow_root", deny_others, 1),
-	LL_OPTION("io_uring", uring.enable, 1),
+	LL_OPTION("io_uring", uring.enabled, 1),
 	LL_OPTION("io_uring_q_depth=%u", uring.q_depth, -1),
 	FUSE_OPT_END
 };
@@ -4629,7 +4636,7 @@ fuse_session_new_versioned(struct fuse_args *args,
 	 * Allow overriding with env, mostly to avoid the need to modify
 	 * all tests. I.e. to test with and without io-uring being enabled.
 	 */
-	se->uring.enable = getenv("FUSE_URING_ENABLE") ?
+	se->uring.enabled = getenv("FUSE_URING_ENABLE") ?
 				   atoi(getenv("FUSE_URING_ENABLE")) :
 				   SESSION_DEF_URING_ENABLE;
 	se->uring.q_depth = getenv("FUSE_URING_QUEUE_DEPTH") ?
@@ -4790,7 +4797,7 @@ int fuse_session_custom_io_317(struct fuse_session *se,
 	 * refusing would let a stray variable break an application that never
 	 * asked for it.
 	 */
-	se->uring.enable = 0;
+	se->uring.enabled = 0;
 	return 0;
 }
 


### PR DESCRIPTION
The io-uring ring threads send FUSE_IO_URING_CMD_REGISTER once they are woken from init_sem. They were woken in _do_init() right after send_reply_ok().

With async init this is fine since send_reply_ok() writes the FUSE_INIT reply and the kernel marks the connection initialized before write() returns, which means when the ring threads submit REGISTER, the connection is already initialized.

With sync init however, this races. _do_init() runs on the sync-init worker thread while the mount is still in progress, and the connection is not marked initialized until the mount completes (which happens after _do_init() returns). Waking the ring threads in _do_init() therefore lets REGISTER reach the kernel before initialization, and the kernel returns -EAGAIN.

Only wake the ring threads in _do_init() for async init, and for sync init defer the wake to fuse_session_mount_new_api() after the mount has completed and the connection is initialized. Sync init is only supported via the new mount API, so that is the only place the deferred wake is needed. se->is_sync_init is not set yet in _do_init(), so async is detected there via init_wakeup_fd == -1.

Signed-off-by: Joanne Koong [joannelkoong@gmail.com](mailto:joannelkoong@gmail.com)