### PR TITLE
ci: adapt to the CodeChecker 6.29.0 gcc checker names

### DIFF
--- a/.github/workflows/codechecker.sh
+++ b/.github/workflows/codechecker.sh
@@ -333,7 +333,11 @@ run_codechecker_gcc()
     cmd="$cmd --analyzers gcc"
 
     # Enable GCC checkers, disable malloc-leak, due to too many false positives
-    cmd="$cmd --enable gcc --disable gcc-malloc-leak"
+    # The gcc prefix on its own also enables every ordinary -W warning
+    cmd="$cmd --enable gcc-analyzer --disable gcc-analyzer-malloc-leak"
+
+    # too-complex reports the analyzer hitting its own enode limits, not a defect
+    cmd="$cmd --disable gcc-analyzer-too-complex"
 
     eval $cmd
 


### PR DESCRIPTION
The runners install CodeChecker unpinned and went from 6.28.3, the last version this worked with, to 6.29.0, which renamed the gcc checkers: gcc-malloc-leak is called gcc-analyzer-malloc-leak there, and the bare gcc prefix now covers every -W warning instead of the analyzer alone. The job aborted on the unknown name.