### PR TITLE
fusermount: don't try opening mnt with privs during auto_umount

### DIFF
--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -1486,11 +1486,9 @@ static int wait_for_signal(int sock_fd)
 
 /* Helper for should_auto_unmount
  *
- * fusermount typically has the s-bit set - initial open of `mnt` was as root
- * and got EACCESS as 'allow_other' was not specified.
- * Try opening `mnt` again with uid and guid of the calling process.
+ * Try opening `mnt` with uid and gid of the calling process.
  */
-static int recheck_ENOTCONN_as_owner(const char *mnt)
+static int check_ENOTCONN_as_owner(const char *mnt)
 {
 	int pid = fork();
 	if(pid == -1) {
@@ -1545,7 +1543,6 @@ static int should_auto_unmount(const char *mnt, const char *type)
 	char *copy;
 	const char *last;
 	int result = 0;
-	int fd;
 
 	copy = strdup(mnt);
 	if (copy == NULL) {
@@ -1558,24 +1555,7 @@ static int should_auto_unmount(const char *mnt, const char *type)
 	if (check_is_mount(last, mnt, type) == -1)
 		goto out;
 
-	fd = open(mnt, O_RDONLY);
-
-	if (fd != -1) {
-		close(fd);
-	} else {
-		switch(errno) {
-		case ENOTCONN:		/* /dev/fuse */
-		case ECONNABORTED:	/* io-uring */
-			result = 1;
-			break;
-		case EACCES:
-			result = recheck_ENOTCONN_as_owner(mnt);
-			break;
-		default:
-			result = 0;
-			break;
-		}
-	}
+	result = check_ENOTCONN_as_owner(mnt);
 out:
 	free(copy);
 	return result;


### PR DESCRIPTION
Always switch to original uid/gid before testing if opening mountpoint would return ENOTCONN.

Otherwise it is possible for a malicious actor to replace the mountpint with a symlink and allow opening/closing an attacker controlled path with elevated privileges, possibly causing side effects.


(cherry picked from commit a486808eca4712da8a4be179c239bdbf565563a3)