### PR TITLE
fusermount: use unmount_fuse() on send_fd() failure

### DIFF
--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1835,12 +1835,7 @@ int main(int argc, char *argv[])
 
 		res = send_fd(cfd, fd);
 		if (res != 0) {
-			/*
-			 * euid 0 here and mnt is caller supplied - without
-			 * UMOUNT_NOFOLLOW a swapped symlink detaches an
-			 * unrelated mount.
-			 */
-			umount2(mnt, MNT_DETACH | UMOUNT_NOFOLLOW); /* lazy umount */
+			unmount_fuse(mnt, 1, 1); /* lazy umount */
 			goto err_out;
 		}
 		close(fd);


### PR DESCRIPTION
This is safer than using umount2() directly, since it does the all the
"fusermount -u" checks.

Signed-off-by: Miklos Szeredi <mszeredi@redhat.com>
