### PR TITLE
Avoid new mount api attempts when old fusermount is used

### DIFF
--- a/lib/fuse_lowlevel.c
+++ b/lib/fuse_lowlevel.c
@@ -5018,6 +5018,10 @@ static int new_api_fusermount(struct fuse_session *se,
 			      const char *mtab_opts,
 			      int *sock_fd, pid_t *fusermount_pid)
 {
+	const uint64_t required_features =
+		FUSERMOUNT_FEATURE_NEW_MOUNT_API |
+		FUSERMOUNT_FEATURE_SYNC_INIT;
+	uint64_t features;
 	int fd, err;
 
 	if (se->debug)
@@ -5027,6 +5031,14 @@ static int new_api_fusermount(struct fuse_session *se,
 	/* Terminate worker thread with wrong fd */
 	if (session_wait_sync_init_completion(se) < 0)
 		fuse_log(FUSE_LOG_ERR, "fuse: sync init completion failed\n");
+
+	features = fuse_mount_fusermount_features();
+	if ((features & required_features) != required_features) {
+		if (se->debug)
+			fuse_log(FUSE_LOG_DEBUG,
+				 "fuse: fusermount3 lacks new mount API sync-init support\n");
+		return -ENOTSUP;
+	}
 
 	/* Call fusermount3 with --sync-init */
 	fd = mount_fusermount_obtain_fd(mountpoint, se->mo, mtab_opts, sock_fd,

--- a/lib/mount.c
+++ b/lib/mount.c
@@ -18,6 +18,7 @@
 #include "mount_util.h"
 #include "mount_i_linux.h"
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -125,6 +126,238 @@ static int fusermount_posix_spawn(posix_spawn_file_actions_t *action,
 		waitpid(pid, NULL, 0); /* FIXME: check exit code and return error if any */
 
 	return 0;
+}
+
+/*
+ * Redirect the child's stdout into @p pipe_fds and leave it neither end.
+ * @return 0 on success, an errno value on failure.
+ */
+static int add_stdout_pipe_actions(posix_spawn_file_actions_t *action,
+				   const int pipe_fds[2])
+{
+	int status;
+
+	status = posix_spawn_file_actions_addclose(action, pipe_fds[0]);
+	if (status == 0)
+		status = posix_spawn_file_actions_adddup2(action, pipe_fds[1],
+							  STDOUT_FILENO);
+	if (status == 0)
+		status = posix_spawn_file_actions_addclose(action, pipe_fds[1]);
+
+	return status;
+}
+
+/* A broken or hostile fusermount3 may write without end. */
+#define FUSERMOUNT_OUTPUT_MAX	(64 * 1024)
+
+/*
+ * Read @p fd until EOF into a NUL-terminated string. No bytes gives "".
+ * @param[in]  max_size Fail instead of growing past this many bytes.
+ * @param[out] outputp Allocated string, freed by the caller.
+ * @return 0 on success, -1 on read, size or allocation failure.
+ */
+static int read_fd_to_string(int fd, size_t max_size, char **outputp)
+{
+	char read_buf[BUFSIZ];
+	char *output = NULL;
+	size_t output_size = 0;
+	ssize_t read_size;
+	int ret = -1;
+
+	while ((read_size = read(fd, read_buf, sizeof(read_buf))) != 0) {
+		char *new_output;
+
+		if (read_size == -1) {
+			if (errno == EINTR)
+				continue;
+			goto out;
+		}
+
+		if (output_size + (size_t) read_size > max_size)
+			goto out;
+
+		new_output = realloc(output, output_size + read_size + 1);
+		if (new_output == NULL)
+			goto out;
+		output = new_output;
+		memcpy(output + output_size, read_buf, read_size);
+		output_size += read_size;
+		output[output_size] = '\0';
+	}
+
+	if (output == NULL) {
+		output = strdup("");
+		if (output == NULL)
+			goto out;
+	}
+
+	*outputp = output;
+	output = NULL;
+	ret = 0;
+
+out:
+	free(output);
+	return ret;
+}
+
+/*
+ * Run fusermount3 with one option and capture stdout.
+ * The caller owns the allocated @p outputp buffer.
+ * @return Child exit status, or -1 before a normal child exit.
+ */
+static int fusermount_capture_output(const char *option, char **outputp)
+{
+	char const *const argv[] = {FUSERMOUNT_PROG, option, NULL};
+	char *output = NULL;
+	posix_spawn_file_actions_t action;
+	pid_t pid;
+	int pipe_fds[2];
+	int child_status;
+	int spawn_status;
+	int read_status = -1;
+	int ret = -1;
+
+	*outputp = NULL;
+	if (pipe(pipe_fds) == -1)
+		return -1;
+
+	spawn_status = posix_spawn_file_actions_init(&action);
+	if (spawn_status == 0) {
+		spawn_status = add_stdout_pipe_actions(&action, pipe_fds);
+		if (spawn_status == 0)
+			spawn_status = fusermount_posix_spawn(&action, argv,
+							      &pid);
+		posix_spawn_file_actions_destroy(&action);
+	}
+
+	/* the child owns the write end now; read() only sees EOF once ours is gone */
+	close(pipe_fds[1]);
+
+	if (spawn_status == 0)
+		read_status = read_fd_to_string(pipe_fds[0],
+						FUSERMOUNT_OUTPUT_MAX, &output);
+
+	/* SIGPIPE ends a helper still writing, so waitpid() cannot block */
+	close(pipe_fds[0]);
+	if (spawn_status != 0)
+		goto out;
+
+	while (waitpid(pid, &child_status, 0) == -1) {
+		if (errno == EINTR)
+			continue;
+		goto out;
+	}
+
+	if (read_status != 0 || !WIFEXITED(child_status))
+		goto out;
+
+	*outputp = output;
+	output = NULL;
+	ret = WEXITSTATUS(child_status);
+
+out:
+	free(output);
+	return ret;
+}
+
+/*
+ * Check whether @p output contains @p word as a complete word.
+ * Whitespace boundaries prevent matching option prefixes.
+ * @return true if @p word occurs as a complete word.
+ */
+static bool fusermount_output_has_word(const char *output, const char *word)
+{
+	size_t word_len = strlen(word);
+	const char *match = output;
+
+	while ((match = strstr(match, word)) != NULL) {
+		if ((match == output || isspace((unsigned char) match[-1])) &&
+		    (match[word_len] == '\0' ||
+		     isspace((unsigned char) match[word_len])))
+			return true;
+		match += word_len;
+	}
+
+	return false;
+}
+
+/*
+ * Convert one hexadecimal digit to its numeric value.
+ * @return 0 to 15, or -1 for a non-hexadecimal byte.
+ */
+static int fusermount_hex_digit_value(char digit)
+{
+	if (digit >= '0' && digit <= '9')
+		return digit - '0';
+	if (digit >= 'a' && digit <= 'f')
+		return digit - 'a' + 10;
+	if (digit >= 'A' && digit <= 'F')
+		return digit - 'A' + 10;
+
+	return -1;
+}
+
+/*
+ * Decode @p output from hexadecimal, most significant digit first.
+ * @return 0 on success, -1 for malformed output.
+ */
+static int fusermount_parse_features(const char *output, uint64_t *featuresp)
+{
+	uint64_t features = 0;
+	size_t output_len = strlen(output);
+
+	if (output_len == sizeof(features) * 2 + 1 &&
+	    output[output_len - 1] == '\n')
+		output_len--;
+	if (output_len != sizeof(features) * 2)
+		return -1;
+
+	/* one hex digit at a time, left to right: every further digit shifts
+	 * the value read so far up by one digit, i.e. 4 bits
+	 */
+	for (size_t digit_idx = 0; digit_idx < output_len; digit_idx++) {
+		int digit_value = fusermount_hex_digit_value(output[digit_idx]);
+
+		if (digit_value < 0)
+			return -1;
+		features = (features << 4) | (uint64_t) digit_value;
+	}
+
+	*featuresp = features;
+	return 0;
+}
+
+/*
+ * Obtain supported feature bits from fusermount3.
+ */
+uint64_t fuse_mount_fusermount_features(void)
+{
+	uint64_t features;
+	char *output;
+	int status;
+
+	/* Older versions reject --features, so probe --help first. */
+	status = fusermount_capture_output("--help", &output);
+	if (status < 0)
+		return 0;
+	if (!fusermount_output_has_word(output, "--features")) {
+		free(output);
+		return 0;
+	}
+	free(output);
+
+	status = fusermount_capture_output("--features", &output);
+	if (status != 0) {
+		free(output);
+		return 0;
+	}
+
+	status = fusermount_parse_features(output, &features);
+	free(output);
+	if (status != 0)
+		return 0;
+
+	return features;
 }
 
 void fuse_mount_version(void)

--- a/lib/mount_i_linux.h
+++ b/lib/mount_i_linux.h
@@ -12,8 +12,12 @@
 
 #include <sys/mount.h>
 #include <linux/mount.h>
+#include <stdint.h>
 
 struct fuse_args;
+
+#define FUSERMOUNT_FEATURE_NEW_MOUNT_API (UINT64_C(1) << 0)
+#define FUSERMOUNT_FEATURE_SYNC_INIT     (UINT64_C(1) << 1)
 
 /*
  * Returned by the kernel for an fsconfig() parameter the filesystem does
@@ -39,6 +43,13 @@ struct mount_opts {
 };
 
 int fuse_kern_mount_prepare(const char *mnt, struct mount_opts *mo);
+
+/**
+ * @brief Obtain feature bits supported by fusermount3.
+ *
+ * @return Supported bits, or zero if the query is unavailable or malformed.
+ */
+uint64_t fuse_mount_fusermount_features(void);
 
 int fuse_kern_mount_get_base_mtab_opts(const struct mount_opts *mo,
 				       char **mtab_optsp);

--- a/test/cases/misc/fusermount-features.sh
+++ b/test/cases/misc/fusermount-features.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# GROUP: unit quick
+
+_fuse_no_mount_needed=1
+. "$TEST_LIB/common.sh"
+
+_require_linux "fusermount3"
+_require_binary util/fusermount3
+
+help_output=$("$FUSE_UTIL_DIR/fusermount3" --help) || true
+printf '%s\n' "$help_output" | grep -q '^ --features[[:space:]]' ||
+	_fail "fusermount3 --help does not advertise --features"
+printf '%s\n' "$help_output" | grep -q '^ --features=text[[:space:]]' ||
+	_fail "fusermount3 --help does not advertise --features=text"
+
+expected_features=0000000000000000
+expected_features_text=
+if grep -q '^#define HAVE_NEW_MOUNT_API' "$BUILD_DIR/fuse_config.h"; then
+	expected_features=0000000000000003
+	expected_features_text="FUSERMOUNT_FEATURE_NEW_MOUNT_API FUSERMOUNT_FEATURE_SYNC_INIT"
+fi
+
+features=$("$FUSE_UTIL_DIR/fusermount3" --features)
+_assert_eq "$features" "$expected_features" "fusermount3 --features"
+
+features_text=$("$FUSE_UTIL_DIR/fusermount3" --features=text)
+_assert_eq "$features_text" "$expected_features_text" \
+	"fusermount3 --features=text"

--- a/test/cases/mount/fusermount-old.sh
+++ b/test/cases/mount/fusermount-old.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# GROUP: mount quick serial
+
+_fuse_no_mount_needed=1
+. "$TEST_LIB/common.sh"
+
+[ "${FUSE_TEST_CI_BUILD:-}" = 1 ] || _notrun "needs test/ci-build.sh"
+_require_linux "fusermount3 feature probing"
+
+install_prefix=$(readlink -f -- "$FUSE_TEST_INSTALL_PREFIX") ||
+	_fail "cannot resolve the test installation prefix"
+case $install_prefix in
+/|/usr|/usr/local)
+	_fail "refusing installation prefix $install_prefix"
+	;;
+esac
+
+fusermount3=$install_prefix/bin/fusermount3
+fusermount3_real=$(readlink -f -- "$fusermount3") ||
+	_fail "cannot resolve installed fusermount3"
+case $fusermount3_real in
+"$install_prefix"/*) ;;
+*) _fail "installed fusermount3 is outside $install_prefix" ;;
+esac
+[ -f "$fusermount3" ] || _fail "installed fusermount3 is not a file"
+[ ! -L "$fusermount3" ] || _fail "installed fusermount3 is a symlink"
+
+unset _fuse_no_mount_needed
+_require_fuse
+_require_nonroot
+[ "${FUSE_URING_ENABLE}" = 0 ] || _notrun "needs the standard transport"
+grep -q '^#define HAVE_NEW_MOUNT_API' "$BUILD_DIR/fuse_config.h" ||
+	_notrun "new mount API not built"
+# ENOSYS puts libfuse on the mount(2) fallback, which never probes the helper.
+[ -z "$FUSE_VALGRIND" ] || _notrun "valgrind fails fsopen() with ENOSYS"
+_require_prog sudo
+sudo -n true >/dev/null 2>&1 || _notrun "needs non-interactive sudo"
+
+fusermount3_moved=$fusermount3.moved
+[ ! -e "$fusermount3_moved" ] ||
+	_fail "$fusermount3_moved already exists"
+
+# Restore the installed helper after the compatibility test.
+restore_fusermount3()
+{
+	[ ! -e "$fusermount3_moved" ] ||
+		sudo -n mv -f -- "$fusermount3_moved" "$fusermount3"
+}
+
+sudo -n mv -- "$fusermount3" "$fusermount3_moved"
+_at_exit restore_fusermount3
+
+# Quoted delimiter: the wrapper reads FUSERMOUNT_TEST_* from its own
+# environment, exported below.
+cat >"$TEST_TMP/fusermount3-old" <<'FUSERMOUNT3_OLD'
+#!/bin/sh
+
+printf '%s\n' "${1-}" >>"$FUSERMOUNT_TEST_LOG"
+
+case ${1-} in
+--help)
+	printf '%s\n' 'usage: fusermount3 [options] mountpoint'
+	exit 1
+	;;
+--features)
+	printf '%s\n' "fusermount3: unrecognized option '--features'" >&2
+	exit 1
+	;;
+*)
+	# fusermount3 in libfuse 3.0 knew only -h -V -o -u -z -q and their long
+	# forms. Reject anything newer the way that version would, so a mount
+	# option added later cannot slip past unnoticed.
+	skip_value=
+	for arg in "$@"; do
+		if [ -n "$skip_value" ]; then
+			skip_value=
+			continue
+		fi
+		case $arg in
+		--)
+			break
+			;;
+		-o)
+			skip_value=1
+			;;
+		-o?* | -h | -V | -u | -z | -q)
+			;;
+		--help | --version | --unmount | --lazy | --quiet)
+			;;
+		-*)
+			printf 'NEW-OPTION %s\n' "$arg" >>"$FUSERMOUNT_TEST_LOG"
+			printf '%s\n' \
+				"fusermount3: unrecognized option '$arg'" >&2
+			exit 1
+			;;
+		esac
+	done
+	exec "$FUSERMOUNT_TEST_REAL" "$@"
+	;;
+esac
+FUSERMOUNT3_OLD
+sudo -n install -m 0755 -- "$TEST_TMP/fusermount3-old" "$fusermount3"
+
+export FUSERMOUNT_TEST_LOG=$TEST_TMP/fusermount3-arguments
+export FUSERMOUNT_TEST_REAL=$fusermount3_moved
+: >"$FUSERMOUNT_TEST_LOG"
+
+fuse_mount hello >/dev/null
+
+grep -qx -- '--help' "$FUSERMOUNT_TEST_LOG" ||
+	_fail "fusermount3 --help was not invoked"
+if grep -qx -- '--features' "$FUSERMOUNT_TEST_LOG"; then
+	_fail "fusermount3 --features was invoked"
+fi
+if grep -q "unrecognized option '--features'" "${FUSE_FS_LOG[0]}"; then
+	_fail "fusermount3 printed an invalid-option diagnostic"
+fi
+# The wrapper exits 1 on such an option, so a regression usually fails the
+# mount above first; this names the option instead of leaving it in the log.
+new_option=$(sed -n 's/^NEW-OPTION //p' "$FUSERMOUNT_TEST_LOG" | head -n 1)
+[ -z "$new_option" ] ||
+	_fail "libfuse passed $new_option, unknown to fusermount3 3.0"

--- a/test/ci-build.sh
+++ b/test/ci-build.sh
@@ -190,13 +190,15 @@ else
     RUN_TESTS_OPTS+=(--setuid-helpers)
 fi
 
-# sudo resets the environment, so PATH and FUSE_TEST_RUN_DIR are passed
-# through env rather than shell-prefix assignments, which sudo would
+# sudo resets the environment, so PATH and the FUSE_TEST_* variables are
+# passed through env rather than shell-prefix assignments, which sudo would
 # otherwise drop; harmless when SUDO is empty. Calling run-tests.py directly,
 # never through `meson test`, keeps its per-test results in the job log
 # instead of only printing output on failure.
 rc=0
-"${SUDO[@]}" env PATH="$PATH" FUSE_TEST_RUN_DIR="${RUN_DIR}/${NAME}" \
+"${SUDO[@]}" env PATH="$PATH" FUSE_TEST_CI_BUILD=1 \
+    FUSE_TEST_INSTALL_PREFIX="${PREFIX_DIR}" \
+    FUSE_TEST_RUN_DIR="${RUN_DIR}/${NAME}" \
     timeout 1800 python3 "${SOURCE_DIR}/test/run-tests.py" \
         "${RUN_TESTS_OPTS[@]}" || rc=$?
 

--- a/util/fusermount.c
+++ b/util/fusermount.c
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <errno.h>
+#include <endian.h>
 #include <fcntl.h>
 #include <pwd.h>
 #include <paths.h>
@@ -38,6 +39,7 @@
 #include <sys/utsname.h>
 #include <sched.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <sys/vfs.h>
 
 #if defined HAVE_CLOSE_RANGE && defined linux
@@ -47,7 +49,6 @@
 #if defined HAVE_LISTMOUNT
 #include <linux/mount.h>
 #include <syscall.h>
-#include <stdint.h>
 #endif
 
 #define FUSE_COMMFD_ENV		"_FUSE_COMMFD"
@@ -1572,12 +1573,51 @@ static void usage(void)
 	       " -q		    quiet\n"
 	       " -z		    lazy unmount\n",
 	       progname);
+	printf(" --features\t    print supported features in hexadecimal\n"
+	       " --features=text    print supported feature names\n");
 	exit(1);
 }
 
 static void show_version(void)
 {
 	printf("fusermount3 version: %s\n", PACKAGE_VERSION);
+	exit(0);
+}
+
+/*
+ * Print supported feature bits in machine-readable or text form.
+ * Machine-readable output is a big-endian uint64_t in hexadecimal.
+ * @param[in] text Select feature names instead.
+ */
+static void show_features(bool text)
+{
+	uint64_t features = 0;
+
+#ifdef HAVE_NEW_MOUNT_API
+	features = FUSERMOUNT_FEATURE_NEW_MOUNT_API |
+		FUSERMOUNT_FEATURE_SYNC_INIT;
+#endif
+
+	if (text) {
+		const char *separator = "";
+
+		if (features & FUSERMOUNT_FEATURE_NEW_MOUNT_API) {
+			printf("%sFUSERMOUNT_FEATURE_NEW_MOUNT_API", separator);
+			separator = " ";
+		}
+		if (features & FUSERMOUNT_FEATURE_SYNC_INIT)
+			printf("%sFUSERMOUNT_FEATURE_SYNC_INIT", separator);
+	} else {
+		uint64_t big_endian_features = htobe64(features);
+		const unsigned char *feature_bytes =
+			(const unsigned char *) &big_endian_features;
+
+		for (size_t byte_idx = 0;
+		     byte_idx < sizeof(big_endian_features);
+		     byte_idx++)
+			printf("%02x", (unsigned int) feature_bytes[byte_idx]);
+	}
+	printf("\n");
 	exit(0);
 }
 
@@ -1664,6 +1704,7 @@ int main(int argc, char *argv[])
 		{"quiet",   no_argument, NULL, 'q'},
 		{"help",    no_argument, NULL, 'h'},
 		{"version", no_argument, NULL, 'V'},
+		{"features", optional_argument, NULL, 'F'},
 		{"options", required_argument, NULL, 'o'},
 		// Note: auto-unmount and comm-fd don't have short versions.
 		// They'ne meant for internal use by mount.c
@@ -1687,6 +1728,11 @@ int main(int argc, char *argv[])
 
 		case 'V':
 			show_version();
+			break;
+		case 'F':
+			if (optarg != NULL && strcmp(optarg, "text") != 0)
+				usage();
+			show_features(optarg != NULL);
 			break;
 
 		case 'o':


### PR DESCRIPTION
Using a mismatching libfuse and fusermount is not ideal, but not uncommon in production. With new mount API and sync init, old fusermount3 would have complained. Also, fusermount3  might be compiled without sync-init or new mount-api, but libfuse might be compiled with. Handle that all through support of feature flags.