### PR TITLE
lib: skip the fusermount3 --sync-init fallback without sync init

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -5112,6 +5112,14 @@ static int fuse_session_mount_new_api(struct fuse_session *se,
 	if (err < 0 && errno == EPERM) {
 		char *fusermount_opts = NULL;
 
+		/*
+		 * Without sync init the handshake is pointless, and older
+		 * fusermount3 rejects --sync-init. Leave the new API;
+		 * fuse_session_mount() falls back to fuse_kern_mount().
+		 */
+		if (!se->is_sync_init)
+			goto err;
+
 		close(fd);
 		fd = -1;
 		se->fd = -1;


### PR DESCRIPTION
On EPERM the new mount API always falls back to fusermount3 --sync-init, without checking whether sync init is in use at all. fusermount3 grew that option only in 3.19, so an unprivileged mount against an older system binary logs two errors before fuse_session_mount() quietly retries via fuse_kern_mount(). Skip the fallback when sync init is off and go straight to the legacy path.