### PR TITLE
fusermount: don't try opening mnt with privs during auto_umount

### DIFF
--- a/.github/workflows/abicheck_prev_release.yml
+++ b/.github/workflows/abicheck_prev_release.yml
@@ -1,5 +1,5 @@
 ---
-name: 'libfuse ABI check'
+name: 'libfuse ABI check against previous major release'
 
 on:
   push:
@@ -31,11 +31,20 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: current
+          fetch-depth: 0  # Fetch all history and tags
+
+      - name: Determine previous major release tag
+        id: prev_release
+        run: |
+          cd current
+          chmod +x .github/workflows/find_previous_release_tag.sh
+          PREV_TAG=$(.github/workflows/find_previous_release_tag.sh)
+          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: previous
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ steps.prev_release.outputs.prev_tag }}
 
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
@@ -51,7 +60,8 @@ jobs:
       - name: Build previous
         working-directory: previous
         run: |
-          echo "Commit-id before PR: $(git show HEAD)"
+          echo "Previous release tag: ${{ steps.prev_release.outputs.prev_tag }}"
+          echo "Commit-id of previous release: $(git show HEAD)"
           pip install -r requirements.txt
           meson setup build --buildtype=debug
           meson compile -C build

--- a/.github/workflows/abidiff_suppressions.abignore
+++ b/.github/workflows/abidiff_suppressions.abignore
@@ -1,0 +1,36 @@
+# Suppression file for abidiff false positives in libfuse
+# This file suppresses ABI changes that are actually compatible but flagged by abidiff
+
+[suppress_type]
+# Suppress the fuse_conn_info reserved array transformation
+# This change is ABI-compatible: uint32_t[16] -> uint16_t request_timeout + uint16_t[31]
+# Both use exactly 64 bytes (16*4 = 32*2 = 64 bytes)
+name = fuse_conn_info
+# Suppress changes to the reserved field that are size/offset related
+change_kind = size-or-offset-change
+has_data_member_inserted_at = offset_in_bits(512)
+
+[suppress_type]
+# Also suppress the general struct size change for fuse_conn_info
+# since the total size remains the same (128 bytes) by a static assertion
+# in the code
+name = fuse_conn_info
+change_kind = size-change
+
+[suppress_type]
+# Suppress ALL changes to fuse_operations struct
+# These are backward compatible due to the op_size mechanism in fuse_main()
+# Applications pass sizeof(struct fuse_operations) at compile time,
+# and the library uses memcpy(&fs->op, op, op_size) to safely copy only
+# the fields the application knows about. New fields remain NULL.
+name = fuse_operations
+has_data_member_inserted_at = end
+has_size_change = yes
+
+[suppress_type]
+# Suppress ALL changes to fuse_lowlevel_ops struct
+# These are backward compatible due to the op_size mechanism in fuse_session_new()
+# Same pattern as fuse_operations - op_size controls safe copying
+name = fuse_lowlevel_ops
+has_data_member_inserted_at = end
+has_size_change = yes

--- a/.github/workflows/find_previous_release_tag.sh
+++ b/.github/workflows/find_previous_release_tag.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+
+# Script to find the previous major release tag for libfuse
+# Usage: ./find_previous_release_tag.sh
+
+# Get current version from meson.build
+# Pattern matches: version : "3.18.0" or version: '3.18.0'
+VERSION_PATTERN="version\s*:\s*['\"]"
+VERSION_EXTRACT="s/.*version\s*:\s*['\"]([^'\"]+)['\"].*/\1/"
+
+CURRENT_VERSION=$(grep -E "$VERSION_PATTERN" meson.build | \
+                  sed -E "$VERSION_EXTRACT")
+echo "Current version: $CURRENT_VERSION" >&2
+
+# Extract major.minor version (e.g., 3.18 from 3.18.0)
+# Pattern captures first two numbers separated by dot
+MAJOR_MINOR_PATTERN='s/^([0-9]+\.[0-9]+).*/\1/'
+
+CURRENT_MAJOR_MINOR=$(echo "$CURRENT_VERSION" | \
+                      sed -E "$MAJOR_MINOR_PATTERN")
+echo "Current major.minor: $CURRENT_MAJOR_MINOR" >&2
+
+# Get all major.minor versions from tags, sort them, and find the one before
+# current
+# Pattern matches tags like: fuse-3.17.0, fuse-3.18.1, etc.
+FUSE_TAG_PATTERN="^fuse-[0-9]+\.[0-9]+"
+# Pattern extracts major.minor from version strings
+TAG_MAJOR_MINOR_PATTERN='s/^([0-9]+\.[0-9]+).*/\1/'
+
+ALL_MAJOR_MINOR=$(git tag --list | \
+                  grep -E "$FUSE_TAG_PATTERN" | \
+                  sed 's/fuse-//' | \
+                  sed -E "$TAG_MAJOR_MINOR_PATTERN" | \
+                  sort -V -u)
+echo "All major.minor versions found:" >&2
+echo "$ALL_MAJOR_MINOR" >&2
+
+# Find the previous major.minor version
+PREV_MAJOR_MINOR=$(echo "$ALL_MAJOR_MINOR" | \
+                   grep -B1 "^${CURRENT_MAJOR_MINOR}$" | \
+                   head -1)
+
+if [ -z "$PREV_MAJOR_MINOR" ] || [ "$PREV_MAJOR_MINOR" = "$CURRENT_MAJOR_MINOR" ]; then
+    echo "Error: No previous major.minor version found before $CURRENT_MAJOR_MINOR" >&2
+    exit 1
+fi
+
+echo "Previous major.minor: $PREV_MAJOR_MINOR" >&2
+
+# Get the latest tag for the previous major.minor version
+# Pattern matches tags like: fuse-3.17.0, fuse-3.17.1, fuse-3.17.2, etc.
+PREV_TAG_PATTERN="^fuse-${PREV_MAJOR_MINOR}\.[0-9]+"
+
+PREV_TAG=$(git tag --list | \
+           grep -E "$PREV_TAG_PATTERN" | \
+           sort -V | \
+           tail -1)
+
+if [ -z "$PREV_TAG" ]; then
+    echo "Error: No previous major release tag found for version $PREV_MAJOR_MINOR" >&2
+    exit 1
+fi
+
+echo "Previous release tag: $PREV_TAG" >&2
+
+# Output the tag to stdout (this is what the workflow will capture)
+echo "$PREV_TAG"

--- a/AUTHORS
+++ b/AUTHORS
@@ -260,6 +260,25 @@ Tyler Hall <tylerwhall@gmail.com>
 yangyun <yangyun50@huawei.com>
 Abhishek <abhi_45645@yahoo.com>
 
-# New authors since 666b2c3fa5159e3c72a0d08117507475117c9319
+# New authors since fuse-3.17.1
 Luis Henriques <luis@igalia.com>
 Zegang <zegang.luo@qq.com>
+swj <1186093704@qq.com>
+Gleb Popov <6yearold@gmail.com>
+WekaJosh <80121792+WekaJosh@users.noreply.github.com>
+Alexander Monakov <amonakov@ispras.ru>
+Ben Dooks <ben.dooks@codethink.co.uk>
+Ben Linsay <blinsay@gmail.com>
+Dave Vasilevsky <dave@vasilevsky.ca>
+Darrick J. Wong <djwong@kernel.org>
+Georgi Valkov <gvalkov@gmail.com>
+Alik Aslanyan <inline0@pm.me>
+jnr0006 <jacob.nick.riley@gmail.com>
+Jingbo Xu <jefflexu@linux.alibaba.com>
+Long Li <leo.lilong@huawei.com>
+Maksim Harbachou <maksim.harbachou@resilio.com>
+Meng Lu Wang <mwang@ddn.com>
+Vassili Tchersky <vt+git@vbc.su>
+Vassili Tchersky <vt+git@vbcy.org>
+izxl007 <zeng.zheng@zte.com.cn>
+Zeno Sebastian Endemann <zeno.endemann@mailbox.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -282,3 +282,6 @@ Vassili Tchersky <vt+git@vbc.su>
 Vassili Tchersky <vt+git@vbcy.org>
 izxl007 <zeng.zheng@zte.com.cn>
 Zeno Sebastian Endemann <zeno.endemann@mailbox.org>
+
+# New authors since fuse-3.18.1
+Abhinav Agarwal <abhinavagarwal1996@gmail.com>

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,81 @@
-libfuse 3.18
+libfuse 3.18.0 (2025-12-18)
+===========================
 
-libfuse 3.17.1-rc0 (2024-02.10)
+New Features
+------------
+
+* fuse-over-io-uring communication
+* statx support
+* Request timeouts: Prevent hung operations
+* FUSE_NOTIFY_INC_EPOCH: New notification mechanism for epoch counters
+
+Important Fixes
+----------------
+
+* Fixed double unmount on FUSE_DESTROY
+* Fixed junk readdirplus results when filesystem doesn't fill stat info
+* Fixed memory deallocation in fuse_session_loop_remember
+* Fixed COPY_FILE_RANGE interface
+
+Platform Support
+----------------
+
+* Improved FreeBSD support (mount error reporting, test runner, build fixes)
+* Fixed 32-bit architecture builds
+* Fixed build with musl libc and older kernels (< 5.9)
+
+Other Improvements
+------------------
+
+* Added PanFS to fusermount whitelist
+* Thread naming support for easier debugging
+
+
+libfuse 3.17.4 (2025-08-19)
+===========================
+- Try to detect mount-utils by checking for /run/mount/utab
+  and don't try to update mtab if it does not exist
+- Fix a build warning when HAVE_BACKTRACE is undefined
+- fuse_loop_mt.c: fix close-on-exec flag on clone fd
+- Remove struct size assertions from fuse_common.h
+
+libfuse 3.17.3 (2025-07-16)
+===========================
+* more conn->want / conn->want_ext conversion fixes
+* Fix feature detection for close_range
+* Avoid double unmount on FUSE_DESTROY
+
+libfuse 3.17.2 (2025-04-23)
+===========================
+* Fixed uninitized bufsize value (compilation warning and real
+  issue when HAVE_SPLICE was not defined)
+* Fixed initialization races related to buffer realocation when
+  large buf sizes are used (/proc/sys/fs/fuse/max_pages_limit)
+* Fix build with kernel < 5.9
+* Fix static_assert build failure with C++ version < 11
+* Compilation fix (remove second fuse_main_real_versioned declaration)
+* Another conn.want flag conversion fix for high-level applications
+* Check if pthread_setname_np() exists before use it
+* fix example/memfs_ll rename deadlock error
+* signal handlers: Store fuse_session unconditionally and restore
+  previous behavior that with multiple sessions the last session
+  was used for the signal exist handler
+
+libfuse 3.17.1 (2025-03-24)
+===========================
+* fuse: Fix want conn.want flag conversion
+* Prevent re-usage of stdio FDs for fusermount
+* PanFS added to fusermount whitelist
+
+libfuse 3.17.1-rc1 (2025-02-18)
+===============================
+* several BSD fixes
+* x86 (32bit) build fixes
+* nested declarations moved out of the inlined functions to avoid
+  build warnings
+* signify public key added for future 3.18
+
+libfuse 3.17.1-rc0 (2025-02.10)
 ===============================
 
 * Fix libfuse build with FUSE_USE_VERSION 30
@@ -16,7 +91,7 @@ libfuse 3.17.1-rc0 (2024-02.10)
   exported to be able to silence leak checkers
 
 
-libfuse 3.17 (2024-01-01, not officially releaesed)
+libfuse 3.17 (2025-01-01, not officially releaesed)
 ==================================================
 
 * 3.11 and 3.14.2 introduced ABI incompatibilities, the ABI is restored

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,9 @@
+libfuse 3.18.1 (2025-12-20)
+===========================
+* Fix a critical ABI issue compared to libfuse-3.17.3+
+* Note: This breaks ABI compatibility to libfuse-3.18.0
+  (given that 3.18.0 is out for 2 days only, probably the lesser evil)
+
 libfuse 3.18.0 (2025-12-18)
 ===========================
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,9 @@
+libfuse 3.18.2 (2026-03-18)
+===========================
+* Fix two io-uring issues that might be security critical
+  * fuse-io-uring: Fix UAF and NULL deref in startup error path
+  * fuse-io-uring: Fix NULL deref and memory leak in fuse_uring_init_queue
+
 libfuse 3.18.1 (2025-12-20)
 ===========================
 * Fix a critical ABI issue compared to libfuse-3.17.3+

--- a/lib/fuse_uring.c
+++ b/lib/fuse_uring.c
@@ -759,7 +759,7 @@ static int fuse_uring_init_queue(struct fuse_ring_queue *queue)
 	if (res != 0) {
 		fuse_log(FUSE_LOG_ERR, "qid=%d io_uring init failed\n",
 			 queue->qid);
-		goto err;
+		return res;
 	}
 
 	queue->req_header_sz = ROUND_UP(sizeof(struct fuse_ring_ent),
@@ -777,10 +777,14 @@ static int fuse_uring_init_queue(struct fuse_ring_queue *queue)
 		 */
 		ring_ent->req_header =
 			numa_alloc_local(queue->req_header_sz);
+		if (!ring_ent->req_header)
+			return -ENOMEM;
 		ring_ent->req_payload_sz = ring->max_req_payload_sz;
 
 		ring_ent->op_payload =
 			numa_alloc_local(ring_ent->req_payload_sz);
+		if (!ring_ent->op_payload)
+			return -ENOMEM;
 
 		req->se = se;
 		pthread_mutex_init(&req->lock, NULL);
@@ -796,13 +800,10 @@ static int fuse_uring_init_queue(struct fuse_ring_queue *queue)
 			"Grave fuse-uring error on preparing SQEs, aborting\n");
 		se->error = -EIO;
 		fuse_session_exit(se);
+		return res;
 	}
 
 	return queue->ring.ring_fd;
-
-err:
-	close(queue->eventfd);
-	return res;
 }
 
 static void *fuse_uring_thread(void *arg)

--- a/lib/fuse_uring.c
+++ b/lib/fuse_uring.c
@@ -925,8 +925,9 @@ int fuse_uring_start(struct fuse_session *se)
 err:
 	if (err) {
 		/* Note all threads need to have been started */
-		fuse_session_destruct_uring(fuse_ring);
-		se->uring.pool = fuse_ring;
+		if (fuse_ring)
+			fuse_session_destruct_uring(fuse_ring);
+		se->uring.pool = NULL;
 	}
 	return err;
 }

--- a/lib/fuse_versionscript
+++ b/lib/fuse_versionscript
@@ -202,17 +202,21 @@ FUSE_3.17 {
 		fuse_log_close_syslog;
 } FUSE_3.12;
 
+FUSE_3.17.3 {
+	global:
+		fuse_set_feature_flag;
+		fuse_unset_feature_flag;
+		fuse_get_feature_flag;
+
+		# Not part of public API, for internal testing only
+		fuse_convert_to_conn_want_ext;
+} FUSE_3.17;
+
 FUSE_3.18 {
 	global:
 		fuse_req_is_uring;
 		fuse_req_get_payload;
-		fuse_set_feature_flag;
-		fuse_unset_feature_flag;
-		fuse_get_feature_flag;
 		fuse_lowlevel_notify_increment_epoch;
-
-		# Not part of public API, for internal test use only
-		fuse_convert_to_conn_want_ext;
 
 		fuse_reply_statx;
 		fuse_fs_statx;

--- a/make_release_tarball.sh
+++ b/make_release_tarball.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -x
 #
 # Create tarball from Git tag, removing and adding
 # some files.

--- a/make_release_tarball.sh
+++ b/make_release_tarball.sh
@@ -30,6 +30,7 @@ cp -a doc/html "${TAG}/doc/"
 tar -czf "${TAG}.tar.gz" "${TAG}/"
 
 signify-openbsd -S -s signify/$MAJOR_REV.sec -m $TAG.tar.gz
+signify-openbsd -V -m ${TAG}.tar.gz -p signify/.$MAJOR_REV.pub
 
 
 echo "Contributors from ${PREV_TAG} to ${TAG}:"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libfuse3', ['c'],
-        version: '3.18.0-rc0',  # Version with RC suffix
+        version: '3.18.0',
         meson_version: '>= 0.60.0',
         default_options: [
             'buildtype=debugoptimized',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libfuse3', ['c'],
-        version: '3.18.0',
+        version: '3.18.1',
         meson_version: '>= 0.60.0',
         default_options: [
             'buildtype=debugoptimized',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libfuse3', ['c'],
-        version: '3.18.1',
+        version: '3.18.2',
         meson_version: '>= 0.60.0',
         default_options: [
             'buildtype=debugoptimized',

--- a/signify/fuse-3.19.pub
+++ b/signify/fuse-3.19.pub
@@ -1,0 +1,2 @@
+untrusted comment: signify public key
+RWR4cEcMGJhD3Dnd3NOeJck3WiuVt9A7mrkq+nQYwrwwmMdDDAan/YiU

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1389,11 +1389,9 @@ static int send_fd(int sock_fd, int fd)
 
 /* Helper for should_auto_unmount
  *
- * fusermount typically has the s-bit set - initial open of `mnt` was as root
- * and got EACCESS as 'allow_other' was not specified.
- * Try opening `mnt` again with uid and guid of the calling process.
+ * Try opening `mnt` with uid and gid of the calling process.
  */
-static int recheck_ENOTCONN_as_owner(const char *mnt)
+static int check_ENOTCONN_as_owner(const char *mnt)
 {
 	int pid = fork();
 	if(pid == -1) {
@@ -1448,7 +1446,6 @@ static int should_auto_unmount(const char *mnt, const char *type)
 	char *copy;
 	const char *last;
 	int result = 0;
-	int fd;
 
 	copy = strdup(mnt);
 	if (copy == NULL) {
@@ -1461,23 +1458,7 @@ static int should_auto_unmount(const char *mnt, const char *type)
 	if (check_is_mount(last, mnt, type) == -1)
 		goto out;
 
-	fd = open(mnt, O_RDONLY);
-
-	if (fd != -1) {
-		close(fd);
-	} else {
-		switch(errno) {
-		case ENOTCONN:
-			result = 1;
-			break;
-		case EACCES:
-			result = recheck_ENOTCONN_as_owner(mnt);
-			break;
-		default:
-			result = 0;
-			break;
-		}
-	}
+	result = check_ENOTCONN_as_owner(mnt);
 out:
 	free(copy);
 	return result;


### PR DESCRIPTION
Always switch to original uid/gid before testing if opening mountpoint
would return ENOTCONN.

Otherwise it is possible for a malicious actor to replace the mountpint
with a symlink and allow opening/closing an attacker controlled path with
elevated privileges, possibly causing side effects.

Signed-off-by: Miklos Szeredi <mszeredi@redhat.com>
